### PR TITLE
feat(46263): Não aceitar lançamentos com datas futuras

### DIFF
--- a/src/componentes/Globais/DatePickerField/index.js
+++ b/src/componentes/Globais/DatePickerField/index.js
@@ -9,7 +9,7 @@ import moment from "moment";
 registerLocale("pt", pt );
 
 
-export const DatePickerField = ({ name, about, value, className="form-control", onChange, onCalendarOpen, onCalendarClose, disabled, placeholderText }) => {
+export const DatePickerField = ({ name, about, value, className="form-control", onChange, onCalendarOpen, onCalendarClose, disabled, placeholderText, maxDate=null }) => {
 
     return (
         <DatePicker
@@ -26,6 +26,7 @@ export const DatePickerField = ({ name, about, value, className="form-control", 
             showYearDropdown
             className = {className}
             placeholderText={placeholderText}
+            maxDate={maxDate}
             customInput={
                 <MaskedInput
                     mask = {[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -304,6 +304,21 @@ export const CadastroForm = ({verbo_http}) => {
 
         const errors = {};
 
+        // Validando se datas são maiores que data de hoje
+
+        let hoje = moment(new Date());
+        let data_digitada_documento = moment(values.data_documento);
+        let data_digitada_transacao = moment(values.data_transacao);
+
+        if (data_digitada_documento > hoje){
+            errors.data_documento = "Data do documento não pode ser maior que a data de hoje"
+        }
+        if (data_digitada_transacao > hoje){
+            errors.data_transacao = "Data da transação não pode ser maior que a data de hoje"
+        }
+
+
+
         // Validando se tipo de documento aceita apenas numéricos e se exibe campo Número do Documento
         if (values.tipo_documento) {
             let exibe_campo_numero_documento;
@@ -511,6 +526,7 @@ export const CadastroForm = ({verbo_http}) => {
                                                 }
                                                 about={despesaContext.verboHttp}
                                                 disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+                                                maxDate={new Date()}
                                             />
                                             {props.errors.data_documento && <span className="span_erro text-danger mt-1"> {props.errors.data_documento}</span>}
                                         </div>
@@ -569,6 +585,7 @@ export const CadastroForm = ({verbo_http}) => {
                                                 about={despesaContext.verboHttp}
                                                 className={`${ !values.data_transacao && verbo_http === "PUT" ? 'is_invalid' : ""} ${ !values.data_transacao && "despesa_incompleta"} form-control`}
                                                 disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+                                                maxDate={new Date()}
                                             />
                                             {props.errors.data_transacao &&
                                             <span

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/index.js
@@ -10,24 +10,21 @@ import {faTrashAlt, faDownload, faUpload, faPaperclip, faCheck} from '@fortaweso
 import 'antd/dist/antd.css';
 import { Upload, Button } from 'antd';
 
-
-
-
 const DataSaldoBancario = ({
-    valoresPendentes, dataSaldoBancario, handleChangaDataSaldo, periodoFechado, 
+    valoresPendentes, dataSaldoBancario, handleChangaDataSaldo, periodoFechado,
     nomeComprovanteExtrato, exibeBtnDownload, msgErroExtensaoArquivo,
     changeUploadExtrato, reiniciaUploadExtrato, downloadComprovanteExtrato, salvarExtratoBancario,
     btnSalvarExtratoBancarioDisable, setBtnSalvarExtratoBancarioDisable, classBtnSalvarExtratoBancario,
-    setClassBtnSalvarExtratoBancario, checkSalvarExtratoBancario, setCheckSalvarExtratoBancario
+    setClassBtnSalvarExtratoBancario, checkSalvarExtratoBancario, setCheckSalvarExtratoBancario, erroDataSaldo
 }) => {
-    
+
     const handleOnClick = () => {
         setBtnSalvarExtratoBancarioDisable(true);
         setCheckSalvarExtratoBancario(true);
         setClassBtnSalvarExtratoBancario("secondary");
         salvarExtratoBancario();
     }
-    
+
     return(
         <>
             <form method="post" encType="multipart/form-data">
@@ -48,7 +45,9 @@ const DataSaldoBancario = ({
                                                     type="date"
                                                     className="form-control"
                                                     disabled={periodoFechado || !visoesService.getPermissoes(['change_conciliacao_bancaria'])}
+                                                    maxDate={new Date()}
                                                 />
+                                                {erroDataSaldo && <span className="span_erro text-danger mt-1"> {erroDataSaldo}</span>}
                                             </div>
                                         </div>
 
@@ -70,24 +69,23 @@ const DataSaldoBancario = ({
                                             </div>
                                         </div>
 
-                                            
-                                        
+
                                     </div>
                                     <div className="col-6">
                                         <div className="form-group">
                                             <label htmlFor="upload_extrato" className="ml-1">Comprovante do saldo da conta</label>
                                             <div className='container-upload-extrato'>
-                                                <Upload 
-                                                    beforeUpload={() => false} 
+                                                <Upload
+                                                    beforeUpload={() => false}
                                                     disabled={periodoFechado || !visoesService.getPermissoes(['change_conciliacao_bancaria'])}
                                                     className={`${periodoFechado || !visoesService.getPermissoes(['change_conciliacao_bancaria']) ? 'disabled_upload' : ''}`}
                                                     {...{
-                                                    
+
                                                         name: 'file',
                                                         accept: ".gif,.jpg,.jpeg,.png, .pdf",
                                                         onChange:changeUploadExtrato,
                                                         showUploadList: false
-                                                    
+
                                                     }}>
                                                     <Button icon={
                                                         <i className="glyphicon mr-2">
@@ -108,7 +106,7 @@ const DataSaldoBancario = ({
                                                         <div className="col-lg-8 mt-2">
                                                             <p>
                                                                 <span className="mr-1 ml-1">
-                                                                    <FontAwesomeIcon 
+                                                                    <FontAwesomeIcon
                                                                     style={{color:'#000000'}}
                                                                     icon={faPaperclip}/>
                                                                 </span>{nomeComprovanteExtrato}
@@ -136,11 +134,11 @@ const DataSaldoBancario = ({
                                                         </div>
                                                     </div>
 
-                                                    
-                                                    
+
+
                                                 </div>
                                             </div>
-                                            
+
 
                                         </div>
                                     </div>
@@ -171,7 +169,7 @@ const DataSaldoBancario = ({
                             </div>
                         </div>
                     </div>
-                </div>   
+                </div>
             </form>
 
             {visoesService.getPermissoes(['change_conciliacao_bancaria']) &&
@@ -189,9 +187,9 @@ const DataSaldoBancario = ({
                         </div>
                     }
 
-                    <button 
-                        disabled={btnSalvarExtratoBancarioDisable} 
-                        type="button" 
+                    <button
+                        disabled={btnSalvarExtratoBancarioDisable}
+                        type="button"
                         className={`btn btn-${classBtnSalvarExtratoBancario} mt-2`}
                         onClick={handleOnClick}
                         >

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -428,11 +428,25 @@ export const DetalheDasPrestacoes = () => {
         }
     }, [nomeComprovanteExtrato, observacaoUuid])
 
+    const [erroDataSaldo, setErroDataSaldo] = useState('')
+
     const handleChangaDataSaldo = useCallback((name, value) => {
+        if (name === 'data_extrato'){
+            let hoje = moment(new Date());
+            let data_digitada = moment(value);
+            if (data_digitada > hoje){
+                setErroDataSaldo("Data do crédito não pode ser maior que a data de hoje")
+                setDataSaldoBancario(prevState => ({ ...prevState,  [name]: ''}));
+                return
+            }else {
+                setErroDataSaldo('')
+            }
+        }
+
         setBtnSalvarExtratoBancarioDisable(false);
         setCheckSalvarExtratoBancario(false);
         setClassBtnSalvarExtratoBancario("success");
-        
+
         setDataSaldoBancario({
             ...dataSaldoBancario,
             [name]: value
@@ -496,6 +510,7 @@ export const DetalheDasPrestacoes = () => {
                                 setClassBtnSalvarExtratoBancario={setClassBtnSalvarExtratoBancario}
                                 checkSalvarExtratoBancario={checkSalvarExtratoBancario}
                                 setCheckSalvarExtratoBancario={setCheckSalvarExtratoBancario}
+                                erroDataSaldo={erroDataSaldo}
                             />
 
                             <p className="detalhe-das-prestacoes-titulo-lancamentos mt-3 mb-3">Lançamentos pendentes de conciliação</p>

--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -790,6 +790,7 @@ export const ReceitaForm = () => {
                                         onChange={setFieldValue}
                                         onBlur={props.handleBlur}
                                         disabled={![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                        maxDate={new Date()}
                                     />
                                     {props.touched.data && props.errors.data &&
                                     <span className="span_erro text-danger mt-1"> {props.errors.data}</span>}


### PR DESCRIPTION
Esse PR:
Inclui validações de data maiores que a data atual, fazendo validações pelo componente Datepicker e nas validações do Form

- Em lançamento de créditos
- Em lancamento de despesas (data do documento e data da transação)
- Em conciliação bancária data do extrato

Hisrória: [AB#46263](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/46263)