### PR TITLE
fix(42457): [Associação] Cadastro de despesa a partir de recurso externo não segue a configuração do cadastro de despesa comum

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
@@ -73,7 +73,6 @@ export const CadastroSaidaForm = () => {
 
         // Validando se tipo de documento aceita apenas numéricos e se exibe campo Número do Documento
         if (values.tipo_documento) {
-            //debugger
             let exibe_campo_numero_documento;
             let so_numeros;
             // verificando se despesasTabelas já está preenchido
@@ -114,8 +113,6 @@ export const CadastroSaidaForm = () => {
                 }
             }
         }
-
-
         return erros;
     }, [despesasTabelas])
 

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
@@ -286,8 +286,7 @@ export const CadastroSaidaForm = () => {
                                                     setErrors({...errors, numero_documento:""})
                                                 }}
                                             />
-                                            {props.errors.numero_documento && <span className="span_erro text-danger mt-1"> {props.errors.numero_documento}</span>}
-                                            {!props.errors.numero_documento && formErrors.numero_documento && <p className='mb-0'><span className="span_erro text-danger mt-1">{formErrors.numero_documento}</span></p>}
+                                            {formErrors.numero_documento && <p className='mb-0'><span className="span_erro text-danger mt-1">{formErrors.numero_documento}</span></p>}
                                         </div>
 
                                         <div className="col-12 col-md-6 mt-4">

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -163,16 +163,7 @@ export const YupSignupSchemaCadastroDespesaSaida = yup.object().shape({
         }
       }),
 
-  numero_documento:yup.string().required("Número documento é obrigatório.")
-  .test('test-numero-documento', 'Selecione um número de documento válido',
-    function (value) {
-      if (value !== undefined || value !== '') {
-        return true
-      } else {
-        return false
-      }
-    }),
-  
+
   data_documento: yup.string().required("Data do documento é obrigatório.").nullable(),
   tipo_transacao: yup.string().required("Tipo da transação é obrigatório.").nullable(),
 


### PR DESCRIPTION
Esse PR:

- Corrige a validação do campo Número do documento no cadastro de despesa de um recurso externo que agora leva em consideração se o campo deve ou não ser digitado e se aceita somente números, parametrizados no admin do sistema

História: [AB#42457](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42457)