### PR TITLE
refactor(24720): Cor para hexadecimal em CSS

### DIFF
--- a/src/componentes/Globais/Dashborard/dashboard.scss
+++ b/src/componentes/Globais/Dashborard/dashboard.scss
@@ -10,7 +10,7 @@
   }
 
   .texto-cor-vermelha{
-    color: darkred;
+    color: #8b0000;
   }
 }
 


### PR DESCRIPTION
Passa cor darkred para a sua representação hexadecimal para manter o
padrão.