### PR TITLE
feat(59984): Créditos da Escola: Exibir a tabela de gasto estornado também no formulário de inclusão do estorno

### DIFF
--- a/src/componentes/escolas/Receitas/ReferenciaDaDespesaEstorno/index.js
+++ b/src/componentes/escolas/Receitas/ReferenciaDaDespesaEstorno/index.js
@@ -45,18 +45,26 @@ const ReferenciaDaDespesaEstorno = ({uuid, rateioEstorno, despesa}) => {
     }
 
     const valorTotalTemplate = () => {
-
-        return parseFloat(rateioEstorno.valor_rateio) ? parseFloat(rateioEstorno.valor_rateio).toLocaleString('pt-BR', {
+        if (uuid) {
+            return parseFloat(rateioEstorno.valor_rateio) ? parseFloat(rateioEstorno.valor_rateio).toLocaleString('pt-BR', {
                 style: 'currency',
                 currency: 'BRL'
             })
             :
             '';
+        } else {
+            return parseFloat(rateioEstorno.valor_total) ? parseFloat(rateioEstorno.valor_total).toLocaleString('pt-BR', {
+                style: 'currency',
+                currency: 'BRL'
+            })
+            :
+            '';
+        }
     }
 
     return (
         <>
-            {uuid && despesa && despesa.uuid &&
+            {despesa && despesa.uuid &&
                 <>
                     <p><strong>Referência da Despesa</strong></p>
 


### PR DESCRIPTION
Esse PR:

- Exibe tabela de estorno na inclusão da receita correspondente ao estorno

História: [AB#59984](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/59984)