### PR TITLE
feat(24720):Resumo Financeiro Saldos negativos em vermelho

### DIFF
--- a/src/componentes/Globais/Dashborard/DashboardCard.js
+++ b/src/componentes/Globais/Dashborard/DashboardCard.js
@@ -3,8 +3,12 @@ import '../../../paginas/escolas/404/pagina-404.scss'
 import {MsgImgLadoDireito} from "../../Globais/Mensagens/MsgImgLadoDireito";
 import Img404 from '../../../assets/img/img-404.svg'
 import {exibeDataPT_BR, exibeDateTimePT_BR, exibeValorFormatadoPT_BR} from '../../../utils/ValidacoesAdicionaisFormularios'
+import {getAcoesAssociacao} from "../../../services/Dashboard.service";
 
 export const DashboardCard = ({acoesAssociacao, corIconeFonte}) => {
+    const getCorSaldo = (valor_saldo) => {
+        return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
+    };
     return (
         <>
             {acoesAssociacao.info_acoes && acoesAssociacao.info_acoes.length > 0 ? (
@@ -46,21 +50,21 @@ export const DashboardCard = ({acoesAssociacao, corIconeFonte}) => {
                                                         <div className='mt-3'>&nbsp;</div>
                                                         {acao.saldo_atual_custeio ? (
                                                             <p className="pt-1">
-                                                                Custeio: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(acao.saldo_atual_custeio)}</strong>
+                                                                Custeio: <strong className={getCorSaldo(acao.saldo_atual_custeio)}>{exibeValorFormatadoPT_BR(acao.saldo_atual_custeio)}</strong>
                                                             </p>
                                                         ) : null}
                                                         {acao.saldo_atual_capital ? (
                                                             <p className="pt-1">
-                                                                Capital: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(acao.saldo_atual_capital)}</strong>
+                                                                Capital: <strong className={getCorSaldo(acao.saldo_atual_capital)}>{exibeValorFormatadoPT_BR(acao.saldo_atual_capital)}</strong>
                                                             </p>
                                                         ) : null}
                                                         {acao.saldo_atual_livre ? (
                                                             <p className="pt-1">
-                                                                RLA: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(acao.saldo_atual_livre)}</strong>
+                                                                RLA: <strong className={getCorSaldo(acao.saldo_atual_livre)}>{exibeValorFormatadoPT_BR(acao.saldo_atual_livre)}</strong>
                                                             </p>
                                                         ) : null}
                                                         <p className="pt-0">
-                                                            Total: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(acao.saldo_atual_total)}</strong>
+                                                            Total: <strong className={getCorSaldo(acao.saldo_atual_total)}>{exibeValorFormatadoPT_BR(acao.saldo_atual_total)}</strong>
                                                         </p>
                                                     </div>
                                                 </div>

--- a/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
+++ b/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
@@ -3,6 +3,9 @@ import {exibeValorFormatadoPT_BR} from "../../../utils/ValidacoesAdicionaisFormu
 
 export const DashboardCardInfoConta = ({acoesAssociacao, corIconeFonte}) =>{
     let info = acoesAssociacao.info_conta;
+    const getCorSaldo = (valor_saldo) => {
+        return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
+    };
     return(
         <>
             {info &&
@@ -41,27 +44,27 @@ export const DashboardCardInfoConta = ({acoesAssociacao, corIconeFonte}) =>{
                                                         {info.saldo_atual_custeio ? (
                                                             <div className="col-12 col-md-6">
                                                                 <p className="pt-1">
-                                                                    Custeio: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(info.saldo_atual_custeio)}</strong>
+                                                                    Custeio: <strong className={getCorSaldo(info.saldo_atual_custeio)}>{exibeValorFormatadoPT_BR(info.saldo_atual_custeio)}</strong>
                                                                 </p>
                                                             </div>
                                                         ) : null}
                                                         {info.saldo_atual_capital ? (
                                                             <div className="col-12 col-md-6">
                                                                 <p className="pt-1">
-                                                                    Capital: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(info.saldo_atual_capital)}</strong>
+                                                                    Capital: <strong className={getCorSaldo(info.saldo_atual_capital)}>{exibeValorFormatadoPT_BR(info.saldo_atual_capital)}</strong>
                                                                 </p>
                                                             </div>
                                                         ) : null}
                                                         {info.saldo_atual_livre ? (
                                                             <div className="col-12 col-md-6">
                                                                 <p className="pt-1">
-                                                                    RLA: <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(info.saldo_atual_livre)}</strong>
+                                                                    RLA: <strong className={getCorSaldo(info.saldo_atual_livre)}>{exibeValorFormatadoPT_BR(info.saldo_atual_livre)}</strong>
                                                                 </p>
                                                             </div>
                                                         ) : null}
                                                         <div className="col-12 col-md-6">
                                                             <p className="pt-0">
-                                                                <strong>Total:</strong> <strong className="texto-cor-verde">{exibeValorFormatadoPT_BR(info.saldo_atual_total)}</strong>
+                                                                <strong>Total:</strong> <strong className={getCorSaldo(info.saldo_atual_total)}>{exibeValorFormatadoPT_BR(info.saldo_atual_total)}</strong>
                                                             </p>
                                                         </div>
                                                     </div>

--- a/src/componentes/Globais/Dashborard/dashboard.scss
+++ b/src/componentes/Globais/Dashborard/dashboard.scss
@@ -8,6 +8,10 @@
   .texto-cor-verde{
     color: #00585E;
   }
+
+  .texto-cor-vermelha{
+    color: darkred;
+  }
 }
 
 .container-lado-esquerdo {


### PR DESCRIPTION
Esse PR:

Altera os paineis de resumo financeiro de associações para exibir saldos negativos em vermelho.