### PR TITLE
feat(42269): [Associação] Créditos de recursos externos: Melhorias no formulário de saída do recurso externo - Parte 2

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -210,6 +210,7 @@ export const ReceitaForm = () => {
         }
 
         setLoading(true);
+
         if (uuid) {
             await atualizar(uuid, payload).then(response => {
                 if (exibeModalSalvoComSucesso){
@@ -220,11 +221,12 @@ export const ReceitaForm = () => {
             });
         } else {
             cadastrar(payload).then(response => {
-                setUuidReceita(response);
                 if (exibeModalSalvoComSucesso){
                     setShowSalvarReceita(true);
+                    setUuidReceita(response);
                 }else {
-                    getPath()
+                    setUuidReceita(response);
+                    getPath(response)
                 }
             });
         }
@@ -315,10 +317,10 @@ export const ReceitaForm = () => {
         setShowErroGeral(true);
     };
 
-    const getPath = () => {
+    const getPath = (uuid_receita_passado='') => {
         let path;
         if (redirectTo !== '') {
-            path = `${redirectTo}/${uuid_receita}`;
+            path = `${redirectTo}/${uuid_receita_passado ? uuid_receita_passado : uuid_receita}`;
         } else if (origem === undefined) {
             path = `/lista-de-receitas`;
         } else {


### PR DESCRIPTION
Esse PR:

- Resolve a passagem de parâmetro para o cadastro de saída
- Anteriormente ao clicar em cadastrar saída, não estava enviando o uuid da receita

História: [AB#42269](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42269)