### PR TITLE
fix(50071) Resolução sistema nao apaga dados CPF

### DIFF
--- a/src/componentes/escolas/Associacao/Membros/index.js
+++ b/src/componentes/escolas/Associacao/Membros/index.js
@@ -506,7 +506,7 @@ export const MembrosDaAssociacao = () => {
                     'representacao': stateFormEditarMembro.representacao ? stateFormEditarMembro.representacao : "",
                     'codigo_identificacao': stateFormEditarMembro.codigo_identificacao ? stateFormEditarMembro.codigo_identificacao : "",
                     'email': stateFormEditarMembro.email ? stateFormEditarMembro.email : "",
-                    'cpf': stateFormEditarMembro.cpf ? stateFormEditarMembro.cpf : "",
+                    'cpf': "",
                     'usuario': usuario,
                     'telefone': stateFormEditarMembro.telefone ? stateFormEditarMembro.telefone : "",
                     'cep': stateFormEditarMembro.cep ? stateFormEditarMembro.cep : "",


### PR DESCRIPTION
fix(50071) Resolução sistema nao apaga dados CPF

Esse PR:

- Ao editar um membro (pai ou responsavel) para servidor, o CPF do membro(pai ou responsavel) será apagado

História: [AB#50071](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/50071)