### PR TITLE
feat(29297): Período anterior default no acompanhamento PC

### DIFF
--- a/src/componentes/dres/Dashboard/index.js
+++ b/src/componentes/dres/Dashboard/index.js
@@ -28,7 +28,9 @@ export const DreDashboard = () => {
         let periodos = await getPeriodos();
         setPeriodos(periodos);
         if (periodos && periodos.length > 0){
-            setPeriodoEsolhido(periodos[0].uuid)
+            //Caso exista mais de um período seleciona por default o anterior ao corrente.
+            const periodoIndex = periodos.length > 1 ? 1 : 0;
+            setPeriodoEsolhido(periodos[periodoIndex].uuid)
         }
         setLoading(false);
     };


### PR DESCRIPTION
Esse PR:
Altera a a seleção de período do acompanhamento de Prestação de Contas
da DRE para trazer como default o período anterior ao período corrente.

História: [AB#29297](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/29297)