### PR TITLE
Features/29270 apc devolucao ao tesouro aprimoramentos

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/InformacoesDevolucaoAoTesouro.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/InformacoesDevolucaoAoTesouro.js
@@ -10,6 +10,7 @@ import {ModalConfirmaRemocaoDevolucaoAoTesouro} from "../ModalConfirmaRemocaoDev
 export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeContas, initialValues, despesas, buscaDespesaPorFiltros, valorTemplate, despesasTabelas, tiposDevolucao, validateFormDevolucaoAoTesouro,}) =>{
 
     const [showConfirmaRemocao, setShowConfirmaRemocao] = useState({abrir:false, indice:0});
+    const [despesaSelecionada, setDespesaSelecionada] = useState(null);
 
     const setDisabledCampos = (devolucao) =>{
        return devolucao.visao_criacao === "DRE" && visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'UE'
@@ -23,6 +24,22 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
     const onHandleClose = () => {
         setShowConfirmaRemocao(false);
     };
+
+    const onClickSelecaoDespesa = (despesa) => {
+        setDespesaSelecionada(despesa);
+    }
+
+    const preencheValor = (name, value, setFieldValue) => {
+        if (despesaSelecionada !== null && value === "true") {
+            setFieldValue(name, valorTemplate(despesaSelecionada.valor_total));
+        }
+    }
+
+    const clear = (index, setFieldValue) => {
+        setDespesaSelecionada(null); 
+        setFieldValue(`devolucoes_ao_tesouro_da_prestacao[${index}].devolucao_total`, '');
+        setFieldValue(`devolucoes_ao_tesouro_da_prestacao[${index}].valor`, '0,00');
+    }
 
     return(
         <>
@@ -111,7 +128,7 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                 </div>
 
                                                                 <div className='col-12 text-right'>
-                                                                    <button disabled={setDisabledCampos(devolucao) } name='btnFiltrar' type='button' onClick={()=>buscaDespesaPorFiltros(index)} className='btn btn-success mt-2'>Filtrar</button>
+                                                                    <button disabled={setDisabledCampos(devolucao) } name='btnFiltrar' type='button' onClick={()=>{buscaDespesaPorFiltros(index); clear(index, setFieldValue)}} className='btn btn-success mt-2'>Filtrar</button>
                                                                 </div>
 
                                                             </div>
@@ -123,13 +140,32 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                 <table className={`table tabela-despesas mb-0 ${despesas && eval('despesas.devolucao_'+index) && eval('despesas.devolucao_'+index).length > 0 ? 'table-bordered' : ''}`}>
                                                                     <tbody>
                                                                     {/* eslint-disable-next-line no-eval */}
-                                                                    {despesas && eval('despesas.devolucao_'+index) && eval('despesas.devolucao_'+index).length > 0 ?
+                                                                    {despesaSelecionada !== null ?  
+                                                                        <Fragment key={0}>
+                                                                            <tr className='divisao'>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}><Field disabled={setDisabledCampos(devolucao) } type="radio" name={`devolucoes_ao_tesouro_da_prestacao[${index}].despesa`} value={despesaSelecionada.uuid}/></td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesaSelecionada.nome_fornecedor}</td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesaSelecionada.cpf_cnpj_fornecedor}</td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesaSelecionada.tipo_documento && despesaSelecionada.tipo_documento.nome ? despesaSelecionada.tipo_documento.nome : ''}</td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesaSelecionada.numero_documento}</td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>R$ {valorTemplate(despesaSelecionada.valor_total)}</td>
+                                                                                {/* eslint-disable-next-line no-eval */}
+                                                                                <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesaSelecionada.data_documento ? exibeDataPT_BR(despesaSelecionada.data_documento) : ''}</td>
+                                                                            </tr>
+                                                                        </Fragment>
+                                                                    : despesas && eval('despesas.devolucao_'+index) && eval('despesas.devolucao_'+index).length > 0 ?
                                                                         // eslint-disable-next-line no-eval
                                                                         eval('despesas.devolucao_'+index).map((despesa, index_interno)=>
                                                                             <Fragment key={index_interno}>
                                                                                 <tr className='divisao'>
                                                                                     {/* eslint-disable-next-line no-eval */}
-                                                                                    <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}><Field disabled={setDisabledCampos(devolucao) } type="radio" name={`devolucoes_ao_tesouro_da_prestacao[${index}].despesa`} value={despesa.uuid} /></td>
+                                                                                    <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}><Field disabled={setDisabledCampos(devolucao) } type="radio" name={`devolucoes_ao_tesouro_da_prestacao[${index}].despesa`} value={despesa.uuid} onChange={(e) => {props.handleChange(e); onClickSelecaoDespesa(despesa);}}/></td>
                                                                                     {/* eslint-disable-next-line no-eval */}
                                                                                     <td className={`td-com-despesas ${eval('despesas.devolucao_'+index).length === 1 ? 'td-com-despesas-unica' : ''}`}>{despesa.nome_fornecedor}</td>
                                                                                     {/* eslint-disable-next-line no-eval */}
