### PR TITLE
feat(45686):  Novo processo de devolução para acertos de PC: Parte 5 - Acompanhamento Prestação de Contas: Lista de PCs com filtro Devolvida para acertos

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/ListaPrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/ListaPrestacaoDeContas/index.js
@@ -69,6 +69,8 @@ export const ListaPrestacaoDeContas = () => {
                 setSelectedStatusPc(['NAO_RECEBIDA', 'NAO_APRESENTADA']);
             }else if(status_prestacao === 'APROVADA'){
                 setSelectedStatusPc(['APROVADA', 'APROVADA_RESSALVA']);
+            }else if(status_prestacao === 'DEVOLVIDA'){
+                setSelectedStatusPc(['DEVOLVIDA', 'DEVOLVIDA_RETORNADA', 'DEVOLVIDA_RECEBIDA']);
             }else {
                 setSelectedStatusPc([status_prestacao]);
             }


### PR DESCRIPTION
Esse PR: 

- Inclui status DEVOLVIDA_RETORNADA e DEVOLVIDA_RECEBIDA ao clicar no Card Devolvida para acertos

História: AB#45686