### PR TITLE
fix(28206): Corrige falha autenticação ao baixar relação de bens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Front da aplicação _SIG.Escola_ da Secretaria de Educação da cidade de São 
 
 License: MIT
 
-Versão: 1.2.0
+Versão: 1.2.1
 
 ## Release Notes
+
+### 1.2.1 - 19/11/2020 - Hotfix
+* 🐞28206 - Erro de autenticação ao baixar relações de bens de prestações de contas
 
 ### 1.2.0 - 10/11/2020 - Entregas da Sprint 11
 * Gestão de perfis de acesso às funcionalidades do sistema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/src/services/escolas/RelacaoDeBens.service.js
+++ b/src/services/escolas/RelacaoDeBens.service.js
@@ -14,6 +14,10 @@ export const previa = async (conta_associacao, periodo, data_inicio, data_fim) =
             .get(`/api/relacao-bens/previa/?conta-associacao=${conta_associacao}&periodo=${periodo}&data_inicio=${data_inicio}&data_fim=${data_fim}`, {
                 responseType: 'blob',
                 timeout: 30000,
+                headers: {
+                    'Authorization': `JWT ${localStorage.getItem(TOKEN_ALIAS)}`,
+                    'Content-Type': 'application/json',
+                }
               })
             .then((response) => {
                 const url = window.URL.createObjectURL(new Blob([response.data]));
@@ -32,6 +36,10 @@ export const documentoFinal = async (conta_associacao, periodo) => {
             .get(`/api/relacao-bens/documento-final/?conta-associacao=${conta_associacao}&periodo=${periodo}`, {
                 responseType: 'blob',
                 timeout: 30000,
+                headers: {
+                    'Authorization': `JWT ${localStorage.getItem(TOKEN_ALIAS)}`,
+                    'Content-Type': 'application/json',
+                }
               })
             .then((response) => {
                 const url = window.URL.createObjectURL(new Blob([response.data]));


### PR DESCRIPTION
O download de relação de bens, prévia e final, não estava passando as
informações de autenticação e por isso o download falhava.