### PR TITLE
feat(47838): Altera a edição de créditos tipo repasse

### DIFF
--- a/src/paginas/escolas/Receitas/CadastroReceita/index.js
+++ b/src/paginas/escolas/Receitas/CadastroReceita/index.js
@@ -5,7 +5,7 @@ import {Receita} from '../../../../componentes/escolas/Receitas';
 export const CadastroDeReceita = props => {
     return (
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Cadastro de Receita</h1>
+            <h1 className="titulo-itens-painel mt-5">Cadastro de Crédito</h1>
             <div className="page-content-inner ">
                 <h2 className="subtitulo-itens-painel">Dados do documento</h2>
                 <Receita {...props}/>


### PR DESCRIPTION
Esse PR Altera o lançamento de crédito para:
- Não exibir o botão deletar na edição de créditos de tipo repasse.
- Pedir confirmação ao incluir crédito de tipo repasse.
- Altera título do formulário de crédito para "Cadastro de Crédito".

História: [AB#47838](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/47838)