### PR TITLE
feat(46268): Resumo de recursos: ícones exclamação sendo exibidos em períodos fechados para lançamentos

### DIFF
--- a/src/componentes/Globais/Dashborard/DashboardCard.js
+++ b/src/componentes/Globais/Dashborard/DashboardCard.js
@@ -4,7 +4,7 @@ import {MsgImgLadoDireito} from "../Mensagens/MsgImgLadoDireito";
 import Img404 from '../../../assets/img/img-404.svg'
 import {exibeDataPT_BR, exibeDateTimePT_BR, exibeValorFormatadoPT_BR} from '../../../utils/ValidacoesAdicionaisFormularios'
 
-export const DashboardCard = ({acoesAssociacao, getCorSaldo, getCssDestaque}) => {
+export const DashboardCard = ({acoesAssociacao, getCorSaldo, getCssDestaque, statusPeriodoAssociacao}) => {
     return (
         <>
             {acoesAssociacao.info_acoes && acoesAssociacao.info_acoes.length > 0 ? (
@@ -26,10 +26,10 @@ export const DashboardCard = ({acoesAssociacao, getCorSaldo, getCssDestaque}) =>
                                                 <p className="pt-1 mb-4">
                                                     Repasses no período: <strong>{exibeValorFormatadoPT_BR(acao.repasses_no_periodo)}</strong>
                                                 </p>
-                                                <p className={getCssDestaque(4)}>
+                                                <p className={getCssDestaque(4, statusPeriodoAssociacao)}>
                                                     Outras receitas: <strong>{exibeValorFormatadoPT_BR(acao.outras_receitas_no_periodo)}</strong>
                                                 </p>
-                                                <p className={getCssDestaque(0)}>
+                                                <p className={getCssDestaque(0, statusPeriodoAssociacao)}>
                                                     Despesa: <strong>{exibeValorFormatadoPT_BR(acao.despesas_no_periodo)}</strong>
                                                 </p>
                                                 {acao.acao_associacao_nome.trim() === 'PTRF' ? (

--- a/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
+++ b/src/componentes/Globais/Dashborard/DashboardCardInfoConta.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {exibeValorFormatadoPT_BR} from "../../../utils/ValidacoesAdicionaisFormularios";
 
-export const DashboardCardInfoConta = ({acoesAssociacao, getCorSaldo, getCssDestaque}) =>{
+export const DashboardCardInfoConta = ({acoesAssociacao, getCorSaldo, getCssDestaque, statusPeriodoAssociacao}) =>{
     let info = acoesAssociacao.info_conta;
     return(
         <>
@@ -25,10 +25,10 @@ export const DashboardCardInfoConta = ({acoesAssociacao, getCorSaldo, getCssDest
                                             <p className="pt-1 mb-2">
                                                 Repasses no período: <strong>{exibeValorFormatadoPT_BR(info.repasses_no_periodo)}</strong>
                                             </p>
-                                            <p className={getCssDestaque(2)}>
+                                            <p className={getCssDestaque(2, statusPeriodoAssociacao)}>
                                                 Outras receitas: <strong>{exibeValorFormatadoPT_BR(info.outras_receitas_no_periodo)}</strong>
                                             </p>
-                                            <p className={getCssDestaque(0)}>
+                                            <p className={getCssDestaque(0, statusPeriodoAssociacao)}>
                                                 Despesa: <strong>{exibeValorFormatadoPT_BR(info.despesas_no_periodo)}</strong>
                                             </p>
                                         </div>

--- a/src/componentes/Globais/Dashborard/index.js
+++ b/src/componentes/Globais/Dashborard/index.js
@@ -109,13 +109,11 @@ export const Dashboard = () => {
         return valor_saldo < 0 ? "texto-cor-vermelha" : "texto-cor-verde"
     };
 
-    const getCssDestaque = (tamanho_margin_bottom=1) =>{
-        if (acoesAssociacao && acoesAssociacao.prestacao_contas_status){
-            if(acoesAssociacao.prestacao_contas_status.periodo_encerrado && acoesAssociacao.prestacao_contas_status.status_prestacao === "APROVADA"){
-                return `pt-1 mb-${tamanho_margin_bottom}`
-            }else {
-                return `pt-1 mb-${tamanho_margin_bottom} texto-com-icone-${getCorStatusPeriodo(statusPeriodoAssociacao)}`
-            }
+    const getCssDestaque = (tamanho_margin_bottom= 1, statusPeriodoAssociacao) =>{
+        if (statusPeriodoAssociacao && statusPeriodoAssociacao.aceita_alteracoes){
+            return `pt-1 mb-${tamanho_margin_bottom} texto-com-icone-amarelo`
+        }else {
+            return `pt-1 mb-${tamanho_margin_bottom}`
         }
     }
 
@@ -150,11 +148,13 @@ export const Dashboard = () => {
                         acoesAssociacao={acoesAssociacao}
                         getCorSaldo={getCorSaldo}
                         getCssDestaque={getCssDestaque}
+                        statusPeriodoAssociacao={statusPeriodoAssociacao}
                     />
                     <DashboardCard
                         acoesAssociacao={acoesAssociacao}
                         getCorSaldo={getCorSaldo}
                         getCssDestaque={getCssDestaque}
+                        statusPeriodoAssociacao={statusPeriodoAssociacao}
                     />
                 </>
             }


### PR DESCRIPTION
Esse PR: 

-  Altera condições de exibição de ícones resumo dos recursos e situação financeira

História: [AB#46268](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/46268)