### PR TITLE
feat(29936) Remove seta do campo status

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/FormRecebimentoPelaDiretoria.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/FormRecebimentoPelaDiretoria.js
@@ -35,7 +35,7 @@ export const FormRecebimentoPelaDiretoria = ({stateFormRecebimentoPelaDiretoria,
                             onChange={(e) => handleChangeFormRecebimentoPelaDiretoria(e.target.name, e.target.value)}
                             name="status"
                             id="status"
-                            className="form-control"
+                            className="form-control retira-dropdown-select"
                             disabled={disabledStatus}
                         >
                             {tabelaPrestacoes.status && tabelaPrestacoes.status.length > 0 && tabelaPrestacoes.status.map(item => (

--- a/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
+++ b/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
@@ -262,3 +262,10 @@
 .container-exibe-motivos{
   background-color: #E9ECEF;
 }
+
+.retira-dropdown-select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 1px;
+  text-overflow: '';
+}


### PR DESCRIPTION
feat(29936): Remove seta do campo status

Esse PR:

- Adiciona classe css para remover dropdown do campo,
- Adiciona a nova classe ao campo de status.

História: [AB#29936](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/29936)