### PR TITLE
feat(43985) Permite cadastro CNPJ zerado

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -5,7 +5,7 @@ import {
     cpfMaskContitional,
     calculaValorRecursoAcoes,
     periodoFechado,
-    comparaObjetos, valida_cpf_cnpj
+    comparaObjetos, valida_cpf_cnpj_permitindo_cnpj_zerado
 } from "../../../../utils/ValidacoesAdicionaisFormularios";
 import MaskedInput from 'react-text-mask'
 import {
@@ -76,6 +76,7 @@ export const CadastroForm = ({verbo_http}) => {
     const [exibeMsgErroValorRecursos, setExibeMsgErroValorRecursos] = useState(false);
     const [exibeMsgErroValorOriginal, setExibeMsgErroValorOriginal] = useState(false);
     const [numeroDocumentoReadOnly, setNumeroDocumentoReadOnly] = useState(false);
+    const [razaoSocialReadOnly, setRazaoSocialReadOnly] = useState(false);
     const [showDespesaConferida, setShowDespesaConferida] = useState(false);
 
     const [objetoParaComparacao, setObjetoParaComparacao] = useState({});
@@ -133,8 +134,10 @@ export const CadastroForm = ({verbo_http}) => {
     const validacoesPersonalizadas = useCallback(async (values, setFieldValue) => {
 
         let erros = {};
-        let cpf_cnpj_valido = !(!values.cpf_cnpj_fornecedor || values.cpf_cnpj_fornecedor.trim() === "" || !valida_cpf_cnpj(values.cpf_cnpj_fornecedor));
+        /* let cpf_cnpj_valido = !(!values.cpf_cnpj_fornecedor || values.cpf_cnpj_fornecedor.trim() === "" || !valida_cpf_cnpj(values.cpf_cnpj_fornecedor)); */
+        let cpf_cnpj_valido = !(!values.cpf_cnpj_fornecedor || values.cpf_cnpj_fornecedor.trim() === "" || !valida_cpf_cnpj_permitindo_cnpj_zerado(values.cpf_cnpj_fornecedor));
 
+        
         if (!cpf_cnpj_valido) {
             erros = {
                 cpf_cnpj_fornecedor: "Digite um CPF ou um CNPJ válido"
@@ -177,6 +180,14 @@ export const CadastroForm = ({verbo_http}) => {
         }
         return erros;
     }, [aux])
+
+    const eh_despesa_sem_comprovacao_fiscal = (cpf_cnpj) => {
+        if(cpf_cnpj == "00.000.000/0000-00"){
+            return true;
+        }
+
+        return false;
+    }
 
     const onShowSaldoInsuficiente = async (values, errors, setFieldValue) => {
         values.despesa_incompleta = document.getElementsByClassName("despesa_incompleta").length
@@ -351,6 +362,15 @@ export const CadastroForm = ({verbo_http}) => {
         setShow(true);
     };
 
+    const setReadOnlyRazaoSocial = (value) => {
+        if(eh_despesa_sem_comprovacao_fiscal(value)){
+            setRazaoSocialReadOnly(true);
+        }
+        else{
+            setRazaoSocialReadOnly(false);
+        }
+    }
+
     const houveAlteracoes = (values) => {
         return !comparaObjetos(values, objetoParaComparacao)
     }
@@ -429,6 +449,7 @@ export const CadastroForm = ({verbo_http}) => {
                                                 }}
                                                 onBlur={async () => {
                                                     setFormErrors(await validacoesPersonalizadas(values, setFieldValue));
+                                                    setReadOnlyRazaoSocial(props.values.cpf_cnpj_fornecedor);
                                                 }}
                                                 onClick={() => {
                                                     setFormErrors({cpf_cnpj_fornecedor: ""})
@@ -444,6 +465,7 @@ export const CadastroForm = ({verbo_http}) => {
                                         <div className="col-12 col-md-6  mt-4">
                                             <label htmlFor="nome_fornecedor">Razão social do fornecedor</label>
                                             <input
+                                                readOnly={razaoSocialReadOnly}
                                                 value={props.values.nome_fornecedor}
                                                 onChange={props.handleChange}
                                                 onBlur={props.handleBlur}
@@ -468,7 +490,11 @@ export const CadastroForm = ({verbo_http}) => {
                                                 onBlur={props.handleBlur}
                                                 name='tipo_documento'
                                                 id='tipo_documento'
-                                                className={`${!props.values.tipo_documento && despesaContext.verboHttp === "PUT" && "is_invalid "} ${!props.values.tipo_documento && 'despesa_incompleta'} form-control`}
+                                                className={
+                                                    eh_despesa_sem_comprovacao_fiscal(props.values.cpf_cnpj_fornecedor) 
+                                                    ? "form-control"
+                                                    : `${!props.values.tipo_documento && despesaContext.verboHttp === "PUT" && "is_invalid "} ${!props.values.tipo_documento && "despesa_incompleta"} form-control`
+                                                }
                                                 disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                                             >
                                                 <option key={0} value="">Selecione o tipo</option>
@@ -489,7 +515,11 @@ export const CadastroForm = ({verbo_http}) => {
                                                 onCalendarClose={async () => {
                                                     setFormErrors(await validacoesPersonalizadas(values, setFieldValue));
                                                 }}
-                                                className={`${ !values.data_documento && verbo_http === "PUT" ? 'is_invalid' : ""} ${ !props.values.data_documento && "despesa_incompleta"} form-control`}
+                                                className={
+                                                    eh_despesa_sem_comprovacao_fiscal(props.values.cpf_cnpj_fornecedor) 
+                                                    ? "form-control"
+                                                    : `${!props.values.data_documento && despesaContext.verboHttp === "PUT" && "is_invalid "} ${!props.values.data_documento && "despesa_incompleta"} form-control`
+                                                }
                                                 about={despesaContext.verboHttp}
                                                 disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                                             />
@@ -504,7 +534,11 @@ export const CadastroForm = ({verbo_http}) => {
                                                 onBlur={props.handleBlur}
                                                 name="numero_documento"
                                                 id="numero_documento" type="text"
-                                                className={`${!numeroDocumentoReadOnly && !props.values.numero_documento && despesaContext.verboHttp === "PUT" ? "is_invalid " : ""} ${!numeroDocumentoReadOnly && !values.numero_documento && 'despesa_incompleta'} form-control`}
+                                                className={
+                                                    eh_despesa_sem_comprovacao_fiscal(props.values.cpf_cnpj_fornecedor) 
+                                                    ? "form-control"
+                                                    : `${!numeroDocumentoReadOnly && !props.values.numero_documento && despesaContext.verboHttp === "PUT" && "is_invalid "} ${!numeroDocumentoReadOnly && !props.values.numero_documento && "despesa_incompleta"} form-control`
+                                                }
                                                 placeholder={numeroDocumentoReadOnly ? "" : "Digite o número"}
                                                 disabled={readOnlyCampos || numeroDocumentoReadOnly || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                                             />
@@ -743,6 +777,8 @@ export const CadastroForm = ({verbo_http}) => {
                                                                         errors={errors}
                                                                         exibeMsgErroValorRecursos={exibeMsgErroValorRecursos}
                                                                         exibeMsgErroValorOriginal={exibeMsgErroValorOriginal}
+                                                                        eh_despesa_sem_comprovacao_fiscal={eh_despesa_sem_comprovacao_fiscal}
+                                                                        cpf_cnpj={props.values.cpf_cnpj_fornecedor}
                                                                     />
                                                                 ) :
                                                                 rateio.aplicacao_recurso && rateio.aplicacao_recurso === 'CAPITAL' ? (

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCusteio.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormCusteio.js
@@ -6,7 +6,7 @@ import {visoesService} from "../../../../services/visoes.service";
 
 export const CadastroFormCusteio = (propriedades) => {
 
-    const {formikProps, rateio, rateios, index, despesasTabelas,  especificacoes_custeio, verboHttp, disabled, errors, exibeMsgErroValorRecursos, exibeMsgErroValorOriginal} = propriedades
+    const {formikProps, rateio, rateios, index, despesasTabelas,  especificacoes_custeio, verboHttp, disabled, errors, exibeMsgErroValorRecursos, exibeMsgErroValorOriginal, eh_despesa_sem_comprovacao_fiscal, cpf_cnpj} = propriedades
 
     const setValorRateioRealizado=(setFieldValue, index, valor)=>{
         setFieldValue(`rateios[${index}].valor_rateio`, trataNumericos(valor))
@@ -28,7 +28,12 @@ export const CadastroFormCusteio = (propriedades) => {
                         }}
                         name={`rateios[${index}].tipo_custeio`}
                         id='tipo_custeio'
-                        className={`${!rateio.tipo_custeio && verboHttp === "PUT" && "is_invalid "} ${!rateio.tipo_custeio && 'despesa_incompleta'} form-control`}
+                        /* className={`${!rateio.tipo_custeio && verboHttp === "PUT" && "is_invalid "} ${!rateio.tipo_custeio && 'despesa_incompleta'} form-control`} */
+                        className={
+                            eh_despesa_sem_comprovacao_fiscal(cpf_cnpj) 
+                            ? "form-control"
+                            : `${!rateio.tipo_custeio && verboHttp === "PUT" && "is_invalid "} ${!rateio.tipo_custeio && "despesa_incompleta"} form-control`
+                        }
                         disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                     >
                         <option value="">Selecione um tipo</option>
@@ -51,7 +56,12 @@ export const CadastroFormCusteio = (propriedades) => {
                         onChange={formikProps.handleChange}
                         name={`rateios[${index}].especificacao_material_servico`}
                         id={`especificacao_material_servico_${index}`}
-                        className={`${!rateio.especificacao_material_servico && verboHttp === "PUT" && "is_invalid "} ${!rateio.especificacao_material_servico && 'despesa_incompleta'} form-control`}
+                        /* className={`${!rateio.especificacao_material_servico && verboHttp === "PUT" && "is_invalid "} ${!rateio.especificacao_material_servico && 'despesa_incompleta'} form-control`} */
+                        className={
+                            eh_despesa_sem_comprovacao_fiscal(cpf_cnpj) 
+                            ? "form-control"
+                            : `${!rateio.especificacao_material_servico && verboHttp === "PUT" && "is_invalid "} ${!rateio.especificacao_material_servico && "despesa_incompleta"} form-control`
+                        }
                         disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                     >
                         <option key={0} value="">Selecione uma especificação</option>

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -430,6 +430,67 @@ export const processoIncorporacaoMask = (value) => {
   return mask
 }
 
+export function valida_cpf_cnpj_permitindo_cnpj_zerado ( valor ) {
+
+  // Remove caracteres inválidos do valor
+  if (valor){
+    valor = valor.replace(/[^0-9]/g, '');
+  }
+
+  if (
+      !valor ||
+      (valor.length < 11 && valor.length > 14) ||
+      valor === "00000000000" ||
+      valor === "11111111111" ||
+      valor === "11111111111111" ||
+      valor === "22222222222" ||
+      valor === "22222222222222" ||
+      valor === "33333333333" ||
+      valor === "33333333333333" ||
+      valor === "44444444444" ||
+      valor === "44444444444444" ||
+      valor === "55555555555" ||
+      valor === "55555555555555" ||
+      valor === "66666666666" ||
+      valor === "66666666666666" ||
+      valor === "77777777777" ||
+      valor === "77777777777777" ||
+      valor === "88888888888" ||
+      valor === "88888888888888" ||
+      valor === "99999999999" ||
+      valor === "99999999999999"
+  ){
+    return false
+  }
+
+
+  // Verifica se é CPF ou CNPJ
+  let valida = verifica_cpf_cnpj( valor );
+
+  // Garante que o valor é uma string
+  valor = valor.toString();
+
+
+
+  // Valida CPF
+  if ( valida === 'CPF' ) {
+    // Retorna true para cpf válido
+    return valida_cpf( valor );
+  }
+
+  // Valida CNPJ
+  else if ( valida === 'CNPJ' ) {
+    // Retorna true para CNPJ válido
+    return valida_cnpj( valor );
+  }
+
+  // Não retorna nada
+  else {
+    return false;
+  }
+
+} // valida_cpf_cnpj
+
 export function valida_cpf_cnpj ( valor ) {
 
   // Remove caracteres inválidos do valor


### PR DESCRIPTION
feat(43985): Permite cadastro CNPJ zerado

Esse PR:

- Altera a interface para permitir cadastro de um CNPJ zerado;
- Altera regra de campos obrigatórios quando for um CNPJ zerado;

História: [AB#43985](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43985)