### PR TITLE
feat(40174): Altera exibição motivo não regularidade se apenas leitura

### DIFF
--- a/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/NomeAssociacaoBotaoVoltar.js
+++ b/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/NomeAssociacaoBotaoVoltar.js
@@ -2,12 +2,14 @@ import React from "react";
 
 export const NomeAssociacaoBotaoVoltar = ({nomeAssociacao}) => {
     const path =  `/regularidade-associacoes`;
-
     return (
         <>
             <div className="d-flex bd-highlight">
                 <div className="p-2 flex-grow-1 bd-highlight">
-                    <h1 className="titulo-itens-painel mt-5">{nomeAssociacao}</h1>
+                    { nomeAssociacao  &&
+                        <h1 className="titulo-itens-painel mt-5">{nomeAssociacao}</h1>
+                    }
+
                 </div>
                 <div className="p-2 bd-highlight mt-5">
                     <button onClick={() => window.location.assign(path)} className="btn btn btn-outline-success">Voltar</button>

--- a/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/RegularidadeAssociacaoNoAno/MotivoNaoRegularidade.js
+++ b/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/RegularidadeAssociacaoNoAno/MotivoNaoRegularidade.js
@@ -1,6 +1,6 @@
 import React, {memo} from "react";
 
-const MotivoNaoRegularidade = ({exibeCampoMotivoNaoRegularidade, campoMotivoNaoRegularidade,setCampoMotivoNaoRegularidade}) => {
+const MotivoNaoRegularidade = ({exibeCampoMotivoNaoRegularidade, campoMotivoNaoRegularidade,setCampoMotivoNaoRegularidade, podeEditar}) => {
     return(
         <>
             {exibeCampoMotivoNaoRegularidade &&
@@ -12,8 +12,9 @@ const MotivoNaoRegularidade = ({exibeCampoMotivoNaoRegularidade, campoMotivoNaoR
                         className="form-control mt-2"
                         name='motivo-nao-regularidade'
                         id='motivo-nao-regularidade'
-                        placeholder='Se necessário, adicione o motivo da não regularidade...'
+                        placeholder={podeEditar ? 'Se necessário, adicione o motivo da não regularidade...' : ''}
                         maxLength='299'
+                        disabled={!podeEditar}
                     />
                 </div>
             }

--- a/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/RegularidadeAssociacaoNoAno/index.js
+++ b/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/RegularidadeAssociacaoNoAno/index.js
@@ -286,6 +286,7 @@ export const RegularidadeAssociacaoNoAno = ({associacaoUuid, ano, apenasLeitura=
                 exibeCampoMotivoNaoRegularidade={exibeCampoMotivoNaoRegularidade}
                 campoMotivoNaoRegularidade={campoMotivoNaoRegularidade}
                 setCampoMotivoNaoRegularidade={setCampoMotivoNaoRegularidade}
+                podeEditar={podeSalvar}
             />
 
             <div

--- a/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/index.js
+++ b/src/componentes/dres/RegularidadeAssociacoes/AnalisesRegularidade/index.js
@@ -23,7 +23,7 @@ export const AnalisesRegularidadeAssociacao = () => {
 
     return (
         <>
-            <NomeAssociacaoBotaoVoltar nomeAssociacao={`${associacao.nome}`}/>
+            <NomeAssociacaoBotaoVoltar nomeAssociacao={associacao ? associacao.nome : ""}/>
             <div className="page-content-inner">
                 <TabsAnaliseAnoVigenteHistorico associacaoUuid={associacao.uuid}/>
             </div>


### PR DESCRIPTION
Esse PR:
- Corrige a exibição de análise de regularidade na aba histórico para apenas exibir o campo motivo de não regularidade sem permitir edição.

- Corrige a exibição do nome da Associação para não exibir "undefined" enquanto carrega os dados.

História: [AB#40174](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/40174)
