### PR TITLE
feat(55934): Altera form devolução ao tesouro na ata

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/ModalDevolucaoAoTesouro.js
+++ b/src/componentes/escolas/GeracaoDaAta/ModalDevolucaoAoTesouro.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {InformacoesDevolucaoAoTesouro} from "../../dres/PrestacaoDeContas/DetalhePrestacaoDeContas/InformacoesDevolucaoAoTesouro";
+import {InformacoesDevolucaoAoTesouro} from "./VisualizacaoDaAta/DevolucoesAoTesouro/InformacoesDevolucaoAoTesouro";
 import {ModalBootstrapDevolucaoAoTesouroAta} from "../../Globais/ModalBootstrap";
 
 export const ModalDevolucaoAoTesouro = ({show, handleClose, onSubmitModalDevolucoesAoTesouro, informacoesPrestacaoDeContas, initialValues, formRef, despesas, buscaDespesaPorFiltros, buscaDespesa, valorTemplate, despesasTabelas, tiposDevolucao, validateFormDevolucaoAoTesouro, camposObrigatorios}) => {

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/DevolucoesAoTesouro/InformacoesDevolucaoAoTesouro.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/DevolucoesAoTesouro/InformacoesDevolucaoAoTesouro.js
@@ -1,0 +1,126 @@
+import React from "react";
+import {Formik, FieldArray} from "formik";
+import {exibeDataPT_BR} from "../../../../../utils/ValidacoesAdicionaisFormularios";
+import {DatePickerField} from "../../../../Globais/DatePickerField";
+import {visoesService} from "../../../../../services/visoes.service";
+
+
+export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeContas, initialValues, despesas, validateFormDevolucaoAoTesouro}) =>{
+
+    const exibeDevolucoesAoTesouro = (index, despesas, valor_devolucao, data_devolucao, props, setDataDevolucaoValue) => {
+
+        if (despesas) {
+            /* eslint-disable-next-line no-eval */
+            let devolucao = eval('despesas.devolucao_' + index);
+            let despesa = devolucao[0]
+            return (
+                <>
+                    <table className="table table-bordered tabela-devolucoes-ao-tesouro">
+                        <thead>
+                        <tr>
+                            <th scope="col">Razão Social</th>
+                            <th scope="col">CNPJ ou CPF</th>
+                            <th scope="col">Tipo de Doc.</th>
+                            <th scope="col">Nº do Doc.</th>
+                            <th scope="col">Data Doc.</th>
+                            <th scope="col">Vr. Devolução</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr key="xxx">
+                            <td>{despesa.nome_fornecedor}</td>
+                            <td>{despesa.cpf_cnpj_fornecedor}</td>
+                            <td>{despesa.tipo_documento.nome}</td>
+                            <td>{despesa.numero_documento}</td>
+                            <td>{despesa.data_documento ? exibeDataPT_BR(despesa.data_documento) : ''}</td>
+                            <td>{valor_devolucao ? valor_devolucao : ''}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+                    <div className="row">
+                        <div
+                            className="col-12 col-sm-5 col-md-5 mt-2 pr-0 mr-xl-n3 mr-lg-n2">
+                            <label htmlFor="data">Insira a data de realização da devolução:</label>
+                        </div>
+                        <div className="col-12 col-sm-7 col-md-3 pl-0">
+                            <div className="form-group">
+                                <DatePickerField
+                                    name={`devolucoes_ao_tesouro_da_prestacao[${index}].data`}
+                                    value={data_devolucao}
+                                    placeholderText='dd/mm/aaaa'
+                                    onChange={setDataDevolucaoValue}
+                                    disabled={visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'DRE'}
+                                />
+                                {props.errors.data && <span className="text-danger mt-1">{props.errors.data}</span>}
+                            </div>
+                        </div>
+                    </div>
+                </>
+            )
+        }
+    };
+
+    return(
+        <>
+            {informacoesPrestacaoDeContas && informacoesPrestacaoDeContas.devolucao_ao_tesouro !== "Não" &&
+            <>
+                <Formik
+                    initialValues={initialValues}
+                    enableReinitialize={true}
+                    validateOnBlur={true}
+                    validate={validateFormDevolucaoAoTesouro}
+                    innerRef={formRef}
+                >
+                    {props => {
+                        const {
+                            values,
+                            setFieldValue,
+                        } = props;
+                        return (
+                            <form>
+                                <FieldArray
+                                    name="devolucoes_ao_tesouro_da_prestacao"
+                                    render={({remove, push}) => (
+                                        <>
+                                            {values.devolucoes_ao_tesouro_da_prestacao && values.devolucoes_ao_tesouro_da_prestacao.length > 0 && values.devolucoes_ao_tesouro_da_prestacao.map((devolucao, index) => {
+                                                return (
+                                                    <div className="row" key={index}>
+                                                        <div className={`col-12 mt-3`}>
+                                                            <p className="mb-0">
+                                                                <strong>Devolução {index + 1}</strong>
+                                                            </p>
+                                                            <hr className="mt-0 mb-1"/>
+                                                        </div>
+
+                                                        <div className='col-12 mt-3 mb-4'>
+                                                            <div className='col-12'>
+                                                                {/* eslint-disable-next-line no-eval */}
+                                                                {values.devolucoes_ao_tesouro_da_prestacao[index].despesa !== "" && despesas && eval('despesas.devolucao_'+index) && eval('despesas.devolucao_'+index).length > 0?
+                                                                exibeDevolucoesAoTesouro(index, despesas, devolucao.valor, devolucao.data, props, setFieldValue) : false}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                )
+                                            })}
+                                            {props.errors.campos_obrigatorios &&
+                                                <div className="row">
+                                                    <div className="col-12 mt-2">
+                                                        <span className="text-danger"> <strong>{props.errors.campos_obrigatorios}</strong></span>
+                                                    </div>
+                                                </div>
+                                            }
+                                        </>
+                                    )}
+                                >
+                                </FieldArray>
+                            </form>
+                        )
+                    }}
+                </Formik>
+            </>
+            }
+        </>
+    )
+};

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TopoComBotoes/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TopoComBotoes/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {visoesService} from "../../../../../services/visoes.service";
 
