### PR TITLE
feat(29418): Alterar cor do destaque (em andamento)

### DIFF
--- a/src/componentes/Globais/Dashborard/index.js
+++ b/src/componentes/Globais/Dashborard/index.js
@@ -39,7 +39,7 @@ export const Dashboard = () => {
     }, [uuid_associacao]);
 
     const buscaPeriodos = useCallback(async () => {
-        let periodos = await getPeriodosAteAgoraForaImplantacaoDaAssociacao();
+        let periodos = await getPeriodosAteAgoraForaImplantacaoDaAssociacao(uuid_associacao);
         setSelectPeriodo(periodos[0].uuid)
         setPeriodosAssociacao(periodos);
     }, []);
@@ -114,7 +114,7 @@ export const Dashboard = () => {
             if(acoesAssociacao.prestacao_contas_status.periodo_encerrado && acoesAssociacao.prestacao_contas_status.status_prestacao === "APROVADA"){
                 return `pt-1 mb-${tamanho_margin_bottom}`
             }else {
-                return `pt-1 mb-${tamanho_margin_bottom} texto-com-icone-${getCorStatusPeriodo(acoesAssociacao.periodo_status)}`
+                return `pt-1 mb-${tamanho_margin_bottom} texto-com-icone-${getCorStatusPeriodo(statusPeriodoAssociacao)}`
             }
         }
     }

--- a/src/services/escolas/PrestacaoDeContas.service.js
+++ b/src/services/escolas/PrestacaoDeContas.service.js
@@ -22,8 +22,8 @@ export const getPeriodosNaoFuturos = async () => {
   return(await api.get('/api/periodos/lookup-until-now/', authHeader)).data
 };
 
-export const getPeriodosAteAgoraForaImplantacaoDaAssociacao = async () => {
-  return(await api.get(`/api/associacoes/${localStorage.getItem(ASSOCIACAO_UUID)}/periodos-ate-agora-fora-implantacao/`, authHeader)).data
+export const getPeriodosAteAgoraForaImplantacaoDaAssociacao = async (uuid_associacao) => {
+  return(await api.get(`/api/associacoes/${uuid_associacao}/periodos-ate-agora-fora-implantacao/`, authHeader)).data
 };
 
 

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -610,7 +610,7 @@ export const getTextoStatusPeriodo = (statusId) => {
 
 export const getCorStatusPeriodo = (statusId) => {
   let cor = ''
-  if (statusId === 'EM_ANDAMENTO') {
+  if (statusId === 'EM_ANDAMENTO' || (statusId && statusId.prestacao_contas_status && statusId.prestacao_contas_status.texto_status === "Período em andamento. ")) {
     cor = 'amarelo'
   } else if (statusId === 'PENDENTE') {
     cor = 'vermelho'


### PR DESCRIPTION
Esse PR:

- Altera a cor do destaque e a cor do ícone para os valores de Outras receitas e Despesas quando o período for em andamento.

História: [AB#29418](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/29418)