### PR TITLE
fix(42727): Oculta botões salvar e cancelar quando apenas visualização

### DIFF
--- a/src/componentes/escolas/Associacao/DadosDaAssociacao/index.js
+++ b/src/componentes/escolas/Associacao/DadosDaAssociacao/index.js
@@ -229,12 +229,17 @@ export const DadosDaAsssociacao = () => {
                                                     }
                                                 </div>
                                             </div>
-                                            <div className="d-flex  justify-content-end pb-3">
-                                                <button onClick={() => setShowModalDadosAssociacaoCancelar(true)}
-                                                        type="reset" className="btn btn btn-outline-success mt-2">Cancelar
-                                                </button>
-                                                <button disabled={!visoesService.getPermissoes(['change_associacao'])} type="submit" className="btn btn-success mt-2 ml-2">Salvar</button>
-                                            </div>
+                                            { visoesService.getPermissoes(['change_associacao']) &&
+                                                <div className="d-flex  justify-content-end pb-3">
+                                                    <button onClick={() => setShowModalDadosAssociacaoCancelar(true)}
+                                                            type="reset"
+                                                            className="btn btn btn-outline-success mt-2">Cancelar
+                                                    </button>
+                                                    <button
+                                                        type="submit" className="btn btn-success mt-2 ml-2">Salvar
+                                                    </button>
+                                                </div>
+                                            }
 
                                             <section>
                                                 <CancelarModalAssociacao show={showModalReceitasCancelar}

--- a/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/index.js
+++ b/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/index.js
@@ -118,10 +118,16 @@ export const FormDadosDasContas = ({intialValues, setaCampoReadonly, onSubmit, e
                                 )}
                             >
                             </FieldArray>
-                            <div className="d-flex  justify-content-end pb-3 mt-3">
-                                <button onClick={props.handleReset} type="button" className="btn btn btn-outline-success mt-2 mr-2">Cancelar</button>
-                                <button disabled={!visoesService.getPermissoes(['change_associacao'])} type="submit" className="btn btn-success mt-2">Salvar</button>
-                            </div>
+                            { visoesService.getPermissoes(['change_associacao']) &&
+                                <div className="d-flex  justify-content-end pb-3 mt-3">
+                                    <button onClick={props.handleReset} type="button"
+                                            className="btn btn btn-outline-success mt-2 mr-2">Cancelar
+                                    </button>
+                                    <button type="submit"
+                                            className="btn btn-success mt-2">Salvar
+                                    </button>
+                                </div>
+                            }
                         </form>
                     )
                 }}


### PR DESCRIPTION
Esse PR alterar a página de Dados da Associação para não exibir os botões de cancelar e salvar quando o usuário tiver perfil de apenas visualização.

Corrige bug: [AB#42727](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42727)