### PR TITLE
feat(39524): Resumo de recursos apenas períodos a partir da implantação

### DIFF
--- a/src/componentes/Globais/Dashborard/index.js
+++ b/src/componentes/Globais/Dashborard/index.js
@@ -3,7 +3,7 @@ import {DashboardCard} from "./DashboardCard";
 import {DashboardCardInfoConta} from "./DashboardCardInfoConta";
 import {SelectPeriodo} from "./SelectPeriodo";
 import {SelectConta} from "./SelectConta";
-import {getPeriodosNaoFuturos, getStatusPeriodoPorData} from "../../../services/escolas/PrestacaoDeContas.service";
+import {getPeriodosAteAgoraForaImplantacaoDaAssociacao, getStatusPeriodoPorData} from "../../../services/escolas/PrestacaoDeContas.service";
 import {getAcoesAssociacao, getAcoesAssociacaoPorPeriodoConta, getTabelas} from "../../../services/Dashboard.service";
 import {exibeDataPT_BR, getCorStatusPeriodo} from "../../../utils/ValidacoesAdicionaisFormularios";
 import Loading from "../../../utils/Loading";
@@ -57,7 +57,7 @@ export const Dashboard = () => {
     }, [acoesAssociacao]);
 
     const buscaPeriodos = async () => {
-        let periodos = await getPeriodosNaoFuturos();
+        let periodos = await getPeriodosAteAgoraForaImplantacaoDaAssociacao();
         setSelectPeriodo(periodos[0].uuid)
         setPeriodosAssociacao(periodos);
     };

--- a/src/services/escolas/PrestacaoDeContas.service.js
+++ b/src/services/escolas/PrestacaoDeContas.service.js
@@ -22,6 +22,11 @@ export const getPeriodosNaoFuturos = async () => {
   return(await api.get('/api/periodos/lookup-until-now/', authHeader)).data
 };
 
+export const getPeriodosAteAgoraForaImplantacaoDaAssociacao = async () => {
+  return(await api.get(`/api/associacoes/${localStorage.getItem(ASSOCIACAO_UUID)}/periodos-ate-agora-fora-implantacao/`, authHeader)).data
+};
+
+
 export const getStatus = async (periodo_uuid, conta_uuid) => {
   return (
     await api.get(


### PR DESCRIPTION
Esse PR altera a consulta de Resumo de Recursos que passa a chamar novo endpoint que retorna os períodos a partir do período de implantação da associação até o período em andamento.

História [AB#39524](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/39524)
