### PR TITLE
fix(42277): Dados da Diretoria: Nome do diretor não é apagado ao se apagar o RF

### DIFF
--- a/src/componentes/dres/Diretoria/DadosDaDiretoria/index.js
+++ b/src/componentes/dres/Diretoria/DadosDaDiretoria/index.js
@@ -78,6 +78,7 @@ export const DadosDaDiretoria = () => {
              }
          }else {
              delete errors.dre_diretor_regional_rf
+             setFieldValue('dre_diretor_regional_nome', '')
          }
     };
 


### PR DESCRIPTION
Esse PR:

- Limpa campo nome do diretor quando não existe codigo RF

História: [AB#42277](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/42277)