### PR TITLE
feat(52316): Não obrigar informação do CNPJ

### DIFF
--- a/src/componentes/dres/Diretoria/DadosDaDiretoria/index.js
+++ b/src/componentes/dres/Diretoria/DadosDaDiretoria/index.js
@@ -98,6 +98,15 @@ export const DadosDaDiretoria = () => {
     const onShowModalSalvar = () => {
         setShowModalDiretoriaSalvar(true);
     };
+
+    const valuesVazio = (values) => {
+        if(!values.dre_cnpj && !values.dre_diretor_regional_rf && !values.dre_diretor_regional_nome && !values.dre_designacao_portaria && !values.dre_designacao_ano){
+            return true
+        }
+        
+        return false;
+    }
+
     return (
         <>
             {loading ? (
@@ -225,7 +234,7 @@ export const DadosDaDiretoria = () => {
                                                 <button
                                                     type="submit"
                                                     className="btn btn-success mt-2 ml-2"
-                                                    disabled={!visoesService.getPermissoes(['change_dados_diretoria'])}
+                                                    disabled={!visoesService.getPermissoes(['change_dados_diretoria']) || valuesVazio(props.values)}
                                                 >
                                                     Salvar
                                                 </button>

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -46,6 +46,10 @@ export const YupSignupSchemaDreDadosDiretoria = yup.object().shape({
         if (value){
           return valida_cnpj(value)
         }
+        else{
+          // O campo CNPJ não é mais obrigatório
+          return true;
+        }
       }),
 });
 


### PR DESCRIPTION
feat(52316): Não obrigar informação do CNPJ

Esse PR:

- Remove CNPJ como campo obrigatório
- Cria condição que só libera o botão de salvar se algum campo estiver preenchido

História: [AB#52316](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/52316)