### PR TITLE
fix(37949): Bug resumo dos recursos

### DIFF
--- a/src/componentes/Globais/Dashborard/DashboardCard.js
+++ b/src/componentes/Globais/Dashborard/DashboardCard.js
@@ -1,14 +1,10 @@
 import React from 'react'
 import '../../../paginas/escolas/404/pagina-404.scss'
-import {MsgImgLadoDireito} from "../../Globais/Mensagens/MsgImgLadoDireito";
+import {MsgImgLadoDireito} from "../Mensagens/MsgImgLadoDireito";
 import Img404 from '../../../assets/img/img-404.svg'
 import {exibeDataPT_BR, exibeDateTimePT_BR, exibeValorFormatadoPT_BR} from '../../../utils/ValidacoesAdicionaisFormularios'
-import {getAcoesAssociacao} from "../../../services/Dashboard.service";
 
-export const DashboardCard = ({acoesAssociacao, corIconeFonte}) => {
-    const getCorSaldo = (valor_saldo) => {
-        return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
-    };
+export const DashboardCard = ({acoesAssociacao, getCorSaldo, getCssDestaque}) => {
     return (
         <>
             {acoesAssociacao.info_acoes && acoesAssociacao.info_acoes.length > 0 ? (
@@ -30,10 +26,10 @@ export const DashboardCard = ({acoesAssociacao, corIconeFonte}) => {
                                                 <p className="pt-1 mb-4">
                                                     Repasses no período: <strong>{exibeValorFormatadoPT_BR(acao.repasses_no_periodo)}</strong>
                                                 </p>
-                                                <p className={`pt-1 mb-4 texto-com-icone-${corIconeFonte}`}>
+                                                <p className={getCssDestaque(4)}>
                                                     Outras receitas: <strong>{exibeValorFormatadoPT_BR(acao.outras_receitas_no_periodo)}</strong>
                                                 </p>
-                                                <p className={`pt-1 mb-0 texto-com-icone-${corIconeFonte}`}>
+                                                <p className={getCssDestaque(0)}>
                                                     Despesa: <strong>{exibeValorFormatadoPT_BR(acao.despesas_no_periodo)}</strong>
                                                 </p>
                                                 {acao.acao_associacao_nome.trim() === 'PTRF' ? (

--- a/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
+++ b/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
@@ -1,11 +1,8 @@
 import React from "react";
 import {exibeValorFormatadoPT_BR} from "../../../utils/ValidacoesAdicionaisFormularios";
 
-export const DashboardCardInfoConta = ({acoesAssociacao, corIconeFonte}) =>{
+export const DashboardCardInfoConta = ({acoesAssociacao, getCorSaldo, getCssDestaque}) =>{
     let info = acoesAssociacao.info_conta;
-    const getCorSaldo = (valor_saldo) => {
-        return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
-    };
     return(
         <>
             {info &&
@@ -28,10 +25,10 @@ export const DashboardCardInfoConta = ({acoesAssociacao, corIconeFonte}) =>{
                                             <p className="pt-1 mb-2">
                                                 Repasses no período: <strong>{exibeValorFormatadoPT_BR(info.repasses_no_periodo)}</strong>
                                             </p>
-                                            <p className={`pt-1 mb-2 texto-com-icone-${corIconeFonte}`}>
+                                            <p className={getCssDestaque(2)}>
                                                 Outras receitas: <strong>{exibeValorFormatadoPT_BR(info.outras_receitas_no_periodo)}</strong>
                                             </p>
-                                            <p className={`pt-1 mb-0 texto-com-icone-${corIconeFonte}`}>
+                                            <p className={getCssDestaque(0)}>
                                                 Despesa: <strong>{exibeValorFormatadoPT_BR(info.despesas_no_periodo)}</strong>
                                             </p>
                                         </div>

--- a/src/componentes/Globais/Dashborard/index.js
+++ b/src/componentes/Globais/Dashborard/index.js
@@ -104,6 +104,21 @@ export const Dashboard = () => {
         setLoading(false);
     };
 
+
+    const getCorSaldo = (valor_saldo) => {
+        return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
+    };
+
+    const getCssDestaque = (tamanho_margin_bottom=1) =>{
+        if (acoesAssociacao && acoesAssociacao.prestacao_contas_status){
+            if(acoesAssociacao.prestacao_contas_status.periodo_encerrado && acoesAssociacao.prestacao_contas_status.status_prestacao === "APROVADA"){
+                return `pt-1 mb-${tamanho_margin_bottom}`
+            }else {
+                return `pt-1 mb-${tamanho_margin_bottom} texto-com-icone-${getCorStatusPeriodo(acoesAssociacao.periodo_status)}`
+            }
+        }
+    }
+
     return (
         <>
             <div className="form-row align-items-center mb-3">
@@ -133,11 +148,13 @@ export const Dashboard = () => {
                     />
                     <DashboardCardInfoConta
                         acoesAssociacao={acoesAssociacao}
-                        corIconeFonte={getCorStatusPeriodo(acoesAssociacao.periodo_status)}
+                        getCorSaldo={getCorSaldo}
+                        getCssDestaque={getCssDestaque}
                     />
                     <DashboardCard
                         acoesAssociacao={acoesAssociacao}
-                        corIconeFonte={getCorStatusPeriodo(acoesAssociacao.periodo_status)}
+                        getCorSaldo={getCorSaldo}
+                        getCssDestaque={getCssDestaque}
                     />
                 </>
             }


### PR DESCRIPTION
Esse PR:

- Corrige a exibição do destaque (cor e ponto de exclamação) nos valores de Despesa e Outras receitas em períodos finalizados, cuja PC fora aprovada pela DRE

Historia: [AB#37949](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/37949)