### PR TITLE
feat(42226):  Altera Perfil Acessos na visão UE

### DIFF
--- a/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisForm.js
+++ b/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisForm.js
@@ -26,6 +26,7 @@ export const GestaoDePerfisForm = () =>{
         visoes: [],
         unidade: "",
         unidades_vinculadas: [],
+        unidade_selecionada: uuid_unidade
     };
 
     const [statePerfisForm, setStatePerfisForm] = useState(initPerfisForm);

--- a/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisForm.js
+++ b/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisForm.js
@@ -515,18 +515,28 @@ export const GestaoDePerfisForm = () =>{
             // Removendo itens duplicados
             let grupos_concatenados_sem_repeticao = [...new Set(grupos_concatenados)]
 
-            let payload = {
-                e_servidor: values.e_servidor,
-                username: values.username,
-                name: values.name,
-                email: values.email ? values.email : "",
-                //visao: visao_selecionada,
-                //groups: values.groups,
-                groups: grupos_concatenados_sem_repeticao,
-                //unidade: visao_selecionada !== "SME" ? codigoEolUnidade : null,
-                unidade: null,
-                visoes: values.visoes,
-            };
+            let payload = {}
+            if (visao_selecionada === "UE") {
+                payload = {
+                    e_servidor: values.e_servidor,
+                    username: values.username,
+                    name: values.name,
+                    email: values.email ? values.email : "",
+                    visao: visao_selecionada,
+                    groups: grupos_concatenados_sem_repeticao,
+                    unidade: codigoEolUnidade,
+                };
+            } else {
+                payload = {
+                    e_servidor: values.e_servidor,
+                    username: values.username,
+                    name: values.name,
+                    email: values.email ? values.email : "",
+                    groups: grupos_concatenados_sem_repeticao,
+                    unidade: null,
+                    visoes: values.visoes,
+                };
+            }
 
             if (values.id || (usuariosStatus.usuario_sig_escola.info_sig_escola && usuariosStatus.usuario_sig_escola.info_sig_escola.user_id)) {
 
@@ -729,6 +739,25 @@ export const GestaoDePerfisForm = () =>{
         }
         return editavel
     }, [exibePermissaoExibicaoVisoes])