@@ -183,8 +219,8 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                 <DatePickerField
                                                                     name={`devolucoes_ao_tesouro_da_prestacao[${index}].data`}
                                                                     value={devolucao.data}
-                                                                    onChange={setFieldValue}
-                                                                    placeholderText='Selecione data'
+                                                                    placeholderText='UE deve preencher.'
+                                                                    disabled={true}
                                                                 />
                                                                 {props.errors.data && <span className="text-danger mt-1">{props.errors.data}</span>}
                                                             </div>
@@ -197,6 +233,7 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                 value={devolucao.devolucao_total}
                                                                 onChange={async (e) => {
                                                                     props.handleChange(e);
+                                                                    preencheValor(`devolucoes_ao_tesouro_da_prestacao[${index}].valor`, e.target.value, setFieldValue);
                                                                 }
                                                                 }
                                                                 className='form-control'
@@ -226,21 +263,6 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                 disabled={setDisabledCampos(devolucao) }
                                                             />
                                                         </div>
-                                                        <div className='col-12 mt-2'>
-                                                            <label htmlFor="motivo">Motivo:</label>
-                                                            <textarea
-                                                                value={devolucao.motivo}
-                                                                name={`devolucoes_ao_tesouro_da_prestacao[${index}].motivo`}
-                                                                onChange={(e) => {
-                                                                    props.handleChange(e);
-                                                                }}
-                                                                className="form-control"
-                                                                rows="3"
-                                                                placeholder='Escreva o motivo da devolução'
-                                                                disabled={setDisabledCampos(devolucao) }
-                                                            >
-                                                            </textarea>
-                                                        </div>
 
                                                         {visoesService.getItemUsuarioLogado('visao_selecionada.nome') === "UE" || (index >= 1 && values.devolucoes_ao_tesouro_da_prestacao.length > 1) ? (
                                                             <div className='col-12'>
@@ -250,6 +272,7 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                                                                         className="btn btn btn-outline-success mr-2"
                                                                         onClick={async ()=>{
                                                                             setDisabledCampos(devolucao) ? setShowConfirmaRemocao({abrir:true, indice:index}) : onClickRemoverDevolucao(remove, index)
+                                                                            setDespesaSelecionada(null);
                                                                         }}
                                                                     >
                                                                         - Remover devolução

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
@@ -608,7 +608,7 @@ export const DetalhePrestacaoDeContas = () =>{
     const validateFormDevolucaoAoTesouro = async (values) => {
         const errors = {};
         values.devolucoes_ao_tesouro_da_prestacao.map((devolucao)=>{
-            if (!devolucao.data || !devolucao.despesa || devolucao.devolucao_total === '' || !devolucao.motivo || !devolucao.tipo || !devolucao.valor){
+            if (!devolucao.despesa || devolucao.devolucao_total === '' || !devolucao.tipo || !devolucao.valor){
                 setCamposObrigatorios(true);
                 errors.campos_obrigatorios = "Todos os campos são obrigatórios";
             }else {


### PR DESCRIPTION
Esse PR contém:

* o campo de data da devolução deve ser exibido como apenas leitura. Este deve ser preenchido pela Associação e, apenas após esse preenchimento, deve ser exibido para a DRE;
* o campo data de devolução não deve ser digitado pela DRE, mesmo nas devoluções ao tesouro incluídas pela Diretoria;
quando o usuário selecionar que a devolução é total, o valor deve ser preenchido automaticamente;
* excluir o campo "motivo"
* manter apenas a despesa selecionada logo após a seleção.