### PR TITLE
feat(19957): Prestações de contas apenas até o próximo período

### DIFF
--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -9,8 +9,6 @@ import {BotaoConciliacao} from "./BotaoConciliacao";
 import {DataUltimaConciliacao} from "./DataUltimaConciliacao";
 import {getTabelasReceita} from "../../../services/escolas/Receitas.service";
 import {
-    getPeriodos,
-    getPeriodosNaoFuturos,
     getStatus,
     getIniciarPrestacaoDeContas,
     getReabrirPeriodo,
@@ -22,6 +20,7 @@ import {ReverConciliacao} from "../../../utils/Modais";
 import {BoxPrestacaoDeContasPorPeriodo} from "../../escolas/GeracaoDaAta/BoxPrestacaoDeContasPorPeriodo";
 import RelacaoDeBens from "./RelacaoDeBens";
 import Loading from "../../../utils/Loading";
+import {getPeriodosDePrestacaoDeContasDaAssociacao} from "../../../services/escolas/Associacao.service"
 
 
 export const PrestacaoDeContas = () => {
@@ -65,7 +64,7 @@ export const PrestacaoDeContas = () => {
         };
 
         const carregaPeriodos = async () => {
-            let periodos = await getPeriodosNaoFuturos();
+            let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao();
             setPeriodosAssociacao(periodos);
         };
 

--- a/src/services/escolas/Associacao.service.js
+++ b/src/services/escolas/Associacao.service.js
@@ -71,3 +71,7 @@ export const exportarDadosAssociacao = async () => {
             });
 }
 
+export const getPeriodosDePrestacaoDeContasDaAssociacao = async () => {
+    return (await api.get(`/api/associacoes/${localStorage.getItem(ASSOCIACAO_UUID)}/periodos-para-prestacao-de-contas/`, authHeader)).data
+};
+


### PR DESCRIPTION
Esse PR:
- Altera a prestação de contas para permitir apenas  a seleção de períodos que já tem prestação de contas para a Associação ou o próximo período sem prestação feita.