### PR TITLE
Correção no build do front

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "primeicons": "^2.0.0",
     "primereact": "^4.1.2",
     "react": "^16.13.1",
-    "react-bootstrap": "^1.0.0",
+    "react-bootstrap": "1.0.1",
     "react-currency-input": "^1.3.6",
     "react-datepicker": "^2.14.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Esse PR contém:
- Correção no build do front.
Hoje dia 06/07/2020 houve uma atualização da biblioteca react-bootstrap para a [versão 1.1.0](https://www.npmjs.com/package/react-bootstrap/v/1.1.0) e que acabou causando problema no build da aplicação, como mostrado abaixo:

![image](https://user-images.githubusercontent.com/8403556/86675513-184ca380-bfd0-11ea-9358-baef7f34be28.png)

para mais detalhes do erro clique [aqui](http://jenkins.sme.prefeitura.sp.gov.br/job/SME-PTRF-FrontEnd/job/develop/165/console). É preciso ter acesso ao jenkins para visualizar.

Para corrigi o problema eu fixei a versão da biblioteca na última que está funcionando na aplicação, [versão 1.0.1](https://www.npmjs.com/package/react-bootstrap/v/1.0.1).

Temos que verificar quando a biblioteca irá corrigi o problema e então atualizar para a mais recente.
