### PR TITLE
feat(43915): Acompanhamento PC: Em análise: Parte 9 - Replicar botão salvar do topo na base da página

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/BotaoSalvarRodape.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/BotaoSalvarRodape.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+export const BotaoSalvarRodape = ({exibeSalvar, metodoSalvarAnalise, btnSalvarDisabled, textoBtn}) =>{
+    return(
+        <>
+        {exibeSalvar &&
+            <div>
+                <button
+                    onClick={metodoSalvarAnalise}
+                    className="btn btn-success ml-2"
+                    disabled={btnSalvarDisabled}
+                >
+                    {textoBtn}
+                </button>
+            </div>
+        }
+        </>
+    )
+}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -13,6 +13,7 @@ import {TabsArquivosDeReferencia} from "./ArquivosDeReferencia/TabsArquivosDeRef
 import ArquivosDeReferenciaVisualizacaoDownload from "./ArquivosDeReferencia/ArquivosDeReferenciaVisualizacaoDownload";
 import ConferenciaDeLancamentos from "./ConferenciaDeLancamentos";
 import DevolucaoParaAcertos from "./DevolucaoParaAcertos";
+import {BotaoSalvarRodape} from "./BotaoSalvarRodape";
 
 
 export const GetComportamentoPorStatus = (
@@ -238,6 +239,15 @@ export const GetComportamentoPorStatus = (
                     <ComentariosDeAnalise
                         prestacaoDeContas={prestacaoDeContas}
                     />
+                    <div className='d-flex flex-row-reverse bd-highlight'>
+                        <BotaoSalvarRodape
+                            exibeSalvar={true}
+                            textoBtn={'Salvar'}
+                            metodoSalvarAnalise={salvarAnalise}
+                            btnSalvarDisabled={btnSalvarDisabled}
+                        />
+                    </div>
+
                 </>
             )
         } else if (prestacaoDeContas.status === 'DEVOLVIDA') {


### PR DESCRIPTION
Esse PR:

- Replica botão salvar no rodapé para PC em Análise

História: [AB#43915](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/43915)