### PR TITLE
feat(17960): Remove do menu a opção cadastro de créditos

### DIFF
--- a/src/componentes/Receitas/Formularios/index.js
+++ b/src/componentes/Receitas/Formularios/index.js
@@ -173,7 +173,7 @@ export const ReceitaForm = props => {
 
     const onDeletarTrue = () => {
         deletarReceita(uuid).then(response => {
-            console.log("Receita deletada com sucesso.");
+            console.log("Crédito deletado com sucesso.");
             setShowDelete(false);
             getPath();
         }).catch(error => {
@@ -510,7 +510,7 @@ export const ReceitaForm = props => {
 
                                 {/*Data da Receita */}
                                 <div className="col-12 col-md-4 mt-4">
-                                    <label htmlFor="data">Data da receita</label>
+                                    <label htmlFor="data">Data do crédito</label>
                                     <DatePickerField
                                         name="data"
                                         id="data"
@@ -628,7 +628,7 @@ export const ReceitaForm = props => {
 
                             <div className="d-flex justify-content-end pb-3" style={{marginTop: '60px'}}>
                                 <button type="reset" onClick={onShowModal}
-                                        className="btn btn btn-outline-success mt-2 mr-2">Cancelar
+                                        className="btn btn btn-outline-success mt-2 mr-2">Voltar
                                 </button>
                                 {uuid
                                     ?

--- a/src/componentes/Receitas/Schemas/index.js
+++ b/src/componentes/Receitas/Schemas/index.js
@@ -3,16 +3,16 @@ import { trataNumericos } from "../../../utils/ValidacoesAdicionaisFormularios";
 
 
 export const ReceitaSchema = yup.object().shape({
-    tipo_receita: yup.string().required("Tipo de receita é obrigatório."),
-    categoria_receita: yup.string().required("Classificação da receita é obrigatório."),
+    tipo_receita: yup.string().required("Tipo de crédito é obrigatório."),
+    categoria_receita: yup.string().required("Classificação do crédito é obrigatório."),
     acao_associacao: yup.string().required("Ação é obrigatório."),
     conta_associacao: yup.string().required("Tipo de conta é obrigatório."),
-    data: yup.string().required("Data da receita é obrigatório.").nullable(),
-    valor: yup.string().required("Valor da receita é obrigatório.")
+    data: yup.string().required("Data do crédito é obrigatório.").nullable(),
+    valor: yup.string().required("Valor do crédito é obrigatório.")
         .test('test-valor', 'Valor deve ser maior que zero.',
         function (value) {
             return !(trataNumericos(value) <= 0);
-        }).test('test-string', 'Valor da receita é obrigatório.',
+        }).test('test-string', 'Valor do crédito é obrigatório.',
         function (value) {
             return !(typeof(value) == undefined)
         }),

--- a/src/componentes/SidebarLeft/index.js
+++ b/src/componentes/SidebarLeft/index.js
@@ -89,7 +89,7 @@ export const SidebarLeft = () => {
             <NavIcon>
               <img src={IconeMenuGastosDaEscola} alt="" />
             </NavIcon>
-            <NavText>Gastos da Escola</NavText>
+            <NavText>Gastos da escola</NavText>
           </NavItem>
 
           <NavItem eventKey="lista-de-receitas">
@@ -97,13 +97,6 @@ export const SidebarLeft = () => {
               <img src={IconeMenuCreditosDaEscola} alt="" />
             </NavIcon>
             <NavText>Créditos da escola</NavText>
-          </NavItem>
-
-          <NavItem eventKey="cadastro-de-credito">
-            <NavIcon>
-              <img src={IconeMenuCadastroDeCredito} alt="" />
-            </NavIcon>
-            <NavText>Cadastro de crédito</NavText>
           </NavItem>
 
           <NavItem eventKey="prestacao-de-contas">

--- a/src/paginas/Receitas/EdicaoReceita/index.js
+++ b/src/paginas/Receitas/EdicaoReceita/index.js
@@ -5,7 +5,7 @@ import {Receita} from '../../../componentes/Receitas';
 export const EdicaoDeReceita = props => {
     return (
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Edição de Receita</h1>
+            <h1 className="titulo-itens-painel mt-5">Edição do Crédito</h1>
             <div className="page-content-inner ">
                 <h2 className="subtitulo-itens-painel">Dados do documento</h2>
                 <Receita {...props}/>

--- a/src/paginas/Receitas/ListaDeReceitas/index.js
+++ b/src/paginas/Receitas/ListaDeReceitas/index.js
@@ -7,7 +7,7 @@ export const ListaDeReceitasPage = props => {
 
     return (
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Créditos recebidos</h1>
+            <h1 className="titulo-itens-painel mt-5">Créditos da escola</h1>
             <div className="page-content-inner ">
                 <ListaDeReceitas {...props}/>
             </div>

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -46,7 +46,7 @@ export const CancelarModalReceitas = (propriedades) => {
         <ModalBootstrap
             show={propriedades.show}
             onHide={propriedades.handleClose}
-            titulo="Deseja cancelar a inclusão de Receita?"
+            titulo="Deseja cancelar a inclusão de Crédito?"
             bodyText=""
             primeiroBotaoOnclick={propriedades.onCancelarTrue}
             primeiroBotaoTexto="OK"
@@ -75,8 +75,8 @@ export const DeletarModalReceitas = (propriedades) => {
         <ModalBootstrap
             show={propriedades.show}
             onHide={propriedades.handleClose}
-            titulo="Deseja excluir esta Receita?"
-            bodyText="<p>Tem certeza que deseja excluir esta Receita? A ação não poderá ser desfeita.</p>"
+            titulo="Deseja excluir este Crédito?"
+            bodyText="<p>Tem certeza que deseja excluir este crédito? A ação não poderá ser desfeita.</p>"
             primeiroBotaoOnclick={propriedades.onDeletarTrue}
             primeiroBotaoTexto="OK"
             segundoBotaoOnclick={propriedades.handleClose}
@@ -194,7 +194,7 @@ export const ReverConciliacao = (propriedades) => {
         return (
             <form className="form-group">
                 <p><strong>Revisão dos lançamentos realizados no período: Ao rever os lançamentos deste período, você
-                    permitirá que alterações sejam feitas nos dados da Associação e cadastro de receitas e
+                    permitirá que alterações sejam feitas nos dados da Associação e cadastro de créditos e
                     despesas.</strong></p>
                 <label htmlFor="reabrir-periodo">Escreva abaixo o motivo da revisão dos lançamentos</label>
                 <textarea


### PR DESCRIPTION
Esse PR:
- Remove do menu a opção de cadastrar créditos;
- Renomeia o botão "Cancelar" no form para "Voltar";
- Altera o termo "Receita" para "Crédito" em vários locais.