### PR TITLE
feat(42704) Exibe loading antes do retorno da API

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -102,9 +102,10 @@ export const CadastroForm = ({verbo_http}) => {
                 const resposta = await getEspecificacoesCusteio(tipoCusteio.id);
                 let_especificacoes_custeio[tipoCusteio.id] = await resposta
             });
-            set_especificacoes_custeio(let_especificacoes_custeio)
+            set_especificacoes_custeio(let_especificacoes_custeio);
+            setLoading(false);
         };
-        carregaTabelasDespesas();
+        carregaTabelasDespesas();   
     }, []);
 
     useEffect(() => {
@@ -112,10 +113,6 @@ export const CadastroForm = ({verbo_http}) => {
             const resp = await getEspecificacoesCapital();
             set_especificaoes_capital(resp)
         })();
-    }, []);
-
-    useEffect(() => {
-        setLoading(false)
     }, []);
 
     const initialValues = () => {

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroSaidaForm.js
@@ -127,6 +127,7 @@ export const CadastroSaidaForm = () => {
                     }
 
                     setReceita(resp);
+                    setLoading(false); 
                 }).catch(error => {
                     console.log(error);
                 });
@@ -134,7 +135,6 @@ export const CadastroSaidaForm = () => {
         };
         buscaReceita();
         carregaTabelasDespesas();
-        setLoading(false);
     }, [uuid_receita, uuid_despesa])
 
     // Validações adicionais

--- a/src/componentes/escolas/Despesas/ListaDeDespesas/index.jsx
+++ b/src/componentes/escolas/Despesas/ListaDeDespesas/index.jsx
@@ -34,6 +34,7 @@ export class ListaDeDespesas extends Component {
     buscaRateiosDespesas = async (palavra = "", aplicacao_recurso = "", acao_associacao__uuid = "", despesa__status = "") => {
         const rateiosDespesas = await getListaRateiosDespesas();
         this.setState({rateiosDespesas})
+        this.setState({loading: false})
     };
 
     reusltadoSomaDosTotais = async (palavra = "", aplicacao_recurso = "", acao_associacao__uuid = "", despesa__status = "", fornecedor = "", data_inicio = "", data_fim = "") => {
@@ -44,7 +45,6 @@ export class ListaDeDespesas extends Component {
     componentDidMount() {
         this.buscaRateiosDespesas();
         this.reusltadoSomaDosTotais();
-        this.setState({loading: false})
     }
 
     numeroDocumentoStatusTemplate(rowData) {


### PR DESCRIPTION
feat(42704): Exibe loading antes do retorno da API

Esse PR:

- Adiciona loading ao esperar retorno da API na listagem de despesas,
- Adiciona loading ao esperar o retorno da API na edição de despesa.

História: [AB#42704](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42704)