+
+    const setaVisaoUE = () => {
+        if (visao_selecionada === "UE" && !id_usuario) {
+            let visao = pesquisaVisao("UE")
+
+            let _visoes = []
+
+            _visoes.push(visao.id)
+
+            setStatePerfisForm({
+                ...statePerfisForm,
+                visoes: _visoes
+
+            })
+        }
+    }
+    useEffect(() => {
+        setaVisaoUE()
+    }, [visoes])
 
     return (
         <PaginasContainer>

--- a/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisFormFormik.js
+++ b/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisFormFormik.js
@@ -101,9 +101,9 @@ export const GestaoDePerfisFormFormik = (
                             </div>
                             <div className="p-Y bd-highlight">
                                 <button
-                                        onClick={() => window.location.assign('/gestao-de-perfis/')}
-                                        type="button"
-                                        className="btn btn btn-outline-success mt-2 ml-2">Voltar
+                                    onClick={() => window.location.assign('/gestao-de-perfis/')}
+                                    type="button"
+                                    className="btn btn btn-outline-success mt-2 ml-2">Voltar
                                 </button>
                             </div>
                         </div>
@@ -134,7 +134,8 @@ export const GestaoDePerfisFormFormik = (
                                         <option value="True">Servidor</option>
                                         <option value="False">Não Servidor</option>
                                     </select>
-                                    {props.errors.e_servidor && <span className="span_erro text-danger mt-1"> {props.errors.e_servidor}</span>}
+                                    {props.errors.e_servidor &&
+                                    <span className="span_erro text-danger mt-1"> {props.errors.e_servidor}</span>}
                                 </div>
                             </div>
 
@@ -165,7 +166,8 @@ export const GestaoDePerfisFormFormik = (
                                     />
                                     {/*Validações personalizadas*/}
                                     {formErrors.username &&
-                                            <p className='mb-0'><span className="span_erro text-danger mt-1">{formErrors.username}</span></p>
+                                    <p className='mb-0'><span
+                                        className="span_erro text-danger mt-1">{formErrors.username}</span></p>
                                     }
                                 </div>
                             </div>
@@ -185,7 +187,7 @@ export const GestaoDePerfisFormFormik = (
                                         maxLength='255'
                                     />
                                     {props.errors.name &&
-                                        <span className="span_erro text-danger mt-1"> {props.errors.name}</span>
+                                    <span className="span_erro text-danger mt-1"> {props.errors.name}</span>
                                     }
                                 </div>
                             </div>
@@ -206,7 +208,7 @@ export const GestaoDePerfisFormFormik = (
                                         maxLength='254'
                                     />
                                     {props.errors.email &&
-                                        <span className="span_erro text-danger mt-1"> {props.errors.email}</span>
+                                    <span className="span_erro text-danger mt-1"> {props.errors.email}</span>
                                     }
                                 </div>
                             </div>
@@ -231,13 +233,14 @@ export const GestaoDePerfisFormFormik = (
                                                         checked={props.values.visoes.includes(parseInt(visao.id))}
                                                         disabled={!visao.editavel}
                                                     />
-                                                    <label className="form-check-label" htmlFor={visao.nome}>{visao.nome}</label>
+                                                    <label className="form-check-label"
+                                                           htmlFor={visao.nome}>{visao.nome}</label>
                                                 </div>
                                             ))}
                                         </div>
                                     </div>
                                     {props.errors.visoes &&
-                                        <span className="span_erro text-danger mt-1"> {props.errors.visoes}</span>
+                                    <span className="span_erro text-danger mt-1"> {props.errors.visoes}</span>
                                     }
                                 </div>
                             </div>
@@ -256,7 +259,8 @@ export const GestaoDePerfisFormFormik = (
                                         }}
                                     >
                                         {grupos && grupos.length > 0 && grupos.map((grupo, index_grupos) => (
-                                                <option disabled={!pesquisaPermissaoExibicaoVisao(grupo.visao)} key={index_grupos} value={grupo.id}>{grupo.nome}</option>
+                                            <option disabled={!pesquisaPermissaoExibicaoVisao(grupo.visao)}
+                                                    key={index_grupos} value={grupo.id}>{grupo.nome}</option>
                                         ))}
                                     </Field>
                                     {props.errors.groups &&
@@ -264,10 +268,14 @@ export const GestaoDePerfisFormFormik = (
                                 </div>
                             </div>
 
+                            {initPerfisForm.visao !== "UE" &&
                             <div className='col-12'>
-                                <p><strong>{values.id ? "Unidades que possui acesso" : "Salve o usuário para poder vincular as unidades."}</strong></p>
+                                <p>
+                                    <strong>{values.id ? "Unidades que possui acesso" : "Salve o usuário para poder vincular as unidades."}</strong>
+                                </p>
                             </div>
-                            {values.id &&
+                            }
+                            {values.id && initPerfisForm.visao !== "UE" &&
                             <FieldArray
                                 name="unidades_vinculadas"
                                 render={({remove, push}) => (
@@ -277,7 +285,8 @@ export const GestaoDePerfisFormFormik = (
                                                 <div className="col-12" key={index_field_array}>
                                                     <div className='row'>
                                                         <div className='col mt-4'>
-                                                            <label htmlFor="tipo_de_unidade">Tipo de Unidade {index_field_array + 1}</label>
+                                                            <label htmlFor="tipo_de_unidade">Tipo de
+                                                                Unidade {index_field_array + 1}</label>
                                                             {values.visao === "UE" ? (
                                                                     <select
                                                                         value={unidade_vinculada.tipo_unidade ? unidade_vinculada.tipo_unidade : ""}
@@ -291,10 +300,15 @@ export const GestaoDePerfisFormFormik = (
                                                                         className="form-control"
                                                                         disabled={unidade_vinculada.nome}
                                                                     >
-                                                                        <option value="">Selecione um tipo de unidade</option>
-                                                                        <option disabled={true} value="DRE">DIRETORIA</option>
+                                                                        <option value="">Selecione um tipo de unidade
+                                                                        </option>
+                                                                        <option disabled={true} value="DRE">DIRETORIA
+                                                                        </option>
                                                                         {tabelaAssociacoes.tipos_unidade && tabelaAssociacoes.tipos_unidade.length > 0 && tabelaAssociacoes.tipos_unidade.filter(element => element.id !== 'ADM' && element.id !== 'DRE' && element.id !== 'IFSP' && element.id !== 'CMCT').map(item => (
-                                                                            <option disabled={!acessoCadastrarUnidade('UE') || item.id !== unidadeVisaoUE.tipo_unidade} key={item.id} value={item.id}>{item.nome}</option>
+                                                                            <option
+                                                                                disabled={!acessoCadastrarUnidade('UE') || item.id !== unidadeVisaoUE.tipo_unidade}
+                                                                                key={item.id}
+                                                                                value={item.id}>{item.nome}</option>
                                                                         ))}
                                                                     </select>
                                                                 ) :
@@ -316,14 +330,17 @@ export const GestaoDePerfisFormFormik = (
                                                                             value="DRE">DIRETORIA
                                                                     </option>
                                                                     {tabelaAssociacoes.tipos_unidade && tabelaAssociacoes.tipos_unidade.length > 0 && tabelaAssociacoes.tipos_unidade.filter(element => element.id !== 'ADM' && element.id !== 'DRE' && element.id !== 'IFSP' && element.id !== 'CMCT').map(item => (
-                                                                        <option disabled={!acessoCadastrarUnidade('UE')} key={item.id} value={item.id}>{item.nome}</option>
+                                                                        <option disabled={!acessoCadastrarUnidade('UE')}
+                                                                                key={item.id}
+                                                                                value={item.id}>{item.nome}</option>
                                                                     ))}
                                                                 </select>
                                                             }
                                                         </div>
 
                                                         <div className="col mt-4">
-                                                            <label htmlFor="groups">Unidade {index_field_array + 1}</label>
+                                                            <label
+                                                                htmlFor="groups">Unidade {index_field_array + 1}</label>
                                                             {unidade_vinculada.nome ? (
                                                                     <input
                                                                         value={unidade_vinculada.nome}
@@ -345,7 +362,8 @@ export const GestaoDePerfisFormFormik = (
                                                                 />
                                                             }
                                                             {props.touched.unidade_vinculada && props.errors.unidade_vinculada &&
-                                                                <span className="text-danger mt-1"> {props.errors.unidade_vinculada}</span>
+                                                            <span
+                                                                className="text-danger mt-1"> {props.errors.unidade_vinculada}</span>
                                                             }
                                                         </div>
 

--- a/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisFormFormik.js
+++ b/src/componentes/Globais/GestaoDePerfis/GestaoDePerfisFormFormik.js
@@ -68,21 +68,60 @@ export const GestaoDePerfisFormFormik = (
                     resetForm,
                     values,
                 } = props;
-                return (
+                    let vinculoUnidade = props.values.unidades_vinculadas.find(element => element.uuid === initPerfisForm.unidade_selecionada)
+                    console.log("Unidade selecionada #####", vinculoUnidade)
+                    let exibirBotaoDesvincular = (initPerfisForm.visao === "UE" && vinculoUnidade);
+                    let temOutrasUnidadesOuVisoes = (
+                        (vinculoUnidade && props.values.unidades_vinculadas.length > 1) ||
+                        (!vinculoUnidade && props.values.unidades_vinculadas.length > 0) ||
+                        props.values.visoes.includes(pesquisaVisao("DRE").id) ||
+                        props.values.visoes.includes(pesquisaVisao("SME").id)
+                    )
+                    return (
                     <form onSubmit={props.handleSubmit}>
                         <div className="d-flex bd-highlight mt-2">
                             <div className="p-Y flex-grow-1 bd-highlight">
                                 <p className='titulo-gestao-de-perfis-form'>{!statePerfisForm.id ? 'Adicionar' : 'Editar'} usuário</p>
                             </div>
+
                             <div className="p-Y bd-highlight">
-                                {statePerfisForm.id &&
+                                {statePerfisForm.id && exibirBotaoDesvincular &&
+                                <button
+                                    onClick={async () => {
+                                            if (vinculoUnidade) {
+                                                    await desvinculaUnidadeUsuario(vinculoUnidade)
+                                            }
+                                            if (! temOutrasUnidadesOuVisoes) {
+                                                    setShowModalDeletePerfil(true)
+                                            } else {
+                                                window.location.assign('/gestao-de-perfis/');
+                                            }
+                                    }}
+                                    type="button"
+                                    className="btn btn btn-danger mt-2"
+                                >
+                                    <FontAwesomeIcon
+                                        style={{
+                                            fontSize: '15px',
+                                            marginRight: "5px",
+                                            color: '#fff'
+                                        }}
+                                        icon={faTrash}
+                                    />
+                                        {temOutrasUnidadesOuVisoes ? "Desvincular usuário" : "Desvilcular e excluir"}
+                                </button>
+                                }
+                            </div>
+
+                            <div className="p-Y bd-highlight">
+                                {statePerfisForm.id && initPerfisForm.visao !== "UE" &&
                                 <button
                                     disabled={serviceTemUnidadeDre(props.values.unidades_vinculadas) || serviceTemUnidadeUE(props.values.unidades_vinculadas) || props.values.visoes.includes(pesquisaVisao("SME").id)}
                                     onClick={() => {
                                         setShowModalDeletePerfil(true)
                                     }}
                                     type="button"
-                                    className="btn btn btn-danger mt-2"
+                                    className="btn btn btn-danger mt-2 ml-2"
                                 >
                                     <FontAwesomeIcon
                                         style={{
@@ -231,7 +270,7 @@ export const GestaoDePerfisFormFormik = (
                                                             getEstadoInicialVisoesChecked()
                                                         }}
                                                         checked={props.values.visoes.includes(parseInt(visao.id))}
-                                                        disabled={!visao.editavel}
+                                                        disabled={!visao.editavel || initPerfisForm.visao === "UE"}
                                                     />
                                                     <label className="form-check-label"
                                                            htmlFor={visao.nome}>{visao.nome}</label>
@@ -275,12 +314,13 @@ export const GestaoDePerfisFormFormik = (
                                 </p>
                             </div>
                             }
-                            {values.id && initPerfisForm.visao !== "UE" &&
+                            {values.id  && initPerfisForm.visao !== "UE" &&
                             <FieldArray
                                 name="unidades_vinculadas"
                                 render={({remove, push}) => (
                                     <>
                                         {props.values.unidades_vinculadas && props.values.unidades_vinculadas.length > 0 && props.values.unidades_vinculadas.map((unidade_vinculada, index_field_array) => {
+                                                console.log("UV ********:", unidade_vinculada)
                                             return (
                                                 <div className="col-12" key={index_field_array}>
                                                     <div className='row'>


### PR DESCRIPTION
Esse PR altera o Perfil Acessos quando na visão UE:

[X] Não deve ser exibida a lista de Unidades vinculadas
[X] Trazer a opção UE selecionada.
[X] Ao salvar o usuário o vínculo ja deve ser feito com a UE logada.
[X] O seletor de visões deve ser apenas leitura.
[X] Botão "Desvincular e Deletar usuário" caso o usuário tenha apenas a visão UE, e esteja vinculado apenas à unidade logada
[X] Botão "Desvincular usuário" caso o usuário tenha outras visões ou outros vínculos

História: [AB#42226](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42226)
