### PR TITLE
feat(42269): [Associação] Créditos de recursos externos: Melhorias no formulário de saída do recurso externo

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/ModalValorReceitaDespesaDiferente.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/ModalValorReceitaDespesaDiferente.js
@@ -1,0 +1,19 @@
+import React from "react";
+import {ModalBootstrap} from "../../../Globais/ModalBootstrap";
+
+export const ModalValorReceitaDespesaDiferente = (props) =>{
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={props.handleClose}
+            titulo={props.titulo}
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.onSalvarValoresDiferentes}
+            primeiroBotaoTexto="Sim"
+            primeiroBotaoCss="success"
+            segundoBotaoOnclick={props.handleClose}
+            segundoBotaoCss="outline-success"
+            segundoBotaoTexto="Não"
+        />
+    )
+};

--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -83,6 +83,8 @@ export const ReceitaForm = () => {
 
     const [msgDeletarReceita, setmsgDeletarReceita] = useState('<p>Tem certeza que deseja excluir este crédito? A ação não poderá ser desfeita.</p>')
 
+    const [exibeModalSalvoComSucesso, setExibeModalSalvoComSucesso] = useState(true)
+
     const carregaTabelas = useCallback(async ()=>{
         let tabelas_receitas = await getTabelasReceitaReceita()
         setTabelas(tabelas_receitas)
@@ -102,6 +104,7 @@ export const ReceitaForm = () => {
             return acao;
         } else {
             setShowCadastrarSaida(false);
+            return false
         }
     }, [tabelas])
 
@@ -209,12 +212,20 @@ export const ReceitaForm = () => {
         setLoading(true);
         if (uuid) {
             await atualizar(uuid, payload).then(response => {
-                setShowSalvarReceita(true);
+                if (exibeModalSalvoComSucesso){
+                    setShowSalvarReceita(true);
+                }else {
+                    getPath()
+                }
             });
         } else {
             cadastrar(payload).then(response => {
-                setShowSalvarReceita(true);
                 setUuidReceita(response);
+                if (exibeModalSalvoComSucesso){
+                    setShowSalvarReceita(true);
+                }else {
+                    getPath()
+                }
             });
         }
         setLoading(false);
@@ -840,7 +851,10 @@ export const ReceitaForm = () => {
                                 {showCadastrarSaida === true ?
                                     <button
                                         type="submit"
-                                        onClick={() => setRedirectTo('/cadastro-de-despesa-recurso-proprio')}
+                                        onClick={() => {
+                                            setExibeModalSalvoComSucesso(false)
+                                            setRedirectTo('/cadastro-de-despesa-recurso-proprio')
+                                        }}
                                         className="btn btn btn-outline-success mt-2 mr-2"
                                     >
                                         Cadastrar saída
@@ -855,7 +869,14 @@ export const ReceitaForm = () => {
                                 {uuid ?
                                     <button disabled={readOnlyBtnAcao || !visoesService.getPermissoes(['delete_receita'])} type="reset" onClick={onShowDeleteModal} className="btn btn btn-danger mt-2 mr-2">Deletar</button> : null
                                 }
-                                <button onClick={(e)=>servicoDeVerificacoes(e, values, errors)} disabled={readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)} type="submit" className="btn btn-success mt-2">Salvar </button>
+                                <button
+                                    onClick={(e)=>servicoDeVerificacoes(e, values, errors)}
+                                    disabled={readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                    type="submit"
+                                    className="btn btn-success mt-2"
+                                >
+                                    Salvar
+                                </button>
 
                             </div>
                             {/*Fim Botões*/}

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -82,7 +82,7 @@ const routesConfig = [
     },
     {
         exact: true,
-        path: "/cadastro-de-despesa-recurso-proprio/:uuid?",
+        path: "/cadastro-de-despesa-recurso-proprio/:uuid_receita?/:uuid_despesa?",
         component: CadastroSaida,
         permissoes: ['access_receita']
     },


### PR DESCRIPTION
Esse PR:

- Implementa o preenchimento automático do valor de uma despesa vinculada
- Implementa a validação do valor da despesa maior que zero
- Permite valores diferentes da entrada, mas solicita uma confirmação ao gravar
- Remove mensagem de "Crédito salvo com sucesso" ao cadastrar/editar saída 
- Exibe mensagem quando for a gravação de um crédito NÃO recurso externo 

Historia: [AB#42269](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42269)