-export const TopoComBotoes = ({dadosAta, prestacaoDeContasDetalhe, handleClickEditarAta, handleClickFecharAta, handleClickCopiarAta, setShowModalDevolucoesAoTesouro}) =>{
+export const TopoComBotoes = ({dadosAta, prestacaoDeContasDetalhe, handleClickEditarAta, handleClickFecharAta, handleClickCopiarAta, setShowModalDevolucoesAoTesouro, exibeBotaoDevolucaoTesouro}) =>{
     const podeEditarAta = [['change_ata_prestacao_contas']].some(visoesService.getPermissoes)
     return(
         <div className="row">
@@ -12,7 +12,7 @@ export const TopoComBotoes = ({dadosAta, prestacaoDeContasDetalhe, handleClickEd
             <div className='col-12 col-md-7 text-right'>
                 { prestacaoDeContasDetalhe && prestacaoDeContasDetalhe.status && (prestacaoDeContasDetalhe.status === 'DEVOLVIDA' || prestacaoDeContasDetalhe.status === 'DEVOLVIDA_RETORNADA') && dadosAta && dadosAta.uuid && dadosAta.tipo_ata === 'RETIFICACAO' ?
                     <>
-                        {podeEditarAta &&
+                        {podeEditarAta && exibeBotaoDevolucaoTesouro &&
                             <button onClick={()=>setShowModalDevolucoesAoTesouro(true)} type="button" className="btn btn-success mr-2 mt-2"> <strong>Devoluções ao Tesouro</strong></button>
                         }
 

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
@@ -400,6 +400,12 @@ export const VisualizacaoDaAta = () => {
     };
     // FIM InformacoesDvolucaoAoTesrouro
 
+    const temDevolucaoAoTesouro = (
+        prestacaoDeContasDetalhe &&
+        prestacaoDeContasDetalhe.devolucoes_ao_tesouro_da_prestacao &&
+        prestacaoDeContasDetalhe.devolucoes_ao_tesouro_da_prestacao.length > 0
+    )
+
     return (
         <div className="col-12 container-visualizacao-da-ata mb-5">
             <div className="col-12 mt-4">
@@ -411,6 +417,7 @@ export const VisualizacaoDaAta = () => {
                         handleClickFecharAta={handleClickFecharAta}
                         handleClickCopiarAta={handleClickCopiarAta}
                         setShowModalDevolucoesAoTesouro={setShowModalDevolucoesAoTesouro}
+                        exibeBotaoDevolucaoTesouro={temDevolucaoAoTesouro}
                     />
                 }
             </div>


### PR DESCRIPTION
Esse PR altera o formulário de devolução ao tesouro na ata de retificação para:
- Não ser possível adicionar devoluções ao tesouro.
- Não ser possível editar uma devolução ao tesouro.
- Não ser possível excluir uma devolução ao tesouro.
- Ser possível atualizar a data de realização de uma devolução ao tesouro.
- Remover área de busca por despesas (botão "filtrar").
- Atender novo layout proposto no protótipo. 
- Exibir o botão "Devoluções ao Tesouro" na ata de retificação apenas se houver devoluções ao tesouro. 

História: [AB#55934](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55934)