### PR TITLE
feat(55188): Altera ata de retificação texto e formulário

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/FormularioEditaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/FormularioEditaAta/index.js
@@ -200,7 +200,6 @@ export const FormularioEditaAta = ({
             return "Cargo (opcional)"
         }
     }
-    
     return (
 
         <div>
@@ -498,6 +497,30 @@ export const FormularioEditaAta = ({
                                         >
                                             
                                         </FieldArray>
+
+                                        {/*So exibe o campo retificações em atas de retificação*/}
+                                        { stateFormEditarAta && stateFormEditarAta.tipo_ata === 'RETIFICACAO' &&
+                                            <div>
+                                                <p className="titulo mt-4"><strong>Retificações</strong></p>
+                                                <div className="form-row">
+                                                    <div className="col-12">
+                                                        <label htmlFor="stateFormEditarAta.retificacoes"
+                                                               className="mb-0">Utilize
+                                                            esse campo para registrar as retificações da Prestação
+                                                            de Contas.</label>
+                                                        <textarea
+                                                            rows="3"
+                                                            placeholder="Escreva seu texto aqui"
+                                                            value={values.stateFormEditarAta.retificacoes}
+                                                            onChange={props.handleChange}
+                                                            name="stateFormEditarAta.retificacoes"
+                                                            className="form-control mt-2"
+                                                            disabled={!podeEditarAta}
+                                                        />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        }
 
                                         <p className="titulo mt-4"><strong>Manifestações, Comentários e Justificativas</strong></p>
                                         <div className="form-row">

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
@@ -90,6 +90,7 @@ export const EdicaoAta = () => {
             cargo_secretaria_reuniao: dados_ata.cargo_secretaria_reuniao,
             retificacoes: dados_ata.retificacoes,
             hora_reuniao: dados_ata.hora_reuniao,
+            tipo_ata: dados_ata.tipo_ata
         });
         setDadosAta(dados_ata);
     };

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TextoDinamicoSuperior/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TextoDinamicoSuperior/index.js
@@ -3,10 +3,28 @@ import React from "react";
 export const TextoDinamicoSuperior = ({dadosAta, retornaDadosAtaFormatado, prestacaoDeContasDetalhe}) => {
     let primeiro_paragrafo = `ATA DA REUNIÃO ${retornaDadosAtaFormatado("tipo_reuniao")} DA Associação ${dadosAta.associacao.nome ? dadosAta.associacao.nome : "___"} DO(A) Unidade Educacional ${dadosAta.associacao.unidade.nome ? dadosAta.associacao.unidade.nome : "___"}`.toUpperCase();
     const textoAlertaPrevia = 'Atenção! Essa é apenas uma prévia da ata. As informações aqui exibidas podem mudar até a conclusão da prestação de contas. A ata final só poderá ser criada após a conclusão do período.'
+
+    let textoPauta = ''
+    let textoObjeto = ''
+    if (dadosAta.tipo_ata === 'RETIFICACAO') {
+        textoPauta = ` Retificação da Prestação de Contas do PTRF e suas ações agregadas, 
+        do período de ${retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a 
+        ${retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")}, 
+        referente ao ${retornaDadosAtaFormatado("periodo.referencia")}.`
+
+        textoObjeto = 'as alterações realizadas, conforme solicitado pela DRE, resultando nos dados consolidados'
+    } else {
+        textoPauta = ` Apresentação ao Conselho Fiscal da prestação de contas da verba do PTRF e suas ações agregadas, 
+        do período de ${retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a 
+        ${retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")}, 
+        referente ao ${retornaDadosAtaFormatado("periodo.referencia")}.`
+
+        textoObjeto = 'os documentos fiscais referentes às despesas realizadas no período para análise dos presentes'
+    }
     return(
         <>
             {/*Para as atas de apresentação (Não retificação)*/}
-            {/*Se não tem Prestação de Conta trata-se de uma prévia e exibe o texto de alertar*/}
+            {/*Se não tem Prestação de Conta trata-se de uma prévia e exibe o texto de alerta*/}
             {dadosAta && dadosAta.tipo_ata !== 'RETIFICACAO' && !dadosAta.prestacao_conta &&
             <p>
                 <strong>{textoAlertaPrevia}</strong>
@@ -14,7 +32,7 @@ export const TextoDinamicoSuperior = ({dadosAta, retornaDadosAtaFormatado, prest
             }
 
             {/*Para as atas de retificação*/}
-            {/*Se o status da PC é DEVOLVIDA trata-se de uma prévia e não exibe o selecionar e copiar*/}
+            {/*Se o status da PC é DEVOLVIDA trata-se de uma prévia e exibe texto de alerta*/}
             {dadosAta && dadosAta.tipo_ata === 'RETIFICACAO' && prestacaoDeContasDetalhe && prestacaoDeContasDetalhe.status && prestacaoDeContasDetalhe.status === 'DEVOLVIDA' &&
             <p>
                 <strong>{textoAlertaPrevia}</strong>
@@ -25,8 +43,15 @@ export const TextoDinamicoSuperior = ({dadosAta, retornaDadosAtaFormatado, prest
                 {primeiro_paragrafo}
             </p>
             <p>
-                {retornaDadosAtaFormatado("data_reuniao")},  no(a) {dadosAta.local_reuniao ? dadosAta.local_reuniao : "___"}, {dadosAta.associacao.unidade.tipo_unidade ? dadosAta.associacao.unidade.tipo_unidade : "___"} {dadosAta.associacao.unidade.nome ? dadosAta.associacao.unidade.nome : "___"}, com início às {dadosAta.hora_reuniao}, reuniram-se os membros da {dadosAta.associacao.nome ? dadosAta.associacao.nome : "___"} para tratar da seguinte pauta: Apresentação ao Conselho Fiscal da prestação de contas da verba do PTRF
-                e suas ações agregadas, do período de {retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a {retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")}, referente ao {retornaDadosAtaFormatado("periodo.referencia")}. Aberta a reunião em {retornaDadosAtaFormatado("convocacao")}, pelo(a) Senhor(a) {dadosAta.presidente_reuniao ? dadosAta.presidente_reuniao : "___"}, {dadosAta.cargo_presidente_reuniao ? dadosAta.cargo_presidente_reuniao : "___"} e verificada a existência de número legal de membros presentes, o(a) senhor(a) {dadosAta.presidente_reuniao ? dadosAta.presidente_reuniao : "___"} apresentou os documentos fiscais referentes às despesas realizadas no período para análise dos presentes, conforme segue:
+                {retornaDadosAtaFormatado("data_reuniao")},
+                no(a) {dadosAta.local_reuniao ? dadosAta.local_reuniao : "___"}, {dadosAta.associacao.unidade.tipo_unidade ? dadosAta.associacao.unidade.tipo_unidade : "___"} {dadosAta.associacao.unidade.nome ? dadosAta.associacao.unidade.nome : "___"},
+                com início às {dadosAta.hora_reuniao}, reuniram-se os membros
+                da {dadosAta.associacao.nome ? dadosAta.associacao.nome : "___"} para tratar da seguinte pauta:
+                {textoPauta} Aberta a reunião
+                em {retornaDadosAtaFormatado("convocacao")}, pelo(a)
+                Senhor(a) {dadosAta.presidente_reuniao ? dadosAta.presidente_reuniao : "___"}, {dadosAta.cargo_presidente_reuniao ? dadosAta.cargo_presidente_reuniao : "___"} e
+                verificada a existência de número legal de membros presentes, o(a)
+                senhor(a) {dadosAta.presidente_reuniao ? dadosAta.presidente_reuniao : "___"} apresentou {textoObjeto}, conforme segue:
             </p>
         </>
     )

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
@@ -451,8 +451,14 @@ export const VisualizacaoDaAta = () => {
 
                 {dadosAta && Object.entries(dadosAta).length > 0 && dadosAta.tipo_ata === 'RETIFICACAO' &&
                     <>
-                        <p className='mt-3'><strong>Retificações:</strong></p>
-                        <p>{stateFormEditarAta.retificacoes}</p>
+                        {/*So exibe as retificações se houver*/}
+                        { stateFormEditarAta && stateFormEditarAta.retificacoes &&
+                            <div>
+                                <p className='mt-3'><strong>Retificações:</strong></p>
+                                <p>{stateFormEditarAta.retificacoes}</p>
+                            </div>
+                        }
+
                         {exibeDevolucoesAoTesouro()}
                     </>
                 }


### PR DESCRIPTION
Esse PR:
- Altera textos da ata para variarem conforme seu tipo, apresentação ou retificação
- inclui o campo retificações no formulário quando for uma ata de retificação

História: [AB#55188](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/55188)