### PR TITLE
feat(61291): Parametrizar tipos de documento que serão exibidos no select de docs comprobatórios de despesas - Parte 02

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -225,13 +225,8 @@ export const CadastroFormFormik = ({
                                             disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes) || !eh_despesa_com_comprovacao_fiscal(props.values)}
                                         >
                                             <option value="">Selecione o tipo</option>
-                                            {props.values.uuid ? (
-                                                despesasTabelas && despesasTabelas.tipos_documento && despesasTabelas.tipos_documento.length > 0 && despesasTabelas.tipos_documento.map(item =>
-                                                    <option disabled={!item.documento_comprobatorio_de_despesa} key={item.id} value={item.id}>{item.nome}</option>
-                                                )
-                                            ):
-                                                despesasTabelas && despesasTabelas.tipos_documento && despesasTabelas.tipos_documento.length > 0 && despesasTabelas.tipos_documento.filter(element => element.documento_comprobatorio_de_despesa).map(item =>
-                                                <option key={item.id} value={item.id}>{item.nome}</option>
+                                            {despesasTabelas && despesasTabelas.tipos_documento && despesasTabelas.tipos_documento.length > 0 && despesasTabelas.tipos_documento.map(item =>
+                                                <option className={!item.documento_comprobatorio_de_despesa ? 'esconde-especificacao-material-servico' : ''} key={item.id} value={item.id}>{item.nome}</option>
                                             )}
                                         </select>
                                     </div>


### PR DESCRIPTION
Esse PR: 

- Corrige exibição ou não de tipos de documento de acordo com parâmetro documento_comprobatorio_de_despesa

História: [AB#61291](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/61291)