### PR TITLE
feat(42275): Gastos da Escola. Não permitir usar ações do tipo recursos externos

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCapital.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCapital.js
@@ -74,7 +74,7 @@ export const CadastroFormCapital = (propriedades) => {
                         disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                     >
                         <option value="">Selecione uma ação</option>
-                        {despesasTabelas.acoes_associacao && despesasTabelas.acoes_associacao.map(item => (
+                        {despesasTabelas.acoes_associacao && despesasTabelas.acoes_associacao.filter(acao => !acao.e_recursos_proprios).map(item => (
                             <option key={item.uuid} value={item.uuid}>{item.nome}</option>
                         ))}
                     </select>

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCusteio.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCusteio.js
@@ -81,8 +81,8 @@ export const CadastroFormCusteio = (propriedades) => {
                         className={`${!rateio.acao_associacao && verboHttp === "PUT" && "is_invalid "} ${!rateio.acao_associacao && 'despesa_incompleta'} form-control`}
                         disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                     >
-                        <option key={0} value="">Selecione uma ação</option>
-                        {despesasTabelas.acoes_associacao && despesasTabelas.acoes_associacao.map(item => (
+                        <option value="">Selecione uma ação</option>
+                        {despesasTabelas.acoes_associacao && despesasTabelas.acoes_associacao.filter(acao => !acao.e_recursos_proprios).map(item => (
                             <option key={item.uuid} value={item.uuid}>{item.nome}</option>
                         ))}
                     </select>


### PR DESCRIPTION
Esse PR:

- Altera o cadastro de despesas para não permitir a escolha de uma ação do tipo recurso externo

História: [AB#42275](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42275)