### PR TITLE
feat(42261): Atas de prestação de contas: Presidente e secretário: Selecionar membros da associação

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/TabsArquivosDeReferencia.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/TabsArquivosDeReferencia.js
@@ -11,7 +11,7 @@ export const TabsArquivosDeReferencia = ({infoAta, toggleBtnEscolheConta, exibeA
             <hr className='mt-4 mb-3'/>
             <h4 className='mb-4'>Arquivos de referência</h4>
             <nav>
-                <div className="nav nav-tabs mb-3 menu-interno" id="nav-tab" role="tablist">
+                <div className="nav nav-tabs mb-3 menu-interno-dre-prestacao-de-contas" id="nav-tab" role="tablist">
                     {infoAta && infoAta.contas && infoAta.contas.length > 0 && infoAta.contas.map((conta, index) =>
                         <Fragment key={conta.conta_associacao.uuid}>
                             <a

--- a/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
+++ b/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
@@ -101,7 +101,7 @@
   font-size: 14px;
 }
 
-.menu-interno {
+.menu-interno-dre-prestacao-de-contas {
   padding-bottom: 0;
   border-bottom: solid 1px #BFBFBF!important;
 

--- a/src/componentes/escolas/GeracaoDaAta/ModalEditarAta.js
+++ b/src/componentes/escolas/GeracaoDaAta/ModalEditarAta.js
@@ -3,14 +3,26 @@ import {ModalBootstrapEditarAta} from "../../Globais/ModalBootstrap";
 import {DatePickerField} from "../../Globais/DatePickerField";
 import {visoesService} from "../../../services/visoes.service";
 
-export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, onChange, stateFormEditarAta, tabelas}) =>{
+export const ModalEditarAta = ({
+                                   dadosAta,
+                                   show,
+                                   handleClose,
+                                   onSubmitEditarAta,
+                                   onChange,
+                                   stateFormEditarAta,
+                                   tabelas,
+                                   membrosCargos,
+                                   handleChangeEditarAtaPresidente,
+                                   handleChangeEditarAtaPresidenteNaoMembro,
+                                   handleChangeEditarAtaSecretario,
+                                   handleChangeEditarAtaSecretarioNaoMembro,
+                               }) => {
     const bodyTextarea = () => {
         const podeEditarAta = [['change_ata_prestacao_contas']].some(visoesService.getPermissoes)
         return (
             <form className="form-group">
                 <div className="row">
-
-                    <div className='col-12 col-md-6'>
+                    <div className='col-6'>
                         <label htmlFor="tipo_reuniao">Tipo de Reunião</label>
                         <select
                             value={stateFormEditarAta.tipo_reuniao}
@@ -22,9 +34,20 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                             {tabelas && tabelas.tipos_reuniao && tabelas.tipos_reuniao.map((tipo) =>
                                 <option key={tipo.id} value={tipo.id}>{tipo.nome}</option>
                             )}
-
                         </select>
-
+                    </div>
+                    <div className='col-6'>
+                        <label htmlFor="data_reuniao">Data</label>
+                        <DatePickerField
+                            name="data_reuniao"
+                            value={stateFormEditarAta.data_reuniao}
+                            onChange={onChange}
+                            disabled={!podeEditarAta}
+                        />
+                    </div>
+                </div>
+                <div className='row'>
+                    <div className='col-6'>
                         <label htmlFor="local_reuniao" className="mt-3">Local da reunião</label>
                         <input
                             value={stateFormEditarAta.local_reuniao}
@@ -33,36 +56,8 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                             className="form-control"
                             disabled={!podeEditarAta}
                         />
-
-                        <label htmlFor="presidente_reuniao" className="mt-3">Presidente da reunião</label>
-                        <input
-                            value={stateFormEditarAta.presidente_reuniao}
-                            onChange={(e) => onChange(e.target.name, e.target.value)}
-                            name="presidente_reuniao"
-                            className="form-control"
-                            disabled={!podeEditarAta}
-                        />
-
-                        <label htmlFor="secretario_reuniao" className="mt-3">Secretário da reunião</label>
-                        <input
-                            value={stateFormEditarAta.secretario_reuniao}
-                            onChange={(e) => onChange(e.target.name, e.target.value)}
-                            name="secretario_reuniao"
-                            className="form-control"
-                            disabled={!podeEditarAta}
-                        />
-
                     </div>
-
-                    <div className='col-12 col-md-6'>
-                        <label htmlFor="data_reuniao">Data</label>
-                        <DatePickerField
-                            name="data_reuniao"
-                            value={stateFormEditarAta.data_reuniao}
-                            onChange={onChange}
-                            disabled={!podeEditarAta}
-                        />
-
+                    <div className='col-6'>
                         <label htmlFor="convocacao" className="mt-3">Abertura da reunião</label>
                         <select
                             value={stateFormEditarAta.convocacao}
@@ -75,33 +70,112 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                                 <option key={tipo.id} value={tipo.id}>{tipo.nome}</option>
                             )}
                         </select>
+                    </div>
+                </div>
 
+                <div className='row'>
+                    <div className='col-12'>
+                        <label htmlFor="presidente_reuniao" className="mt-3">Presidente da reunião</label>
+                        <select
+                            value={stateFormEditarAta.presidente_reuniao}
+                            onChange={(e) => {
+                                onChange(e.target.name, e.target.value)
+                                handleChangeEditarAtaPresidente(e)
+                            }}
+                            name="presidente_reuniao"
+                            className="form-control"
+                            disabled={!podeEditarAta}
+                        >
+                            <option value=''>Não membro</option>
+                            {membrosCargos && membrosCargos.length > 0 && membrosCargos.map((membro) =>
+                                <option data-objeto={JSON.stringify({...membro})} key={membro.nome}
+                                        value={membro.nome}>{membro.nome}</option>
+                            )}
+                        </select>
+                    </div>
+                </div>
+                <div className='row'>
+                    {!membrosCargos.find(membro => membro.nome === stateFormEditarAta.presidente_reuniao) &&
+                        <div className='col-6'>
+                            <label htmlFor="presidente_reuniao_nao_membro" className="mt-3">Nome do membro</label>
+                            <input
+                                defaultValue={stateFormEditarAta.presidente_reuniao}
+                                onChange={(e) => {
+                                    handleChangeEditarAtaPresidenteNaoMembro(e.target.value)
+                                }}
+                                name="presidente_reuniao_nao_membro"
+                                className="form-control"
+                                disabled={!podeEditarAta}
+                            />
+                        </div>
+                    }
+                    <div
+                        className={!membrosCargos.find(membro => membro.nome === stateFormEditarAta.presidente_reuniao) ? 'col-6' : 'col-12'}>
                         <label htmlFor="cargo_presidente_reuniao" className="mt-3">Cargo</label>
                         <input
                             value={stateFormEditarAta.cargo_presidente_reuniao}
                             onChange={(e) => onChange(e.target.name, e.target.value)}
                             name="cargo_presidente_reuniao"
                             className="form-control"
-                            disabled={!podeEditarAta}
+                            disabled={!membrosCargos.find(membro => membro.nome === stateFormEditarAta.presidente_reuniao) ? !podeEditarAta : true}
                         />
-
+                    </div>
+                </div>
+                <div className='row'>
+                    <div className='col-12'>
+                        <label htmlFor="secretario_reuniao" className="mt-3">Secretário da reunião</label>
+                        <select
+                            value={stateFormEditarAta.secretario_reuniao}
+                            onChange={(e) => {
+                                onChange(e.target.name, e.target.value)
+                                handleChangeEditarAtaSecretario(e)
+                            }}
+                            name="secretario_reuniao"
+                            className="form-control"
+                            disabled={!podeEditarAta}
+                        >
+                            <option value=''>Não membro</option>
+                            {membrosCargos && membrosCargos.length > 0 && membrosCargos.map((membro) =>
+                                <option data-objeto={JSON.stringify({...membro})} key={membro.nome} value={membro.nome}>{membro.nome}</option>
+                            )}
+                        </select>
+                    </div>
+                </div>
+                <div className='row'>
+                    {!membrosCargos.find(membro => membro.nome === stateFormEditarAta.secretario_reuniao) &&
+                        <div className='col-6'>
+                            <label htmlFor="secretario_reuniao_nao_membro" className="mt-3">Nome do membro</label>
+                            <input
+                                defaultValue={stateFormEditarAta.secretario_reuniao}
+                                onChange={(e) => {
+                                    handleChangeEditarAtaSecretarioNaoMembro(e.target.value)
+                                }}
+                                name="secretario_reuniao_nao_membro"
+                                className="form-control"
+                                disabled={!podeEditarAta}
+                            />
+                        </div>
+                    }
+                    <div className={!membrosCargos.find(membro => membro.nome === stateFormEditarAta.secretario_reuniao) ? 'col-6' : 'col-12'}>
                         <label htmlFor="cargo_secretaria_reuniao" className="mt-3">Cargo</label>
                         <input
                             value={stateFormEditarAta.cargo_secretaria_reuniao}
                             onChange={(e) => onChange(e.target.name, e.target.value)}
                             name="cargo_secretaria_reuniao"
                             className="form-control"
-                            disabled={!podeEditarAta}
+                            disabled={!membrosCargos.find(membro => membro.nome === stateFormEditarAta.secretario_reuniao) ? !podeEditarAta : true}
                         />
-
                     </div>
+                </div>
 
+                <div className="row">
                     {dadosAta && dadosAta.tipo_ata === "RETIFICACAO" &&
-                    <>
                         <div className="col-12 mt-3">
                             <div className="form-group">
                                 <label htmlFor="retificacoes" className="mb-0">Retificações</label>
-                                <p><small>Utilize esse campo para registrar as retificações da prestação de contas</small></p>
+                                <p><small>Utilize esse campo para registrar as retificações da prestação de
+                                    contas</small>
+                                </p>
                                 <textarea
                                     rows="3"
                                     placeholder="Escreva seu texto aqui"
@@ -113,11 +187,7 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                                 />
                             </div>
                         </div>
-                    </>
                     }
-
-
-
                     <div className="col-12 mt-3">
                         <div className="form-group">
                             <label htmlFor="comentarios" className="mb-0">Manifestações, Comentários e Justificativas</label>
@@ -132,7 +202,6 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                                 disabled={!podeEditarAta}
                             />
                         </div>
-
                         <div className="form-group">
                             <label htmlFor="parecer_conselho">Como os presentes se posicionam à prestação de contas apresentada?</label>
                             <select
@@ -148,12 +217,9 @@ export const ModalEditarAta = ({dadosAta, show, handleClose, onSubmitEditarAta, 
                             </select>
                         </div>
                     </div>
-
-
                 </div>
             </form>
         )
-
     };
     const podeEditarAta = [['change_ata_prestacao_contas']].some(visoesService.getPermissoes)
     return (

--- a/src/services/escolas/PrestacaoDeContas.service.js
+++ b/src/services/escolas/PrestacaoDeContas.service.js
@@ -204,4 +204,8 @@ export const getIniciarAtaRetificadora = async (uuidPrestacaoDeContas) => {
   return (await api.post(`/api/prestacoes-contas/${uuidPrestacaoDeContas}/iniciar-ata-retificacao/`, {}, authHeader)).data
 };
 
+export const getMembrosCargos = async (associacao_uuid) => {
+    return (await api.get(`/api/membros-associacao/membros-cargos/?associacao_uuid=${associacao_uuid}`,authHeader)).data
+};
+
 


### PR DESCRIPTION
Esse PR:

- Altera ata de PC
- Agora o Presidente e o Secretário podem ser selecionados pelo retorno da API de membros da Associação
- Caso não queira escolher um membro, continua sendo possível digitar os dados
- Faz a rediagramação dos dados para se adequar

História: [AB#42261](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42261)