### PR TITLE
feat(45693): Cria aviso de notificação de devolução de PC não vista

### DIFF
--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -1,0 +1,28 @@
+.barra-mensagem {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  background-color: black;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 24px;
+  color: #FFFFFF;
+  border-radius: 4px;
+  margin-top: 32px !important;
+}
+
+.btn-barra-mensagem{
+  border-color: #fff !important;
+  font-weight: 700 !important;
+  font-size: 14px !important;
+  line-height: 22px !important;
+  color: #FFFFFF !important;
+}
+
+.icone-alert-barra-mensagem{
+  color: #EAAA5E !important;
+  font-size: 28px;
+  font-weight: 900;
+  line-height: 18px;
+  align-items: center;
+  margin-top: 5px;
+}

--- a/src/componentes/Globais/BarraMensagem/index.js
+++ b/src/componentes/Globais/BarraMensagem/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+import "./barraMensagem.scss"
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+
+export const BarraDeMensagem = ({mensagem, textoBotao, handleClickBotao, icone}) => {
+    return (
+        <>
+            <div className="col-12 mt-3 barra-mensagem d-flex">
+                <div className='col-auto'>
+                    <FontAwesomeIcon className='icone-alert-barra-mensagem'
+                        icon={icone}
+                    />
+                </div>
+                <div className="flex-grow-1 bd-highlight align-self-center">
+                    <p className="mb-0">{mensagem}</p>
+                </div>
+                <div className="bd-highlight">
+                    <button
+                        onClick={() => handleClickBotao()}
+                        className="btn btn-outline-success btn-barra-mensagem">
+                        {textoBotao}
+                    </button>
+                </div>
+            </div>
+        </>
+    )
+};

--- a/src/componentes/Globais/Cabecalho/ModalNotificaDevolucao.js
+++ b/src/componentes/Globais/Cabecalho/ModalNotificaDevolucao.js
@@ -1,0 +1,19 @@
+import React from "react";
+import {ModalBootstrap} from "../../Globais/ModalBootstrap";
+
+export const ModalNotificaDevolucao = (props) =>{
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={props.handleClose}
+            titulo={props.titulo}
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.onVerAcertosDepois}
+            primeiroBotaoTexto="Ver depois"
+            primeiroBotaoCss="outline-success"
+            segundoBotaoOnclick={props.onVerAcertos}
+            segundoBotaoCss="success"
+            segundoBotaoTexto="Ver acertos"
+        />
+    )
+};

--- a/src/componentes/Globais/Cabecalho/index.js
+++ b/src/componentes/Globais/Cabecalho/index.js
@@ -2,15 +2,15 @@ import React, {useContext, useEffect, useState} from "react";
 import {useHistory } from "react-router-dom";
 import "./cabecalho.scss"
 import LogoPtrf from "../../../assets/img/logo-ptrf-verde.png"
-import IconeSair from "../../../assets/img/sair.svg"
-import IconeMenuMeuPerfil from "../../../assets/img/icone-menu-meu-perfil.png"
 import { authService, USUARIO_LOGIN } from '../../../services/auth.service';
 import {visoesService} from "../../../services/visoes.service";
 import {NotificacaoContext} from "../../../context/Notificacoes";
 import {CentralDeDownloadContext} from "../../../context/CentralDeDownloads"
 import {ModalConfirmaLogout} from "./ModalConfirmaLogout";
+import {ModalNotificaDevolucao} from "./ModalNotificaDevolucao";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faBell, faChevronDown, faTrash, faUser, faFileDownload} from "@fortawesome/free-solid-svg-icons";
+import {notificaDevolucaoPCService} from "../../../services/NotificacaDevolucaoPC.service";
 
 export const Cabecalho = () => {
 
@@ -52,10 +52,12 @@ export const Cabecalho = () => {
             obj.nome_associacao,
             obj.unidade_tipo,
             obj.unidade_nome,
+            obj.notificar_devolucao_referencia,
+            obj.notificacao_uuid,
         );
     };
 
