### PR TITLE
feat(52133): Remove da ata função copiar

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TopoComBotoes/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TopoComBotoes/index.js
@@ -44,12 +44,6 @@ export const TopoComBotoes = ({dadosAta, prestacaoDeContasDetalhe, handleClickEd
                 <button onClick={handleClickCopiarAta} type="button" className="btn btn-outline-success mr-2 mt-2"><strong>Selecionar e copiar</strong></button>
                 }
 
-                {/*Para as atas de retificação*/}
-                {/*Se o status da PC é DEVOLVIDA trata-se de uma prévia e não exibe o selecionar e copiar*/}
-                {dadosAta && dadosAta.tipo_ata === 'RETIFICACAO' && prestacaoDeContasDetalhe && prestacaoDeContasDetalhe.status && prestacaoDeContasDetalhe.status !== 'DEVOLVIDA' &&
-                <button onClick={handleClickCopiarAta} type="button" className="btn btn-outline-success mr-2 mt-2"><strong>Selecionar e copiar</strong></button>
-                }
-
                 <button onClick={handleClickFecharAta} type="button" className="btn btn-outline-success mt-2"><strong>Fechar</strong></button>
             </div>
         </div>


### PR DESCRIPTION
Esse PR remove o botão de copiar na ata em tela.

História: [AB#52133](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/52133)