### PR TITLE
feat(31426): Relatório consolidado DRE - Assíncrono - Parte 2

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/RelatorioConsolidadoApuracao/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/RelatorioConsolidadoApuracao/index.js
@@ -88,10 +88,23 @@ export const RelatorioConsolidadoApuracao = () => {
     }, [itensDashboard]);
 
     const consultarStatus = async () => {
+        console.log("Consultar status...")
         if (dre_uuid && periodo_uuid && conta_uuid) {
             let status = await getConsultarStatus(dre_uuid, periodo_uuid, conta_uuid);
             setStatusRelatorio(status);
+            console.log('Status:', status)
         }
+    };
+
+    const setaStatusComoProcessando = () => {
+        const statusProcessando = {
+            pcs_em_analise: false,
+            status_geracao: "EM_PROCESSAMENTO",
+            status_txt: "Análise de prestações de contas das associações completa. Relatório em processamento.",
+            cor_idx: 3,
+            status_arquivo: "Relatório sendo gerado. Aguarde."
+        }
+        setStatusRelatorio(statusProcessando);
     };
 
     const textoBtnRelatorio = () =>{
@@ -297,6 +310,7 @@ export const RelatorioConsolidadoApuracao = () => {
             setLoading(false);
             setMsgGeracaoRelatorio('O relatório está sendo gerado, enquanto isso você pode continuar a usar o sistema. Consulte na tela anterior o status de geração do relatório.');
             setShowModalMsgGeracaoRelatorio(true)
+            setaStatusComoProcessando()
         } catch (e) {
             setShowModalAssociacoesEmAnalise(false);
             setLoading(false);


### PR DESCRIPTION
Esse PR ajusta a página de apuração do relatório consolidado DRE para alterar o status do relatório
no momento em que se pede a geração do relatório, para que tenha inicio o ciclo de verificação 
de status que atualiza o caption do botão de geração.

História [AB#31426](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/31426)