### PR TITLE
feat(56099): Altera quadro de saldos de conciliação

### DIFF
--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/TabelaValoresPendentesPorAcao/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/TabelaValoresPendentesPorAcao/index.js
@@ -2,7 +2,6 @@ import React, {memo} from "react";
 import "./styles.css";
 
 const TabelaValoresPendentesPorAcao = ({valoresPendentes, valorTemplate}) =>{
-
     return(
         <>
             <p className="detalhe-das-prestacoes-titulo-lancamentos">Quadro resumo</p>
@@ -19,8 +18,8 @@ const TabelaValoresPendentesPorAcao = ({valoresPendentes, valorTemplate}) =>{
                 <tr>
                     <th scope="row">Saldo reprogramado anterior</th>
                     <td>{valorTemplate(valoresPendentes.saldo_anterior)}</td>
-                    <td className='coluna-cinza-escuro'>{valorTemplate(valoresPendentes.saldo_anterior)}</td>
-                    <td className='coluna-cinza-escuro'> </td>
+                    <td className='coluna-cinza-escuro'>{valorTemplate(valoresPendentes.saldo_anterior_conciliado)}</td>
+                    <td className='coluna-cinza-escuro'>{valorTemplate(valoresPendentes.saldo_anterior_nao_conciliado)}</td>
                 </tr>
                 <tr>
                     <th scope="row">Créditos</th>


### PR DESCRIPTION
Esse PR:
- Altera o quadro de saldos de conciliação para exibir os saldos conciliados e a conciliar na linha de saldo anterior.

História: [AB#56099](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/56099)