### PR TITLE
feat(52005): Parametrização aplicações aceitas pela ação

### DIFF
--- a/src/componentes/Globais/ModalBootstrap/index.js
+++ b/src/componentes/Globais/ModalBootstrap/index.js
@@ -344,3 +344,28 @@ export const ModalFormParametrizacoesAcoes = (propriedades) =>{
         </Fragment>
     )
 };
+
+export const ModalBootstrapTipoRecursoNaoAceito = (propriedades) =>{
+    return (
+        <Fragment>
+            <Modal centered show={propriedades.show} onHide={propriedades.onHide}>
+                <Modal.Header>
+                    <Modal.Title>{propriedades.titulo}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {propriedades.bodyText}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant={propriedades.primeiroBotaoCss ? propriedades.primeiroBotaoCss : "primary"} onClick={propriedades.primeiroBotaoOnclick}>
+                        {propriedades.primeiroBotaoTexto}
+                    </Button>
+                    {propriedades.segundoBotaoOnclick && propriedades.segundoBotaoTexto ? (
+                        <Button variant={propriedades.segundoBotaoCss ? propriedades.segundoBotaoCss : "primary"} onClick={propriedades.segundoBotaoOnclick}>
+                            {propriedades.segundoBotaoTexto}
+                        </Button>
+                    ):null}
+                </Modal.Footer>
+            </Modal>
+        </Fragment>
+    )
+};

--- a/src/componentes/escolas/ValoresReprogramados/index.js
+++ b/src/componentes/escolas/ValoresReprogramados/index.js
@@ -172,6 +172,34 @@ export const ValoresReprogramados = () => {
         }
     };
 
+    const retornaClassificacaoReceita = (uuid_acao) => {
+        if(tabelas.categorias_receita !== undefined && tabelas.categorias_receita.length > 0 && uuid_acao){
+            return tabelas.categorias_receita.map((item, index) => {
+                return (
+                    <option
+                        style={{display: getDisplayOptionClassificacaoReceita(item.id, uuid_acao)}}
+                        key={item.id}
+                        value={item.id}
+                    >
+                        {item.nome}
+                    </option>
+                );
+            })
+        }
+    };
+
+    const getDisplayOptionClassificacaoReceita = (id_categoria_receita, uuid_acao) => {
+        let id_categoria_receita_lower = id_categoria_receita.toLowerCase();
+        let aceitaClassificacao  = eval('tabelas.acoes_associacao.find(element => element.uuid === uuid_acao).acao.aceita_' + id_categoria_receita_lower);
+
+        if(aceitaClassificacao){
+            return "block"
+        }
+        else{
+            return "none"
+        }
+    };
+
     return (
         <>
             {loading ? (
@@ -299,10 +327,7 @@ export const ValoresReprogramados = () => {
                                                                     className="form-control"
                                                                 >
                                                                     <option value="">Escolha o tipo de aplicação</option>
-                                                                    {tabelas.categorias_receita !== undefined && tabelas.categorias_receita.length > 0 ? (tabelas.categorias_receita.map((item, key) => (
-                                                                        <option key={key}
-                                                                                value={item.id}>{item.nome}</option>
-                                                                    ))) : null}
+                                                                    {retornaClassificacaoReceita(saldo.acao_associacao)}
                                                                 </select>
                                                                 {props.touched.aplicacao && props.errors.aplicacao &&
                                                                 <span

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { Fragment } from "react";
 import {
     ModalBootstrap,
     ModalBootstrapReverConciliacao,
     ModalBootstrapSaldoInsuficiente,
+    ModalBootstrapTipoRecursoNaoAceito,
     ModalBootstrapSaldoInsuficienteDaconta,
     ModalBootstrapFormMembros,
     ModalBootstrapFormMeusDadosSenha,
@@ -271,6 +272,49 @@ export const SaldoInsuficiente = (propriedades) => {
             primeiroBotaoTexto="OK"
             segundoBotaoOnclick={propriedades.handleClose}
             segundoBotaoTexto="Fechar"
+        />
+    )
+};
+
+export const TipoAplicacaoRecursoNaoAceito = (propriedades) => {
+    
+    const listaRecursosNaoAceito = () => {
+        return (
+            <>
+                {propriedades.mensagensAceitaCusteioCapital && propriedades.mensagensAceitaCusteioCapital.length > 0 && propriedades.mensagensAceitaCusteioCapital.map((item, index) =>
+                    <Fragment key={index}>
+                        <div key={`titulo-${index}`} className="row">
+                            <div className="col-12">
+                                <strong>Despesa {item.despesa}</strong>
+                            </div>
+                        </div>
+
+                        <div key={`mensagem-${index}`} className="row mt-2">
+                            <div className="col-12">
+                                {item.mensagem}
+                            </div>
+                        </div>
+
+                        <hr></hr>
+                    </Fragment>
+                )}
+            </>
+        )
+    }
+
+    
+    return (
+        <ModalBootstrapTipoRecursoNaoAceito
+            show={propriedades.show}
+            onHide={propriedades.handleClose}
+            titulo="Tipo de aplicação não aceito pela ação"
+            bodyText={listaRecursosNaoAceito()}
+            primeiroBotaoOnclick={propriedades.onSalvarTipoRecursoNaoAceito}
+            primeiroBotaoTexto="Sim"
+            primeiroBotaoCss="success"
+            segundoBotaoOnclick={propriedades.handleClose}
+            segundoBotaoTexto="Não"
+            segundoBotaoCss="outline-success"
         />
     )
 };


### PR DESCRIPTION
feat(52005): Parametrização aplicações aceitas pela ação

Esse PR:

- Refatora formulario de receitas, agora só é permitido uma aplicação que o tipo de receita e a ação permitem
- Refatora formulario de despesas, agora é exibido uma mensagem caso a aplicação selecionada não seja compativel com a ação
- Refatora formulario de valores reprogramados, agora só é permitido uma aplicação que a ação permita

História: [AB#52005](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/52005)