-    const retornaVisaoConvertida = (visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome) =>{
+    const retornaVisaoConvertida = (visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome, notificar_devolucao_referencia, notificacao_uuid) =>{
         let visao_convertida = visoesService.converteNomeVisao(visao);
         let obj;
         if (visao === "DRE" || visao === "SME"){
@@ -66,6 +68,8 @@ export const Cabecalho = () => {
                 nome_associacao:nome_associacao,
                 unidade_tipo:unidade_tipo,
                 unidade_nome:unidade_nome,
+                notificar_devolucao_referencia:null,
+                notificacao_uuid:null,
             })
         }else {
             obj = JSON.stringify({
@@ -75,6 +79,8 @@ export const Cabecalho = () => {
                 nome_associacao:nome_associacao,
                 unidade_tipo:unidade_tipo,
                 unidade_nome:unidade_nome,
+                notificar_devolucao_referencia:notificar_devolucao_referencia,
+                notificacao_uuid:notificacao_uuid,
             })
         }
         return obj
@@ -113,6 +119,18 @@ export const Cabecalho = () => {
         window.location.assign('/central-de-notificacoes')
     };
 
+    const onVerAcertosDepois = async () => {
+        notificacaoContext.setExibeModalTemDevolucao(false)
+        notificacaoContext.setExibeMensagemFixaTemDevolucao(true)
+    };
+
+    const onVerAcertos = () => {
+        let periodoReferencia = localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")
+        notificacaoContext.setExibeModalTemDevolucao(false)
+        notificaDevolucaoPCService.marcaNotificacaoComoLida()
+        notificaDevolucaoPCService.redirectVerAcertos(periodoReferencia, history)
+    };
+
     return (
         <>
             {authService.isLoggedIn() &&
@@ -139,7 +157,9 @@ export const Cabecalho = () => {
                                                         dados_usuario_logado.associacao_selecionada.uuid,
                                                         dados_usuario_logado.associacao_selecionada.nome,
                                                         dados_usuario_logado.unidade_selecionada.tipo_unidade,
-                                                        dados_usuario_logado.unidade_selecionada.nome
+                                                        dados_usuario_logado.unidade_selecionada.nome,
+                                                        dados_usuario_logado.unidade_selecionada.notificar_devolucao_referencia,
+                                                        dados_usuario_logado.unidade_selecionada.notificacao_uuid,
                                                     )}
                                                 onChange={(e)=>onChangeVisao(e)}
                                                 className="form-control"
@@ -155,6 +175,8 @@ export const Cabecalho = () => {
                                                                 unidade.tipo_unidade === "DRE" || unidade.tipo_unidade === "SME" ? unidade.nome : unidade.associacao.nome,
                                                                 unidade.tipo_unidade,
                                                                 unidade.nome,
+                                                                unidade.notificar_devolucao_referencia,
+                                                                unidade.notificacao_uuid,
                                                             )}
                                                     >
                                                         {unidade.tipo_unidade} - {unidade.nome}
@@ -242,6 +264,16 @@ export const Cabecalho = () => {
                             texto="<p>Deseja ver as notificações ou sair do sistema</p>"
                         />
                     </section>
+                    <section>
+                        <ModalNotificaDevolucao
+                            show={notificacaoContext.exibeModalTemDevolucao}
+                            handleClose={onHandleClose}
+                            onVerAcertos={onVerAcertos}
+                            onVerAcertosDepois={onVerAcertosDepois}
+                            titulo="Atenção"
+                            texto={`<p>A prestação de contas ${dados_usuario_logado.unidade_selecionada.notificar_devolucao_referencia} foi devolvida para acertos pela DRE.</p>`}
+                        />
+                    </section>
                 </>
 
             }
@@ -249,4 +281,3 @@ export const Cabecalho = () => {
         </>
     );
 };
-

--- a/src/componentes/Globais/CentralDeNotificacoes/index.js
+++ b/src/componentes/Globais/CentralDeNotificacoes/index.js
@@ -3,7 +3,7 @@ import "./central-de-notificacoes.scss"
 import {BotoesCategoriasNotificacoes} from "./BotoesCategoriasNotificacoes";
 import {CardNotificacoes} from "./CardNotificacoes";
 import {FormFiltrosNotificacoes} from "./FormFiltrosNotificacoes";
-import {getNotificacoes, getNotificacoesLidasNaoLidas, getNotificacaoMarcarDesmarcarLida, getNotificacoesTabela, getNotificacoesFiltros, getNotificacoesPaginacao, getNotificacoesLidasNaoLidasPaginacao, getNotificacoesFiltrosPaginacao} from "../../../services/Notificacoes.service";
+import {getNotificacoes, getNotificacoesLidasNaoLidas, setNotificacaoMarcarDesmarcarLida, getNotificacoesTabela, getNotificacoesFiltros, getNotificacoesPaginacao, getNotificacoesLidasNaoLidasPaginacao, getNotificacoesFiltrosPaginacao} from "../../../services/Notificacoes.service";
 import Loading from "../../../utils/Loading";
 import {NotificacaoContext} from "../../../context/Notificacoes";
 import moment from "moment";
@@ -133,7 +133,7 @@ export const CentralDeNotificacoes = () => {
             "uuid": uuid,
             "lido": checado
         };
-        await getNotificacaoMarcarDesmarcarLida(payload);
+        await setNotificacaoMarcarDesmarcarLida(payload);
         await trazerNotificacoes();
     };
 

