### PR TITLE
feat(42271): Remove despesa vinculada ao crédito de recurso externo

### DIFF
--- a/src/componentes/escolas/Receitas/ModalDeletarReceita.js
+++ b/src/componentes/escolas/Receitas/ModalDeletarReceita.js
@@ -1,0 +1,17 @@
+import React from "react";
+import {ModalBootstrap} from "../../Globais/ModalBootstrap";
+
+export const ModalDeletarReceita = (props) =>{
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={props.handleClose}
+            titulo="Deseja excluir este Crédito?"
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.onDeletarTrue}
+            primeiroBotaoTexto="OK"
+            segundoBotaoOnclick={props.handleClose}
+            segundoBotaoTexto="Fechar"
+        />
+    )
+};

--- a/src/services/escolas/Receitas.service.js
+++ b/src/services/escolas/Receitas.service.js
@@ -59,14 +59,7 @@ export const atualizaReceita = async (uuid, payload) => {
 };
 
 export const deletarReceita = async uuid => {
-    return api
-        .delete(`api/receitas/${uuid}/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, authHeader)
-        .then(response => {
-            return response;
-        })
-        .catch(error => {
-            return error.response;
-        });
+    return (await api.delete(`api/receitas/${uuid}/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, authHeader)).data
 };
 
 export const getListaReceitas = async () => {

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -58,20 +58,6 @@ export const DeletarModal = (propriedades) => {
         />
     )
 };
-export const DeletarModalReceitas = (propriedades) => {
-    return (
-        <ModalBootstrap
-            show={propriedades.show}
-            onHide={propriedades.handleClose}
-            titulo="Deseja excluir este Crédito?"
-            bodyText="<p>Tem certeza que deseja excluir este crédito? A ação não poderá ser desfeita.</p>"
-            primeiroBotaoOnclick={propriedades.onDeletarTrue}
-            primeiroBotaoTexto="OK"
-            segundoBotaoOnclick={propriedades.handleClose}
-            segundoBotaoTexto="Fechar"
-        />
-    )
-};
 
 export const CancelarModalAssociacao = (propriedades) => {
     return (


### PR DESCRIPTION
Esse PR: 

- Exclui a despesa vinculada ao crédito do recurso externo, caso exista, e no momento de exclusão do crédito o usuário é avisado

História: [AB#42271](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42271)