### PR TITLE
features/17272-deixar-padrao-escolha-opcao

### DIFF
--- a/src/componentes/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -613,7 +613,7 @@ export const CadastroForm = ({verbo_http}) => {
                                                                         id='aplicacao_recurso'
                                                                         className={`${!rateio.aplicacao_recurso && despesaContext.verboHttp === "PUT" && "is_invalid "} form-control`}
                                                                         disabled={readOnlyCampos}
-                                                                    >
+                                                                    >   
                                                                         <option key={0} value="">Escolha uma opção</option>
                                                                         {despesasTabelas.tipos_aplicacao_recurso && despesasTabelas.tipos_aplicacao_recurso.map(item => (
                                                                             <option key={item.id}

--- a/src/context/Despesa/index.js
+++ b/src/context/Despesa/index.js
@@ -75,7 +75,7 @@ export const DespesaContextProvider = ({children}) => {
                 associacao: localStorage.getItem(ASSOCIACAO_UUID),
                 conta_associacao: "",
                 acao_associacao: "",
-                aplicacao_recurso: "CUSTEIO",
+                aplicacao_recurso: "",
                 tipo_custeio: "",
                 especificacao_material_servico: "",
                 valor_rateio: "",


### PR DESCRIPTION
Esse PR contém:
- Deixar como padrão 'Escolha uma opção' no campo 'Tipo aplicação do recurso' no cadastro da despesa.