--- a/src/componentes/sme/Parametrizacoees/Estrutura/Periodos/index.js
+++ b/src/componentes/sme/Parametrizacoees/Estrutura/Periodos/index.js
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useMemo, useState} from "react";
 import {PaginasContainer} from "../../../../../paginas/PaginasContainer";
-import {getTodosPeriodos, getFiltrosPeriodos, getDatasAtendemRegras, getPeriodoPorUuid, postCriarPeriodo, patchUpdatePeriodo, deletePeriodo} from "../../../../../services/sme/Parametrizacoes.service";
+import {getTodosPeriodos, getPeriodoPorReferencia, getDatasAtendemRegras, getPeriodoPorUuid, postCriarPeriodo, patchUpdatePeriodo, deletePeriodo} from "../../../../../services/sme/Parametrizacoes.service";
 import TabelaPeriodos from "./TabelaPeriodos";
 import moment from "moment";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -46,7 +46,7 @@ export const Periodos = () =>{
 
     const handleSubmitFiltros = async () => {
         setLoading(true);
-        let periodos_filtrados = await getFiltrosPeriodos(stateFiltros.filtrar_por_referencia);
+        let periodos_filtrados = await getPeriodoPorReferencia(stateFiltros.filtrar_por_referencia);
         setListaDePeriodos(periodos_filtrados);
         setLoading(false);
     };

--- a/src/context/Notificacoes/index.js
+++ b/src/context/Notificacoes/index.js
@@ -4,12 +4,25 @@ import {getQuantidadeNaoLidas} from "../../services/Notificacoes.service";
 export const NotificacaoContext = createContext( {
     qtdeNotificacoesNaoLidas: '',
     setQtdeNotificacoesNaoLidas(){},
-
     getQtdeNotificacoesNaoLidas(){},
+
+    temNotificacaoDevolucaoNaoLida: '',
+    setTemNotificacaoDevolucaoNaoLida(){},
+
+    exibeModalTemDevolucao: false,
+    setExibeModalTemDevolucao(){},
+
+    exibeMensagemFixaTemDevolucao: false,
+    setExibeMensagemFixaTemDevolucao(){},
+
 });
 
 export const NotificacaoContextProvider = ({children}) => {
+
     const [qtdeNotificacoesNaoLidas, setQtdeNotificacoesNaoLidas] = useState(true);
+    const [temNotificacaoDevolucaoNaoLida, setTemNotificacaoDevolucaoNaoLida] = useState(true);
+    const [exibeModalTemDevolucao, setExibeModalTemDevolucao] = useState(localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA") !== 'null');
+    const [exibeMensagemFixaTemDevolucao, setExibeMensagemFixaTemDevolucao] = useState(false);
 
     const getQtdeNotificacoesNaoLidas = async () =>{
         let qtde = await getQuantidadeNaoLidas();
@@ -18,8 +31,16 @@ export const NotificacaoContextProvider = ({children}) => {
     };
 
     return (
-        <NotificacaoContext.Provider value={{ qtdeNotificacoesNaoLidas, setQtdeNotificacoesNaoLidas, getQtdeNotificacoesNaoLidas }}>
+        <NotificacaoContext.Provider value={
+            {
+                qtdeNotificacoesNaoLidas, setQtdeNotificacoesNaoLidas, getQtdeNotificacoesNaoLidas,
+                temNotificacaoDevolucaoNaoLida, setTemNotificacaoDevolucaoNaoLida,
+                exibeModalTemDevolucao, setExibeModalTemDevolucao,
+                exibeMensagemFixaTemDevolucao, setExibeMensagemFixaTemDevolucao
+            }
+        }>
             {children}
         </NotificacaoContext.Provider>
     )
 }
+

--- a/src/paginas/PaginasContainer.js
+++ b/src/paginas/PaginasContainer.js
@@ -1,11 +1,36 @@
 import React, {useContext} from "react";
 import {SidebarContext} from "../context/Sidebar";
+import {NotificacaoContext} from "../context/Notificacoes";
+import {BarraDeMensagem} from "../componentes/Globais/BarraMensagem"
+import {useHistory} from "react-router-dom";
+import {notificaDevolucaoPCService} from "../services/NotificacaDevolucaoPC.service";
+import {faExclamationCircle} from "@fortawesome/free-solid-svg-icons";
 
 export const PaginasContainer = ({children}) => {
+    const history = useHistory();
     const sidebarStatus = useContext(SidebarContext);
+    const notificacaoContext = useContext(NotificacaoContext);
+
+    const onVerAcertos = () => {
+        let periodoReferencia = localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")
+        notificacaoContext.setExibeMensagemFixaTemDevolucao(false)
+        notificaDevolucaoPCService.marcaNotificacaoComoLida()
+        notificaDevolucaoPCService.redirectVerAcertos(periodoReferencia, history)
+    };
+
     return (
-        <div className={`page-content  px-5 pt-0 pb-5 ${!sidebarStatus.sideBarStatus ? "active" : ""}`} id="content">
-            {children}
-        </div>
+        <>
+            <div className={`page-content  px-5 pt-0 pb-5 ${!sidebarStatus.sideBarStatus ? "active" : ""}`} id="content">
+                { notificacaoContext.exibeMensagemFixaTemDevolucao &&
+                    <BarraDeMensagem
+                        mensagem={`A prestação de contas ${localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")} foi devolvida para acertos pela DRE.`}
+                        textoBotao={'Ver acertos'}
+                        handleClickBotao={onVerAcertos}
+                        icone={faExclamationCircle}
+                    />
+                }
+                {children}
+            </div>
+        </>
     );
 }

--- a/src/services/NotificacaDevolucaoPC.service.js
+++ b/src/services/NotificacaDevolucaoPC.service.js
@@ -1,0 +1,45 @@
+import {visoesService} from "./visoes.service";
+import {setNotificacaoMarcarDesmarcarLida} from "./Notificacoes.service";
+import {getPeriodoPorReferencia} from "./sme/Parametrizacoes.service";
+
+const marcaNotificacaoComoLida = async () => {
+        let dados_usuario_logado = visoesService.getDadosDoUsuarioLogado();
+
+        let unidades_updated = []
+        dados_usuario_logado.unidades.forEach(unidade => {
+            if (unidade.uuid === dados_usuario_logado.unidade_selecionada.uuid) {
+                unidade.notificar_devolucao_referencia = null
+                unidade.notificacao_uuid = null
+            }
+            unidades_updated.push(unidade)
+        })
+        dados_usuario_logado.unidades = unidades_updated
+        visoesService.setDadosDoUsuarioLogado(dados_usuario_logado)
+        localStorage.removeItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")
+
+        await setNotificacaoMarcarDesmarcarLida({
+            uuid: dados_usuario_logado.unidade_selecionada.notificacao_uuid,
+            lido: true,
+        })
+    }
+
+const redirectVerAcertos = (periodoReferencia, history) => {
+    let path = `/consulta-detalhamento-analise-da-dre/676c71de-f5c3-44a2-91ed-c80a544c0153`;
+    getPeriodoPorReferencia(periodoReferencia).then(
+        (periodo) => {
+            let state = {
+                periodoFormatado: {
+                    referencia: periodo && periodo.length > 0 ? periodo[0].referencia : '',
+                    data_inicio_realizacao_despesas: periodo && periodo.length > 0 ? periodo[0].data_inicio_realizacao_despesas : '',
+                    data_fim_realizacao_despesas: periodo && periodo.length > 0 ? periodo[0].data_fim_realizacao_despesas : '',
+                }
+            }
+            history.push(path, state);
+        }
+    )
+};
+
+export const notificaDevolucaoPCService = {
+    marcaNotificacaoComoLida,
+    redirectVerAcertos
+};

--- a/src/services/Notificacoes.service.js
+++ b/src/services/Notificacoes.service.js
@@ -28,7 +28,7 @@ export const getNotificacoesLidasNaoLidasPaginacao = async (lidas, page) =>{
     return (await api.get(`/api/notificacoes/?lido=${lidas}&page=${page}`, authHeader)).data
 };
 
-export const getNotificacaoMarcarDesmarcarLida = async (payload) =>{
+export const setNotificacaoMarcarDesmarcarLida = async (payload) =>{
     return (await api.put(`/api/notificacoes/marcar-lido/`,payload, authHeader)).data
 };
 
@@ -43,3 +43,4 @@ export const getNotificacoesFiltros = async (tipo=null, remetente=null, categori
 export const getNotificacoesFiltrosPaginacao = async (tipo=null, remetente=null, categoria=null, lido=null, data_inicio=null, data_fim=null, page) =>{
     return (await api.get(`/api/notificacoes/?${tipo ? 'tipo=' + tipo : ""}${remetente ? '&remetente='+remetente: ""}${categoria ? '&categoria='+categoria : ""}${lido ? '&lido='+lido : ""}${data_inicio ? '&data_inicio='+data_inicio : ""}${data_fim ? '&data_fim='+data_fim : ""}&page=${page}`, authHeader)).data
 };
+

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -150,7 +150,7 @@ export const getContasAssociacao = async (associacao_uuid) => {
 export const getTodosPeriodos = async () => {
     return (await api.get(`/api/periodos/`, authHeader)).data
 };
-export const getFiltrosPeriodos = async (referencia) => {
+export const getPeriodoPorReferencia = async (referencia) => {
     return (await api.get(`/api/periodos/?referencia=${referencia}`, authHeader)).data
 };
 export const getDatasAtendemRegras = async (data_inicio_realizacao_despesas, data_fim_realizacao_despesas, periodo_anterior_uuid, periodo_uuid) => {

--- a/src/services/visoes.service.js
+++ b/src/services/visoes.service.js
@@ -1,4 +1,3 @@
-
 import {
     USUARIO_LOGIN,
     ASSOCIACAO_UUID,
@@ -42,9 +41,23 @@ const getDadosDoUsuarioLogado = () => {
     return dados_usuario_logado ? eval('dados_usuario_logado.usuario_' + getUsuarioLogin()) : null
 };
 
+const setDadosDoUsuarioLogado = (dados_usuario_logado) => {
+
+    let dados_usuario_logado_atual = localStorage.getItem(DADOS_USUARIO_LOGADO) ? JSON.parse(localStorage.getItem(DADOS_USUARIO_LOGADO)) : null;
+    let dados_usuario_logado_update = {
+        ...dados_usuario_logado_atual,
+        [`usuario_${getUsuarioLogin()}`]: {
+            ...dados_usuario_logado,
+        }
+    };
+    localStorage.setItem(DADOS_USUARIO_LOGADO, JSON.stringify(dados_usuario_logado_update));
+
+};
+
+
 const setDadosPrimeiroAcesso = async (resp) =>{
 
-    let visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome;
+    let visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome, notificar_devolucao_referencia, notificacao_uuid;
     let usuario_logado = getDadosDoUsuarioLogado();
 
     if (usuario_logado && usuario_logado.associacao_selecionada.uuid){
@@ -52,6 +65,17 @@ const setDadosPrimeiroAcesso = async (resp) =>{
         uuid_unidade = usuario_logado.unidade_selecionada.uuid;
         uuid_associacao = usuario_logado.associacao_selecionada.uuid;
         nome_associacao = usuario_logado.associacao_selecionada.nome;
+
+        // Atualiza as variáveis de informação sobre devolução de PC com as informações da lista de unidades.
+        let unidade_update = resp.unidades.find(unidade => unidade.uuid === uuid_unidade);
+        if (unidade_update) {
+            notificar_devolucao_referencia = unidade_update.notificar_devolucao_referencia;
+            notificacao_uuid = unidade_update.notificacao_uuid;
+        } else {
+            notificar_devolucao_referencia = usuario_logado.unidade_selecionada.notificar_devolucao_referencia;
+            notificacao_uuid = usuario_logado.unidade_selecionada.notificacao_uuid;
+        }
+
     }else {
         if (resp.visoes.find(visao=> visao === 'SME') && resp.unidades.find(unidade => unidade.tipo_unidade === "SME")){
             let unidade = resp.unidades.find(unidade => unidade.tipo_unidade === "SME");
@@ -59,18 +83,24 @@ const setDadosPrimeiroAcesso = async (resp) =>{
             uuid_unidade = unidade.uuid;
             uuid_associacao = unidade.uuid;
             nome_associacao = unidade.nome;
+            notificar_devolucao_referencia = null;
+            notificacao_uuid = null;
         }else if (resp.visoes.find(visao=> visao === 'DRE') && resp.unidades.find(unidade => unidade.tipo_unidade === "DRE")){
             let unidade = resp.unidades.find(unidade => unidade.tipo_unidade === "DRE");
             visao="DRE";
             uuid_unidade = unidade.uuid;
             uuid_associacao = unidade.uuid;
             nome_associacao = unidade.nome;
+            notificar_devolucao_referencia = null;
+            notificacao_uuid = null;
         }else if (resp.visoes.find(visao=> visao === 'UE')){
             let unidade = resp.unidades.find(unidade => unidade.tipo_unidade !== "DRE");
             visao="UE";
             uuid_unidade = unidade.uuid;
             uuid_associacao = unidade.associacao.uuid;
             nome_associacao = unidade.associacao.nome;
+            notificar_devolucao_referencia = unidade.notificar_devolucao_referencia;
+            notificacao_uuid = unidade.notificacao_uuid;
         }
     }
 
@@ -102,7 +132,7 @@ const setDadosPrimeiroAcesso = async (resp) =>{
             unidade_tipo = unidade.tipo_unidade;
         }
     }
-    alternaVisoes(visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome)
+    alternaVisoes(visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome, notificar_devolucao_referencia, notificacao_uuid)
 };
 
 const getPermissoes = (permissao) =>{
@@ -144,6 +174,9 @@ const setDadosUsuariosLogados = async (resp) => {
                 uuid: usuario_logado ? usuario_logado.unidade_selecionada.uuid : "",
                 tipo_unidade: usuario_logado ? usuario_logado.unidade_selecionada.tipo_unidade : "",
                 nome: usuario_logado ? usuario_logado.unidade_selecionada.nome : "",
+                notificar_devolucao_referencia: usuario_logado ? usuario_logado.unidade_selecionada.notificar_devolucao_referencia : "",
+                notificacao_uuid: usuario_logado ? usuario_logado.unidade_selecionada.notificacao_uuid : "",
+
             },
 
             associacao_selecionada: {
@@ -165,7 +198,7 @@ const converteNomeVisao = (visao) => {
     }
 };
 
-const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome) => {
+const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome, notificar_devolucao_referencia, notificacao_uuid) => {
 
     let todos_os_dados_usuario_logado = localStorage.getItem(DADOS_USUARIO_LOGADO) ? JSON.parse(localStorage.getItem(DADOS_USUARIO_LOGADO)) : null;
     let dados_usuario_logado = getDadosDoUsuarioLogado();
@@ -178,11 +211,12 @@ const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, un
                 visao_selecionada: {
                     nome: converteNomeVisao(visao)
                 },
-
                 unidade_selecionada: {
                     uuid: uuid_unidade,
                     tipo_unidade:unidade_tipo,
                     nome:unidade_nome,
+                    notificar_devolucao_referencia:notificar_devolucao_referencia,
+                    notificacao_uuid: notificacao_uuid,
                 },
 
                 associacao_selecionada: {
@@ -204,6 +238,9 @@ const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, un
         localStorage.removeItem('uuidPrestacaoConta');
         localStorage.removeItem('uuidAta');
         localStorage.removeItem('prestacao_de_contas_nao_apresentada');
+
+        localStorage.setItem("NOTIFICAR_DEVOLUCAO_REFERENCIA", notificar_devolucao_referencia)
+
         redirectVisao(visao)
     }
 };
@@ -244,6 +281,7 @@ export const visoesService = {
     converteNomeVisao,
     alternaVisoes,
     getDadosDoUsuarioLogado,
+    setDadosDoUsuarioLogado,
     redirectVisao,
     getItemUsuarioLogado,
 };


### PR DESCRIPTION
Esse PR cria notificações para usuário quando houver uma devolução de PC ainda
não vista. 

Inicialmente um modal é apresentado, onde o usuário pode
escolher entre ver os acertos solicitados imediatamente ou depois. Caso opte por ver depois uma mensagem fixa é apresentada em todas as páginas da visão UE até que veja as solicitações de ajustes.

História [AB#45693](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/45693)