### PR TITLE
feat(31424): [DRE] Não permitir reabrir ou devolver para ajustes PC com PC´s posteriores

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/ModalErroPrestacaoDeContasPosterior.js
+++ b/src/componentes/dres/PrestacaoDeContas/ModalErroPrestacaoDeContasPosterior.js
@@ -1,0 +1,16 @@
+import {ModalBootstrap} from "../../Globais/ModalBootstrap";
+import React from "react";
+
+export const ModalErroPrestacaoDeContasPosterior = (props) => {
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={props.handleClose}
+            titulo={props.titulo}
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.handleClose}
+            primeiroBotaoTexto={props.primeiroBotaoTexto}
+            primeiroBotaoCss={props.primeiroBotaoCss}
+        />
+    )
+};


### PR DESCRIPTION
Esse PR:

- Implementa tratamento e exibição de mensagem amigável para usuário quando da reabertura ou conclusão de uma prestação de contas que tenha prestações de contas posteriores

História: [AB#31424](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/31424)