### PR TITLE
feat(35135): Permite despesas anteriores ao período inicial

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -131,7 +131,8 @@ export const CadastroForm = ({verbo_http}) => {
 
             let retorno_saldo = await aux.verificarSaldo(values, despesaContext);
 
-            if (retorno_saldo.situacao_do_saldo === "saldo_conta_insuficiente"){
+            if (retorno_saldo.situacao_do_saldo === "saldo_conta_insuficiente" ||
+                retorno_saldo.situacao_do_saldo === "lancamento_anterior_implantacao"){
                 setSaldosInsuficientesDaConta(retorno_saldo);
                 setShowSaldoInsuficienteConta(true)
 
@@ -139,11 +140,11 @@ export const CadastroForm = ({verbo_http}) => {
                 setSaldosInsuficientesDaAcao(retorno_saldo.saldos_insuficientes);
                 setShowSaldoInsuficiente(true);
 
-            // Checando se depesa já foi conferida
+            // Checando se despesa já foi conferida
             }else if (values.rateios.find(element=> element.conferido)) {
                 setShowDespesaConferida(true)
 
-                // Checando se depesa já foi cadastrada
+                // Checando se despesa já foi cadastrada
             }else if (values.tipo_documento && values.numero_documento) {
                 try {
                     let despesa_cadastrada = await getDespesaCadastrada(values.tipo_documento, values.numero_documento, values.cpf_cnpj_fornecedor, despesaContext.idDespesa);

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -280,10 +280,18 @@ export const SaldoInsuficienteConta = (propriedades) => {
 
     const listaDeSaldosInsuficientes = () => {
 
+        let mensagem = ""
+
+        if (propriedades.saldosInsuficientesDaConta.situacao_do_saldo === "lancamento_anterior_implantacao"){
+            mensagem = "Você está tentando lançar uma despesa em uma data anterior ao período inicial de uso do sistema."
+        }
+        else {
+            mensagem = "Não há saldo disponível para a despesa cadastrada na conta selecionada."
+        }
+
         return (
             <>
-                <p>Não há saldo disponível para a despesa cadastrada na conta
-                    selecionada. {propriedades.saldosInsuficientesDaConta.aceitar_lancamento ? "Deseja salvar assim mesmo?" : ""}</p>
+                <p>{mensagem} {propriedades.saldosInsuficientesDaConta.aceitar_lancamento ? "Confirma a operação?" : ""}</p>
                 {propriedades.saldosInsuficientesDaConta.saldos_insuficientes && propriedades.saldosInsuficientesDaConta.saldos_insuficientes.length > 0 && propriedades.saldosInsuficientesDaConta.saldos_insuficientes.map((item, index) =>
                     <ul key={index} className="list-group list-group-flush mb-3">
                         <li className="list-group-item p-0">
@@ -307,11 +315,19 @@ export const SaldoInsuficienteConta = (propriedades) => {
             </>
         )
     };
+    let titulo = ""
+    if (propriedades.saldosInsuficientesDaConta.situacao_do_saldo === "lancamento_anterior_implantacao"){
+        titulo = "Despesa anterior ao período inicial"
+    }
+    else {
+        titulo = "Saldo da Conta Insuficiente"
+    }
+
     return (
         <ModalBootstrapSaldoInsuficienteDaconta
             show={propriedades.show}
             onHide={propriedades.handleClose}
-            titulo="Saldo da Conta Insuficiente"
+            titulo={titulo}
             bodyText={listaDeSaldosInsuficientes()}
             aceitarLancamento={propriedades.saldosInsuficientesDaConta.aceitar_lancamento}
             primeiroBotaoOnclick={propriedades.onSaldoInsuficienteContaTrue}


### PR DESCRIPTION
Esse PR altera o lançamento de despesas que passa a tratar o lançamento de despesas anteriores ao período inicial da associação.


História [AB#35135](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/35135)