### PR TITLE
fix(47912): Membros não localização de estudantes do CEU Gestão

### DIFF
--- a/src/componentes/escolas/Associacao/Membros/index.js
+++ b/src/componentes/escolas/Associacao/Membros/index.js
@@ -381,7 +381,7 @@ export const MembrosDaAssociacao = () => {
                         if (cod_eol.status === 200 || cod_eol.status === 201) {
                             const init = {
                                 ...stateFormEditarMembro,
-                                nome: cod_eol.data.nm_aluno,
+                                nome: cod_eol.data.nomeAluno,
                                 codigo_identificacao: values.codigo_identificacao,
                                 cargo_associacao: values.cargo_associacao,
                                 cargo_educacao: "",


### PR DESCRIPTION
Esse PR: 

- Altera nome do campo que recebe o retorno do nome do Estudante vindo da API

História: [AB#47912](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/47912)