### PR TITLE
fix(47932): Corrige exibição da Gestão de Perfis nos menus das visões UE e SME

### DIFF
--- a/src/componentes/Globais/SidebarLeft/getUrls.js
+++ b/src/componentes/Globais/SidebarLeft/getUrls.js
@@ -50,7 +50,7 @@ const UrlsMenuEscolas ={
                 },
             ]
         },
-        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_gestao_perfis_ue', 'access_gestao_perfis_dre', 'access_gestao_perfis_sme'],},
+        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_gestao_perfis_ue'],},
     ]
 };
 
@@ -74,7 +74,7 @@ const UrlsMenuDres ={
             ]
         },
         {label: "Fornecedores", url: "parametro-fornecedores", dataFor:"parametro_fornecedores", icone:IconeMenuFornecedores, permissoes: ['access_fornecedores'],},
-        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_dados_diretoria'],},
+        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_gestao_perfis_dre'],},
     ]
 };
 
@@ -88,8 +88,8 @@ const UrlsMenuSME ={
     lista_de_urls:[
         {label: "Parametrizações", url: "painel-parametrizacoes", dataFor:"sme_painel_parametrizacoes", icone:IconeMenuParametrizacoes, permissoes: ['access_painel_parametrizacoes'],},
         {label: "Acompanhamento de PCs", url: "acompanhamento-pcs-sme", dataFor:"acompanhamento_pcs_sme", icone:IconeAcompanhamento, permissoes: ['access_acompanhamento_pc_sme'],},
-        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_gestao_perfis_ue', 'access_gestao_perfis_dre', 'access_gestao_perfis_sme'],},
         {label: "Consulta de saldos bancários", url: "consulta-de-saldos-bancarios", dataFor:"consulta_de_saldos_bancarios", icone:IconeMenuSaldosBancarios, permissoes: ['access_consulta_saldo_bancario'],},
+        {label: "Gestão de perfis", url: "gestao-de-perfis", dataFor:"gestao_de_perfis", icone:IconeGestaoDePerfis, permissoes: ['access_gestao_perfis_sme'],},
     ]
 };
 

--- a/src/services/visoes.service.js
+++ b/src/services/visoes.service.js
@@ -110,7 +110,10 @@ const getPermissoes = (permissao) =>{
     if (permissao && authService.isLoggedIn()){
         let permissoes = getItemUsuarioLogado('permissoes');
         let result = permissao.filter(item => permissoes.indexOf(item) > -1);
-        let tem_acesso = result.length === permissao.length;
+        // let tem_acesso = result.length === permissao.length;
+        // Alterado para conceder acesso se tiver ao menos uma das permissões da lista passada.
+        // Anteriormente estava exigindo que tivesse todas as permissões passadas na lista o que quebrava o acesso ao perfil de acessos
+        let tem_acesso = result.length > 0;
         return tem_acesso
     }
 


### PR DESCRIPTION
Esse PR:
 - Altera os menus de UE e SME para exigirem para acesso à Gestão de Perfis apenas as permissões das respectivas visões;
 - Alterar o algoritmo de verificação de permissões que exigia que o usuário tivesse todas as permissões da lista passada e não apenas uma delas.

Solução para o bug [AB#47932](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/47932)
