### PR TITLE
feat(61290): Cadastro de mais de um imposto

### DIFF
--- a/src/componentes/Globais/DatePickerField/index.js
+++ b/src/componentes/Globais/DatePickerField/index.js
@@ -9,7 +9,7 @@ import moment from "moment";
 registerLocale("pt", pt );
 
 
-export const DatePickerField = ({ name, about, value, className="form-control", onChange, onCalendarOpen, onCalendarClose, disabled, placeholderText, maxDate=null, wrapperClassName=null }) => {
+export const DatePickerField = ({ name, about, value, className="form-control", onChange, onCalendarOpen, onCalendarClose, disabled, placeholderText, maxDate=null, wrapperClassName=null, minDate=null }) => {
 
     return (
         <DatePicker
@@ -27,6 +27,7 @@ export const DatePickerField = ({ name, about, value, className="form-control", 
             className = {className}
             placeholderText={placeholderText}
             maxDate={maxDate}
+            minDate={minDate}
             wrapperClassName={wrapperClassName}
             customInput={
                 <MaskedInput

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormDespesaImposto.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormDespesaImposto.js
@@ -3,6 +3,8 @@ import { DatePickerField } from "../../../Globais/DatePickerField";
 import CurrencyInput from "react-currency-input";
 import { visoesService } from "../../../../services/visoes.service";
 import { trataNumericos } from "../../../../utils/ValidacoesAdicionaisFormularios";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTimesCircle} from "@fortawesome/free-solid-svg-icons";
 
 export const CadastroFormDespesaImposto = ({
 												formikProps, 
@@ -18,82 +20,69 @@ export const CadastroFormDespesaImposto = ({
 												labelDocumentoTransacaoImposto,
 												setCssEscondeDocumentoTransacaoImposto,
 												setLabelDocumentoTransacaoImposto,
-												setFormErrors,
-												validacoesPersonalizadas,
-												formErrors,
 												despesaContext,
 												acoes_custeio,
 												setValorRateioRealizadoImposto,
 												readOnlyCamposImposto,
-												mostraModalExcluirImposto
+												index,
+												despesa_imposto,
+												remove,
+												formErrorsImposto,
+												onCalendarCloseDataPagamentoImposto
 											}) => {
     
 	return(
 		<>
-        <div className="container-retencao-imposto mt-2">
-            <div className="form-row align-items-center box-escolha-retencao-imposto">
-                <div className="col-auto">
-                    <p className='mb-0 mr-4 font-weight-normal'>Este serviço teve/terá retenção de imposto por parte da Associação?</p>
-                </div>
-                <div className="col-auto">
-                    <div className="form-check form-check-inline">
-                        <input
-                            name="retem_imposto"
-                            onChange={(e) => {
-                                formikProps.handleChange(e);
-                                formikProps.setFieldValue("retem_imposto", true)
-                            }}
-                            onBlur={formikProps.handleBlur}
-                            className={`form-check-input`}
-                            type="radio"
-                            id="retem_imposto_sim"
-                            disabled={disabled}
-                            checked={eh_despesa_com_retencao_imposto(formikProps.values)}
-                            value={eh_despesa_com_retencao_imposto(formikProps.values)}
-                        />
-                        <label className="form-check-label" htmlFor="retem_imposto_sim">Sim</label>
-                    </div>
-
-                    <div className="form-check form-check-inline">
-                        <input
-                            name="retem_imposto"
-                            onChange={(e) => {
-                                formikProps.handleChange(e);
-                                formikProps.setFieldValue("retem_imposto", false)
-								mostraModalExcluirImposto();
-                            }}
-                            onBlur={formikProps.handleBlur}
-                            className={`form-check-input`}
-                            type="radio"
-                            id="retem_imposto_nao"
-                            disabled={disabled}
-                            checked={!eh_despesa_com_retencao_imposto(formikProps.values)}
-                            value={!eh_despesa_com_retencao_imposto(formikProps.values)}
-                        />
-                        <label className="form-check-label" htmlFor="retem_imposto_nao">Não</label>
-                    </div>
-                </div>
-            </div>
-		
-		
+		<div key={index}>
             {eh_despesa_com_retencao_imposto(formikProps.values) &&
 				<div className="form-retencao-imposto">
-					<p><strong>Dados do imposto retido</strong></p>
+
+					<div className="d-flex bd-highlight border-bottom mt-2 mb-2 align-items-center">
+						<div className="flex-grow-1 bd-highlight">
+							<p className='mb-0'>
+								<strong>Imposto retido {index + 1}</strong>
+							</p>
+						</div>
+						
+						<div className="bd-highlight">
+							<div className="d-flex justify-content-start">
+								{index >= 1 && (
+									<button
+										type="button"
+										className="btn btn-link btn-remover-despesa mr-2 d-flex align-items-center"
+										onClick={() => remove(index)}
+										disabled={!visoesService.getPermissoes(['delete_despesa'])}
+									>
+										<FontAwesomeIcon
+											style={{
+												fontSize: '17px',
+												marginRight: "4px",
+												color: "#B40C02"
+											}}
+											icon={faTimesCircle}
+										/>
+										Remover Imposto
+									</button>
+								)}
+							</div>
+						</div>
+					</div>
+
 					<div className="form-row">
 						<div className="col-12 col-md-4 mt-1">
-							<label htmlFor="despesa_imposto.tipo_documento">Tipo de documento</label>
+							<label htmlFor={`tipo_documento_${index}`}>Tipo de documento</label>
 							<select
 								value={
-									formikProps.values.despesa_imposto && formikProps.values.despesa_imposto.tipo_documento !== null ? (
-										formikProps.values.despesa_imposto.tipo_documento === "object" ? formikProps.values.despesa_imposto.tipo_documento.id : formikProps.values.despesa_imposto.tipo_documento
+									despesa_imposto && despesa_imposto.tipo_documento !== null ? (
+										despesa_imposto.tipo_documento === "object" ? despesa_imposto.tipo_documento.id : despesa_imposto.tipo_documento
 									) : ""
 								}
 								onChange={formikProps.handleChange}
 								onBlur={formikProps.handleBlur}
-								name='despesa_imposto.tipo_documento'
-								id='despesa_imposto.tipo_documento'
+								name={`despesas_impostos[${index}].tipo_documento`}
+								id={`tipo_documento_${index}`}
 								className="form-control"
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							>
 								<option key={0} value="">Selecione o tipo</option>
 								{tipos_documento_com_recolhimento_imposto().map(item =>
@@ -103,67 +92,69 @@ export const CadastroFormDespesaImposto = ({
 						</div>
 
 						<div className="col-12 col-md-4 mt-1">
-							<label htmlFor="despesa_imposto.numero_documento">Número do documento</label>
+							<label htmlFor={`numero_documento_${index}`}>Número do documento</label>
 							<input
 								value={
-									formikProps.values.despesa_imposto && formikProps.values.despesa_imposto.numero_documento !== null ? (
-										formikProps.values.despesa_imposto.numero_documento
+									despesa_imposto && despesa_imposto.numero_documento !== null ? (
+										despesa_imposto.numero_documento
 									) : ""
 								}
 								onChange={(e) => {
-									aux.onHandleChangeApenasNumero(e, formikProps.setFieldValue, "despesa_imposto.numero_documento");
+									aux.onHandleChangeApenasNumero(e, formikProps.setFieldValue, `despesas_impostos[${index}].numero_documento`);
 								}}
 								onBlur={formikProps.handleBlur}
-								name="despesa_imposto.numero_documento"
-								id="despesa_imposto.numero_documento" type="text"
+								name={`despesas_impostos[${index}].numero_documento`}
+								id={`numero_documento_${index}`} type="text"
 								className="form-control"
-								placeholder={numeroDocumentoImpostoReadOnly ? "" : "Digite o número"}
-								disabled={readOnlyCamposImposto || numeroDocumentoImpostoReadOnly || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								placeholder={numeroDocumentoImpostoReadOnly(despesa_imposto.tipo_documento, index, formikProps.values) ? "" : "Digite o número"}
+								disabled={readOnlyCamposImposto[index] || numeroDocumentoImpostoReadOnly(despesa_imposto.tipo_documento, index, formikProps.values) || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							/>
 						</div>
 
 						<div className="col-12 col-md-4 mt-1">
 							
-							<label htmlFor={`despesa_imposto.rateios[0].tipo_custeio`}>Tipo de despesa</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].tipo_custeio`}>Tipo de despesa</label>
 							<select
-								value={preenche_tipo_despesa_custeio().id}
+								value={preenche_tipo_despesa_custeio(formikProps.values, index)}
 								onChange={(e) => {
 									formikProps.handleChange(e);
 								}}
 								onBlur={formikProps.handleBlur}	
-								name={"despesa_imposto.rateios[0].tipo_custeio"}
-								id={"despesa_imposto.rateios[0].tipo_custeio"}
+								name={`despesas_impostos[${index}].rateios[0].tipo_custeio`}
+								id={`despesas_impostos[${index}].rateios[0].tipo_custeio`}
 								className={"form-control retira-dropdown-select"}
 								readOnly={true}
 								disabled={true}
 							>
-								<option key={preenche_tipo_despesa_custeio().id} value={preenche_tipo_despesa_custeio().id}>{preenche_tipo_despesa_custeio().nome}</option>
+								<option key={preenche_tipo_despesa_custeio(formikProps.values, index).id} value={preenche_tipo_despesa_custeio(formikProps.values, index).id}>{preenche_tipo_despesa_custeio(formikProps.values, index).nome}</option>
 							</select>
 						</div>
 					</div>
 
 					<div className="form-row">
 						<div className="col-12 mt-4">
-							<label htmlFor={`despesa_imposto.rateios[0].especificacao_material_servico`}>Especificação do imposto</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].especificacao_material_servico`}>Especificação do imposto</label>
 							<select
 								value={
-									formikProps.values.despesa_imposto && formikProps.values.despesa_imposto.rateios[0].especificacao_material_servico !== null ? (
-										typeof formikProps.values.despesa_imposto.rateios[0].especificacao_material_servico === "object" ? formikProps.values.despesa_imposto.rateios[0].especificacao_material_servico.id : formikProps.values.despesa_imposto.rateios[0].especificacao_material_servico
+									despesa_imposto && despesa_imposto.rateios[0].especificacao_material_servico !== null ? (
+										typeof despesa_imposto.rateios[0].especificacao_material_servico === "object" ? despesa_imposto.rateios[0].especificacao_material_servico.id : despesa_imposto.rateios[0].especificacao_material_servico
 									) : ""
 								}
-								onChange={formikProps.handleChange}
-								name={"despesa_imposto.rateios[0].especificacao_material_servico"}
-								id={"despesa_imposto.rateios[0].especificacao_material_servico"}
+								onChange={(e) => {
+									formikProps.handleChange(e);
+								}}
+								name={`despesas_impostos[${index}].rateios[0].especificacao_material_servico`}
+								id={`despesas_impostos[${index}].rateios[0].especificacao_material_servico`}
 								className={"form-control"}
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							>
 								<option key={0} value="">Selecione uma especificação</option>
 								{
-									formikProps.values.despesa_imposto.rateios[0].tipo_custeio !== null && formikProps.values.despesa_imposto.rateios[0].tipo_custeio !== undefined && formikProps.values.despesa_imposto.rateios[0].tipo_custeio.id !== null && formikProps.values.despesa_imposto.rateios[0].tipo_custeio.id !== undefined && typeof especificacoes_custeio === "object" && especificacoes_custeio[formikProps.values.despesa_imposto.rateios[0].tipo_custeio] ? (especificacoes_custeio[formikProps.values.despesa_imposto.rateios[0].tipo_custeio].map((item) => (
+									despesa_imposto.rateios[0].tipo_custeio !== null && despesa_imposto.rateios[0].tipo_custeio !== undefined && despesa_imposto.rateios[0].tipo_custeio.id !== null && despesa_imposto.rateios[0].tipo_custeio.id !== undefined && typeof especificacoes_custeio === "object" && especificacoes_custeio[despesa_imposto.rateios[0].tipo_custeio] ? (especificacoes_custeio[despesa_imposto.rateios[0].tipo_custeio].map((item) => (
 											<option className={!item.ativa ? 'esconde-especificacao-material-servico' : ''} key={item.id} value={item.id}>{item.descricao}</option>
 									)))
 									: (
-										especificacoes_custeio && especificacoes_custeio[formikProps.values.despesa_imposto.rateios[0].tipo_custeio] && especificacoes_custeio[formikProps.values.despesa_imposto.rateios[0].tipo_custeio].map(item => (
+										especificacoes_custeio && especificacoes_custeio[despesa_imposto.rateios[0].tipo_custeio] && especificacoes_custeio[despesa_imposto.rateios[0].tipo_custeio].map(item => (
 											<option className={!item.ativa ? 'esconde-especificacao-material-servico' : ''} key={item.id} value={item.id}>{item.descricao}</option>
 										))
 									)
@@ -174,20 +165,20 @@ export const CadastroFormDespesaImposto = ({
 
 					<div className="form-row">
 						<div className="col-md-6 mt-4">
-							<label htmlFor="despesa_imposto.tipo_transacao">Forma de pagamento</label>
+							<label htmlFor={`tipo_transacao_${index}`}>Forma de pagamento</label>
 							<select
 								value={
-									formikProps.values.despesa_imposto.tipo_transacao !== null ? (formikProps.values.despesa_imposto.tipo_transacao === "object" ? formikProps.values.despesa_imposto.tipo_transacao.id : formikProps.values.despesa_imposto.tipo_transacao) : ""
+									despesa_imposto.tipo_transacao !== null ? (despesa_imposto.tipo_transacao === "object" ? despesa_imposto.tipo_transacao.id : despesa_imposto.tipo_transacao) : ""
 								}
 								onChange={(e) => {
 									formikProps.handleChange(e);
-									aux.exibeDocumentoTransacao(e.target.value, setCssEscondeDocumentoTransacaoImposto, setLabelDocumentoTransacaoImposto, despesasTabelas)
+									aux.exibeDocumentoTransacaoImposto(e.target.value, setLabelDocumentoTransacaoImposto, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas, index)
 								}}
 								onBlur={formikProps.handleBlur}
-								name='despesa_imposto.tipo_transacao'
-								id='despesa_imposto.tipo_transacao'
+								name={`despesas_impostos[${index}].tipo_transacao`}
+								id={`tipo_transacao_${index}`}
 								className="form-control"
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							>
 								<option key={0} value="">Selecione o tipo</option>
 								{despesasTabelas.tipos_transacao && despesasTabelas.tipos_transacao.map(item => (
@@ -197,39 +188,39 @@ export const CadastroFormDespesaImposto = ({
 						</div>
 
 						<div className="col-md-3 mt-4">
-							<label htmlFor="despesa_imposto.data_transacao">Data do pagamento</label>
+							<label htmlFor={`data_transacao_${index}`}>Data do pagamento</label>
 							<DatePickerField
-								name="despesa_imposto.data_transacao"
-								id="despesa_imposto.data_transacao"
+								name={`despesas_impostos[${index}].data_transacao`}
+								id={`data_transacao_${index}`}
 								value={
-									formikProps.values.despesa_imposto.data_transacao !== null ? formikProps.values.despesa_imposto.data_transacao : ""
+									despesa_imposto.data_transacao !== null ? despesa_imposto.data_transacao : ""
 								}
 								onChange={formikProps.setFieldValue}
 								onCalendarClose={async () => {
-									
-									setFormErrors(await validacoesPersonalizadas(formikProps.values, formikProps.setFieldValue, "despesa_imposto"));
+									onCalendarCloseDataPagamentoImposto(formikProps.values, formikProps.setFieldValue, index)
 								}}
 								about={despesaContext.verboHttp}
 								className="form-control"
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 								maxDate={new Date()}
+								minDate={formikProps.values.data_transacao}
 							/>
-							{formErrors.despesa_imposto_data_transacao && <span className="span_erro text-danger mt-1"> {formErrors.despesa_imposto_data_transacao}</span>}
+							{formErrorsImposto[index] && formErrorsImposto[index].despesa_imposto_data_transacao && <span className="span_erro text-danger mt-1"> {formErrorsImposto[index].despesa_imposto_data_transacao}</span>}
 						</div>
 
 						<div className="col-12 col-md-3 mt-4">
-							<div className={cssEscondeDocumentoTransacaoImposto}>
-								<label htmlFor="despesa_imposto.documento_transacao">Número do {labelDocumentoTransacaoImposto}</label>
+							<div className={cssEscondeDocumentoTransacaoImposto[index] === '' ? cssEscondeDocumentoTransacaoImposto[index] : 'escondeItem'}>
+								<label htmlFor={`documento_transacao_${index}`}>Número do {labelDocumentoTransacaoImposto[index]}</label>
 								<input
-									value={formikProps.values.despesa_imposto.documento_transacao}
+									value={despesa_imposto.documento_transacao}
 									onChange={formikProps.handleChange}
 									onBlur={formikProps.handleBlur}
-									name="despesa_imposto.documento_transacao"
-									id="despesa_imposto.documento_transacao"
+									name={`despesas_impostos[${index}].documento_transacao`}
+									id={`documento_transacao_${index}`}
 									type="text"
 									className="form-control"
 									placeholder="Digite o número do documento"
-									disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+									disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 								/>
 							</div>
 						</div>
@@ -239,18 +230,18 @@ export const CadastroFormDespesaImposto = ({
 
 					<div className="form-row">
 						<div className="col-12 col-md-3 mt-4">
-							<label htmlFor="despesa_imposto.rateios[0].acao_associacao">Ação</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].acao_associacao`}>Ação</label>
 							<select
 								value={
-									formikProps.values.despesa_imposto.rateios[0].acao_associacao !== null ? (
-										typeof formikProps.values.despesa_imposto.rateios[0].acao_associacao === "object" ? formikProps.values.despesa_imposto.rateios[0].acao_associacao.uuid : formikProps.values.despesa_imposto.rateios[0].acao_associacao
+									despesa_imposto.rateios[0].acao_associacao !== null ? (
+										typeof despesa_imposto.rateios[0].acao_associacao === "object" ? despesa_imposto.rateios[0].acao_associacao.uuid : despesa_imposto.rateios[0].acao_associacao
 									) : ""
 								}
 								onChange={formikProps.handleChange}
-								name='despesa_imposto.rateios[0].acao_associacao'
-								id='despesa_imposto.rateios[0].acao_associacao'
+								name={`despesas_impostos[${index}].rateios[0].acao_associacao`}
+								id={`despesas_impostos[${index}].rateios[0].acao_associacao`}
 								className="form-control"
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							>
 								<option value="">Selecione uma ação</option>
 								{acoes_custeio().map(item =>
@@ -260,18 +251,18 @@ export const CadastroFormDespesaImposto = ({
 						</div>
 
 						<div className="col-12 col-md-3 mt-4">
-							<label htmlFor="despesa_imposto.rateios[0].conta_associacao">Tipo de conta utilizada</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].conta_associacao`}>Tipo de conta utilizada</label>
 							<select
 								value={
-									formikProps.values.despesa_imposto.rateios[0].conta_associacao !== null ? (
-										typeof formikProps.values.despesa_imposto.rateios[0].conta_associacao === "object" ? formikProps.values.despesa_imposto.rateios[0].conta_associacao.uuid : formikProps.values.despesa_imposto.rateios[0].conta_associacao
+									despesa_imposto.rateios[0].conta_associacao !== null ? (
+										typeof despesa_imposto.rateios[0].conta_associacao === "object" ? despesa_imposto.rateios[0].conta_associacao.uuid : despesa_imposto.rateios[0].conta_associacao
 									) : ""
 								}
 								onChange={formikProps.handleChange}
-								name='despesa_imposto.rateios[0].conta_associacao'
-								id='despesa_imposto.rateios[0].conta_associacao'
+								name={`despesas_impostos[${index}].rateios[0].conta_associacao`}
+								id={`despesas_impostos[${index}].rateios[0].conta_associacao`}
 								className="form-control"
-								disabled={readOnlyCamposImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+								disabled={readOnlyCamposImposto[index] || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
 							>
 								<option key={0} value="">Selecione uma conta</option>
 								{despesasTabelas.contas_associacao && despesasTabelas.contas_associacao.map(item => (
@@ -281,19 +272,19 @@ export const CadastroFormDespesaImposto = ({
 						</div>
 
 						<div className="col-12 col-md-3 mt-4">
-							<label htmlFor="despesa_imposto.rateios[0].valor_original">Valor do imposto</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].valor_original`}>Valor do imposto</label>
 							<CurrencyInput
 								allowNegative={false}
 								prefix='R$'
 								decimalSeparator=","
 								thousandSeparator="."
-								value={formikProps.values.despesa_imposto.rateios[0].valor_original}
-								name="despesa_imposto.rateios[0].valor_original"
-								id="vdespesa_imposto.rateios[0].valor_original"
+								value={despesa_imposto.rateios[0].valor_original}
+								name={`despesas_impostos[${index}].rateios[0].valor_original`}
+								id={`despesas_impostos[${index}].rateios[0].valor_original`}
 								className={`form-control`}
 								onChangeEvent={(e) => {
 									formikProps.handleChange(e);
-									setValorRateioRealizadoImposto(formikProps.setFieldValue, e.target.value)
+									setValorRateioRealizadoImposto(formikProps.setFieldValue, e.target.value, index)
 								}}
 								onBlur={formikProps.handleBlur}
 								disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
@@ -301,16 +292,16 @@ export const CadastroFormDespesaImposto = ({
 						</div>
 
 						<div className="col-12 col-md-3 mt-4">
-							<label htmlFor="despesa_imposto.rateios[0].valor_rateio" className="label-valor-realizado">Valor realizado do imposto</label>
+							<label htmlFor={`despesas_impostos[${index}].rateios[0].valor_rateio`} className="label-valor-realizado">Valor realizado do imposto</label>
 							<CurrencyInput
 								allowNegative={false}
 								prefix='R$'
 								decimalSeparator=","
 								thousandSeparator="."
-								value={formikProps.values.despesa_imposto.rateios[0].valor_rateio}
-								name="despesa_imposto.rateios[0].valor_rateio"
-								id="despesa_imposto.rateios[0].valor_rateio"
-								className={`${ trataNumericos(formikProps.values.despesa_imposto.rateios[0].valor_rateio) === 0 && despesaContext.verboHttp === "PUT" ? "is_invalid" : ""} form-control ${trataNumericos(formikProps.values.despesa_imposto.rateios[0].valor_rateio) === 0 ? " input-valor-realizado-vazio" : " input-valor-realizado-preenchido"}`}
+								value={despesa_imposto.rateios[0].valor_rateio}
+								name={`despesas_impostos[${index}].rateios[0].valor_rateio`}
+								id={`despesas_impostos[${index}].rateios[0].valor_rateio`}
+								className={`${ trataNumericos(despesa_imposto.rateios[0].valor_rateio) === 0 && despesaContext.verboHttp === "PUT" ? "is_invalid" : ""} form-control ${trataNumericos(despesa_imposto.rateios[0].valor_rateio) === 0 ? " input-valor-realizado-vazio" : " input-valor-realizado-preenchido"}`}
 								onChangeEvent={formikProps.handleChange}
 								onBlur={formikProps.handleBlur}
 								disabled={disabled || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -30,6 +30,7 @@ import {ModalDespesaConferida} from "./ModalDespesaJaConferida";
 import {ModalDespesaIncompleta} from "./ModalDespesaIncompleta";
 import ModalMotivosPagamentoAntecipado from "./ModalMotivosPagamentoAntecipado";
 import ExibeMotivosPagamentoAntecipadoNoForm from "./ExibeMotivosPagamentoAntecipadoNoForm";
+import { RetemImposto } from "../RetemImposto";
 
 
 export const CadastroFormFormik = ({
@@ -99,6 +100,10 @@ export const CadastroFormFormik = ({
                                        setModalState,
                                        serviceIniciaEncadeamentoDosModais,
                                        serviceSubmitModais,
+                                       formErrorsImposto,
+                                       disableBtnAdicionarImposto,
+                                       onCalendarCloseDataPagamento,
+                                       onCalendarCloseDataPagamentoImposto
                                    }) => {
 
     // Corrigi Cálculo validação dos valores
@@ -291,6 +296,7 @@ export const CadastroFormFormik = ({
                                             onChange={setFieldValue}
                                             onCalendarClose={async () => {
                                                 setFormErrors(await validacoesPersonalizadas(values, setFieldValue, "despesa_principal"));
+                                                onCalendarCloseDataPagamento(values, setFieldValue);
                                             }}
                                             about={despesaContext.verboHttp}
                                             className={`${!values.data_transacao && verbo_http === "PUT" ? 'is_invalid' : ""} ${!values.data_transacao && "despesa_incompleta"} form-control`}
@@ -449,31 +455,100 @@ export const CadastroFormFormik = ({
                                 }
 
                                 {showRetencaoImposto &&
-                                    <div className="form-row mt-4">
-                                        <div className="col-12">
-                                            <CadastroFormDespesaImposto
-                                                formikProps={props}
-                                                eh_despesa_com_retencao_imposto={eh_despesa_com_retencao_imposto}
-                                                disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
-                                                tipos_documento_com_recolhimento_imposto={tipos_documento_com_recolhimento_imposto}
-                                                numeroDocumentoImpostoReadOnly={numeroDocumentoImpostoReadOnly}
-                                                aux={aux}
-                                                preenche_tipo_despesa_custeio={preenche_tipo_despesa_custeio}
-                                                especificacoes_custeio={especificacoes_custeio}
-                                                despesasTabelas={despesasTabelas}
-                                                cssEscondeDocumentoTransacaoImposto={cssEscondeDocumentoTransacaoImposto}
-                                                labelDocumentoTransacaoImposto={labelDocumentoTransacaoImposto}
-                                                setCssEscondeDocumentoTransacaoImposto={setCssEscondeDocumentoTransacaoImposto}
-                                                setLabelDocumentoTransacaoImposto={setLabelDocumentoTransacaoImposto}
-                                                setFormErrors={setFormErrors}
-                                                validacoesPersonalizadas={validacoesPersonalizadas}
-                                                readOnlyCamposImposto={readOnlyCamposImposto}
-                                                formErrors={formErrors}
-                                                despesaContext={despesaContext}
-                                                acoes_custeio={acoes_custeio}
-                                                setValorRateioRealizadoImposto={setValorRateioRealizadoImposto}
-                                                mostraModalExcluirImposto={mostraModalExcluirImposto}
-                                            />
+                                    <div className="container-retencao-imposto mt-2">
+                                        <div className="form-row mt-4">
+                                            <div className="col-12">
+                                                <RetemImposto
+                                                    formikProps={props}
+                                                    eh_despesa_com_retencao_imposto={eh_despesa_com_retencao_imposto}
+                                                    disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+                                                    mostraModalExcluirImposto={mostraModalExcluirImposto}
+                                                />
+                                                
+                                                <FieldArray
+                                                    name="despesas_impostos"
+                                                    render={({remove, push}) => (
+                                                        <>
+                                                            {values.despesas_impostos.length > 0 && values.despesas_impostos.map((despesa_imposto, index) => {
+                                                                return (
+                                                                    <div key={index}>
+                                                                        <CadastroFormDespesaImposto
+                                                                            formikProps={props}
+                                                                            eh_despesa_com_retencao_imposto={eh_despesa_com_retencao_imposto}
+                                                                            disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+                                                                            tipos_documento_com_recolhimento_imposto={tipos_documento_com_recolhimento_imposto}
+                                                                            numeroDocumentoImpostoReadOnly={numeroDocumentoImpostoReadOnly}
+                                                                            aux={aux}
+                                                                            preenche_tipo_despesa_custeio={preenche_tipo_despesa_custeio}
+                                                                            especificacoes_custeio={especificacoes_custeio}
+                                                                            despesasTabelas={despesasTabelas}
+                                                                            cssEscondeDocumentoTransacaoImposto={cssEscondeDocumentoTransacaoImposto}
+                                                                            labelDocumentoTransacaoImposto={labelDocumentoTransacaoImposto}
+                                                                            setCssEscondeDocumentoTransacaoImposto={setCssEscondeDocumentoTransacaoImposto}
+                                                                            setLabelDocumentoTransacaoImposto={setLabelDocumentoTransacaoImposto}
+                                                                            readOnlyCamposImposto={readOnlyCamposImposto}
+                                                                            despesaContext={despesaContext}
+                                                                            acoes_custeio={acoes_custeio}
+                                                                            setValorRateioRealizadoImposto={setValorRateioRealizadoImposto}
+                                                                            index={index}
+                                                                            despesa_imposto={despesa_imposto}
+                                                                            remove={remove}
+                                                                            formErrorsImposto={formErrorsImposto}
+                                                                            onCalendarCloseDataPagamentoImposto={onCalendarCloseDataPagamentoImposto}
+                                                                        />
+                                                                    </div>
+                                                                )
+                                                            })}
+
+                                                            {eh_despesa_com_retencao_imposto(values) &&
+                                                                <div className="d-flex  justify-content-start mt-3 mb-3">
+                                                                    <button
+                                                                        type="button"
+                                                                        className="btn btn btn-outline-success mt-2 mr-2"
+                                                                        disabled={disableBtnAdicionarImposto || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
+                                                                        onChange={(e) => {
+                                                                            props.handleChange(e);
+                                                                        }}
+                                                                        onClick={() => {
+                                                                            push(
+                                                                                {
+                                                                                    associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                                                                                    tipo_documento: "",
+                                                                                    numero_documento: "",
+                                                                                    tipo_transacao: "",
+                                                                                    documento_transacao: "",
+                                                                                    data_transacao: "",
+                                                                                    despesas_impostos: [],
+                                                                                    motivos_pagamento_antecipado: [],
+                                                                                    rateios: [
+                                                                                        {
+                                                                                            tipo_custeio: "",
+                                                                                            especificacao_material_servico: "",
+                                                                                            acao_associacao: "",
+                                                                                            aplicacao_recurso: "CUSTEIO",
+                                                                                            associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                                                                                            conta_associacao: "",
+                                                                                            escolha_tags:"",
+                                                                                            tag: "",
+                                                                                            numero_processo_incorporacao_capital: "",
+                                                                                            quantidade_itens_capital: 0,
+                                                                                            valor_item_capital: 0,
+                                                                                            valor_original: "",
+                                                                                            valor_rateio: ""
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        }}
+                                                                    >
+                                                                        + Adicionar imposto
+                                                                    </button>
+                                                                </div>
+                                                            }
+                                                        </>
+                                                    )}
+                                                />
+                                            </div>
                                         </div>
                                     </div>
                                 }

--- a/src/componentes/escolas/Despesas/RetemImposto/index.js
+++ b/src/componentes/escolas/Despesas/RetemImposto/index.js
@@ -1,0 +1,50 @@
+import React from "react";
+
+
+export const RetemImposto = ({formikProps, eh_despesa_com_retencao_imposto, disabled, mostraModalExcluirImposto}) => {
+    return(
+        <div className="form-row align-items-center box-escolha-retencao-imposto">
+            <div className="col-auto">
+                <p className='mb-0 mr-4 font-weight-normal'>Este serviço teve/terá retenção de imposto por parte da Associação?</p>
+            </div>
+            <div className="col-auto">
+                <div className="form-check form-check-inline">
+                    <input
+                        name="retem_imposto"
+                        onChange={(e) => {
+                            formikProps.handleChange(e);
+                            formikProps.setFieldValue("retem_imposto", true)
+                        }}
+                        onBlur={formikProps.handleBlur}
+                        className={`form-check-input`}
+                        type="radio"
+                        id="retem_imposto_sim"
+                        disabled={disabled}
+                        checked={eh_despesa_com_retencao_imposto(formikProps.values)}
+                        value={eh_despesa_com_retencao_imposto(formikProps.values)}
+                    />
+                    <label className="form-check-label" htmlFor="retem_imposto_sim">Sim</label>
+                </div>
+
+                <div className="form-check form-check-inline">
+                    <input
+                        name="retem_imposto"
+                        onChange={(e) => {
+                            formikProps.handleChange(e);
+                            formikProps.setFieldValue("retem_imposto", false)
+                            mostraModalExcluirImposto();
+                        }}
+                        onBlur={formikProps.handleBlur}
+                        className={`form-check-input`}
+                        type="radio"
+                        id="retem_imposto_nao"
+                        disabled={disabled}
+                        checked={!eh_despesa_com_retencao_imposto(formikProps.values)}
+                        value={!eh_despesa_com_retencao_imposto(formikProps.values)}
+                    />
+                    <label className="form-check-label" htmlFor="retem_imposto_nao">Não</label>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/componentes/escolas/Despesas/metodosAuxiliares.js
+++ b/src/componentes/escolas/Despesas/metodosAuxiliares.js
@@ -118,6 +118,53 @@ const exibeDocumentoTransacao = (valor, setCssEscondeDocumentoTransacao, setLabe
     }
 };
 
+const exibeDocumentoTransacaoImposto = (valor, setLabelDocumentoTransacao, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas, index) => {
+    if(valor && despesasTabelas && despesasTabelas.tipos_transacao){
+        let exibe_documento_transacao =  despesasTabelas.tipos_transacao.find(element => element.id === Number(valor));
+        if (exibe_documento_transacao.tem_documento){
+            setCssEscondeDocumentoTransacaoImposto({
+                ...cssEscondeDocumentoTransacaoImposto,
+                [index]: ""
+            })
+            setLabelDocumentoTransacao({
+                ...labelDocumentoTransacaoImposto,
+                [index]: exibe_documento_transacao.nome
+            })
+        }
+        else{
+            setCssEscondeDocumentoTransacaoImposto({
+                ...cssEscondeDocumentoTransacaoImposto,
+                [index]: "escondeItem"
+            })
+        }
+    }
+    else{
+        setCssEscondeDocumentoTransacaoImposto({
+            ...cssEscondeDocumentoTransacaoImposto,
+            [index]: "escondeItem"
+        })
+    }
+}
+
+const exibeDocumentoTransacaoImpostoUseEffect = (despesas_impostos, setLabelDocumentoTransacao, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas) => {
+    despesas_impostos.map((despesa_imposto, index_imposto) => {
+        if(despesa_imposto.tipo_transacao && despesasTabelas && despesasTabelas.tipos_transacao){
+            let exibe_documento_transacao =  despesasTabelas.tipos_transacao.find(element => element.id === Number(despesa_imposto.tipo_transacao));
+            if(exibe_documento_transacao.tem_documento){
+                setCssEscondeDocumentoTransacaoImposto(prevState => ([...prevState, ""]))
+                setLabelDocumentoTransacao(prevState => ([...prevState, exibe_documento_transacao.nome]))
+            }
+            else{
+                setCssEscondeDocumentoTransacaoImposto(prevState => ([...prevState, {[index_imposto]: "escondeItem"}]))
+            }
+        }
+        else{
+            setCssEscondeDocumentoTransacaoImposto(prevState => ([...prevState, {[index_imposto]: "escondeItem"}]))
+        }  
+    });
+
+    
+}
 
 const setValorRealizado = (setFieldValue, valor) =>{
     setFieldValue("valor_total", trataNumericos(valor))
@@ -154,9 +201,18 @@ const getErroValorOriginalRateios = (values) =>{
         }
     });
 
-    if(values.retem_imposto && values.despesa_imposto && values.despesa_imposto.rateios.length > 0){
-        let valor_imposto_tratado = trataNumericos(values.despesa_imposto.rateios[0].valor_original);
-        valor_total_dos_rateios_original = valor_total_dos_rateios_capital_original + valor_total_dos_rateios_custeio_original + valor_imposto_tratado;
+    if(values.retem_imposto && values.despesas_impostos && values.despesas_impostos.length > 0){
+        let valor_imposto = 0;
+
+        values.despesas_impostos.map((despesa_imposto) => {
+            if(despesa_imposto.rateios.length > 0){
+                despesa_imposto.rateios.map((rateio) => {
+                    valor_imposto = valor_imposto + trataNumericos(rateio.valor_rateio);
+                });
+            }
+        });
+
+        valor_total_dos_rateios_original = valor_total_dos_rateios_capital_original + valor_total_dos_rateios_custeio_original + valor_imposto;
     }
     else{
         valor_total_dos_rateios_original = valor_total_dos_rateios_capital_original + valor_total_dos_rateios_custeio_original;
@@ -169,9 +225,18 @@ const getErroValorOriginalRateios = (values) =>{
 const getErroValorRealizadoRateios = (values) =>{
     let var_valor_recursos_acoes;
 
-    if(values.retem_imposto && values.despesa_imposto && values.despesa_imposto.rateios.length > 0){
-        let valor_imposto_tratado = values.despesa_imposto.rateios[0].valor_rateio;
-        var_valor_recursos_acoes = trataNumericos(values.valor_total) - trataNumericos(values.valor_recursos_proprios) - trataNumericos(valor_imposto_tratado);
+    if(values.retem_imposto && values.despesas_impostos && values.despesas_impostos.length > 0){
+        let valor_imposto = 0;
+
+        values.despesas_impostos.map((despesa_imposto) => {
+            if(despesa_imposto.rateios.length > 0){
+                despesa_imposto.rateios.map((rateio) => {
+                    valor_imposto = valor_imposto + trataNumericos(rateio.valor_rateio);
+                });
+            }
+        });
+
+        var_valor_recursos_acoes = trataNumericos(values.valor_total) - trataNumericos(values.valor_recursos_proprios) - trataNumericos(valor_imposto);
     }
     else{
         var_valor_recursos_acoes = trataNumericos(values.valor_total) - trataNumericos(values.valor_recursos_proprios);
@@ -225,5 +290,7 @@ export const metodosAuxiliares = {
     setValoresRateiosOriginal,
     getErroValorOriginalRateios,
     getErroValorRealizadoRateios,
-    onHandleChangeApenasNumero
+    onHandleChangeApenasNumero,
+    exibeDocumentoTransacaoImposto,
+    exibeDocumentoTransacaoImpostoUseEffect
 };

--- a/src/context/Despesa/index.js
+++ b/src/context/Despesa/index.js
@@ -42,30 +42,32 @@ export const DespesaContextProvider = ({children}) => {
         retem_imposto: false,
         motivos_pagamento_antecipado: [],
         outros_motivos_pagamento_antecipado:"",
-        despesa_imposto: {
-            associacao: localStorage.getItem(ASSOCIACAO_UUID),
-            tipo_documento: "",
-            numero_documento: "",
-            tipo_transacao: "",
-            documento_transacao: "",
-            data_transacao: "",
-            rateios: [
-                {
-                    tipo_custeio: "",
-                    especificacao_material_servico: "",
-                    acao_associacao: "",
-                    aplicacao_recurso: "CUSTEIO",
-                    associacao: localStorage.getItem(ASSOCIACAO_UUID),
-                    conta_associacao: "",
-                    escolha_tags:"",
-                    numero_processo_incorporacao_capital: "",
-                    quantidade_itens_capital: 0,
-                    valor_item_capital: 0,
-                    valor_original: "",
-                    valor_rateio: "",           
-                }
-            ],
-        },
+        despesas_impostos: [
+            {
+                associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                tipo_documento: "",
+                numero_documento: "",
+                tipo_transacao: "",
+                documento_transacao: "",
+                data_transacao: "",
+                rateios: [
+                    {
+                        tipo_custeio: "",
+                        especificacao_material_servico: "",
+                        acao_associacao: "",
+                        aplicacao_recurso: "CUSTEIO",
+                        associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                        conta_associacao: "",
+                        escolha_tags:"",
+                        numero_processo_incorporacao_capital: "",
+                        quantidade_itens_capital: 0,
+                        valor_item_capital: 0,
+                        valor_original: "",
+                        valor_rateio: "",           
+                    }
+                ]
+            }
+        ],
         // Fim Auxiliares
         rateios: [
             {
@@ -107,30 +109,32 @@ export const DespesaContextProvider = ({children}) => {
         retem_imposto: false,
         motivos_pagamento_antecipado: [],
         outros_motivos_pagamento_antecipado:"",
-        despesa_imposto: {
-            associacao: localStorage.getItem(ASSOCIACAO_UUID),
-            tipo_documento: "",
-            numero_documento: "",
-            tipo_transacao: "",
-            documento_transacao: "",
-            data_transacao: "",
-            rateios: [
-                {
-                    tipo_custeio: "",
-                    especificacao_material_servico: "",
-                    acao_associacao: "",
-                    aplicacao_recurso: "CUSTEIO",
-                    associacao: localStorage.getItem(ASSOCIACAO_UUID),
-                    conta_associacao: "",
-                    escolha_tags:"",
-                    numero_processo_incorporacao_capital: "",
-                    quantidade_itens_capital: 0,
-                    valor_item_capital: 0,
-                    valor_original: "",
-                    valor_rateio: "",           
-                }
-            ],
-        },
+        despesas_impostos: [
+            {
+                associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                tipo_documento: "",
+                numero_documento: "",
+                tipo_transacao: "",
+                documento_transacao: "",
+                data_transacao: "",
+                rateios: [
+                    {
+                        tipo_custeio: "",
+                        especificacao_material_servico: "",
+                        acao_associacao: "",
+                        aplicacao_recurso: "CUSTEIO",
+                        associacao: localStorage.getItem(ASSOCIACAO_UUID),
+                        conta_associacao: "",
+                        escolha_tags:"",
+                        numero_processo_incorporacao_capital: "",
+                        quantidade_itens_capital: 0,
+                        valor_item_capital: 0,
+                        valor_original: "",
+                        valor_rateio: "",           
+                    }
+                ]
+            }
+        ],
         // Fim Auxiliares
         rateios: [
             {

--- a/src/paginas/escolas/Despesas/EdicaoDeDespesa/index.js
+++ b/src/paginas/escolas/Despesas/EdicaoDeDespesa/index.js
@@ -52,54 +52,43 @@ export const EdicaoDeDespesa = ()=>{
                     }) : ""
                 });
 
+                if(resp && resp.despesas_impostos && resp.despesas_impostos.length > 0){
+                    let despesas_impostos_tratados = resp.despesas_impostos.map((despesa_imposto) => {
+                        despesa_imposto.associacao = localStorage.getItem(ASSOCIACAO_UUID);
+                        despesa_imposto.tipo_documento = despesa_imposto.tipo_documento ? despesa_imposto.tipo_documento : "";
+                        despesa_imposto.numero_documento = despesa_imposto.numero_documento ? despesa_imposto.numero_documento : "";
+                        despesa_imposto.tipo_transacao = despesa_imposto.tipo_transacao ? despesa_imposto.tipo_transacao : "";
+                        despesa_imposto.documento_transacao = despesa_imposto.documento_transacao ? despesa_imposto.documento_transacao : "";
+                        despesa_imposto.data_transacao = despesa_imposto.data_transacao ? moment(despesa_imposto.data_transacao, "YYYY-MM-DD"): null;
+
+                        if(despesa_imposto.rateios && despesa_imposto.rateios.length > 0){
+                            despesa_imposto.rateios.map((rateio) => {
+                                rateio.uuid = rateio.uuid ? rateio.uuid : null;
+                                rateio.tipo_custeio = rateio.tipo_custeio ? rateio.tipo_custeio : "";
+                                rateio.especificacao_material_servico = rateio.especificacao_material_servico ? rateio.especificacao_material_servico : "";
+                                rateio.acao_associacao = rateio.acao_associacao ? rateio.acao_associacao : "";
+                                rateio.aplicacao_recurso = "CUSTEIO";
+                                rateio.associacao = localStorage.getItem(ASSOCIACAO_UUID);
+                                rateio.conta_associacao = rateio.conta_associacao ? rateio.conta_associacao : "";
+                                rateio.escolha_tags = "";
+                                rateio.numero_processo_incorporacao_capital = rateio.numero_processo_incorporacao_capital ? rateio.numero_processo_incorporacao_capital : "";
+                                rateio.quantidade_itens_capital = 0;
+                                rateio.valor_item_capital = 0;
+                                rateio.valor_original = rateio.valor_original ? Number(rateio.valor_original).toLocaleString('pt-BR', {
+                                    style: 'currency',
+                                    currency: 'BRL'
+                                }) : "";
+                                rateio.valor_rateio = rateio.valor_rateio ? Number(rateio.valor_rateio).toLocaleString('pt-BR', {
+                                    style: 'currency',
+                                    currency: 'BRL'
+                                }) : "";
+                            })
+                        }
+                    })
+                }
+                
                 const init = {
                     ...resp,
-                    despesa_imposto: {
-                        associacao: localStorage.getItem(ASSOCIACAO_UUID),
-                        tipo_documento: resp && resp.despesa_imposto && resp.despesa_imposto.tipo_documento ? resp.despesa_imposto.tipo_documento : "",
-                        numero_documento: resp && resp.despesa_imposto && resp.despesa_imposto.numero_documento ? resp.despesa_imposto.numero_documento : "",
-                        tipo_transacao: resp && resp.despesa_imposto && resp.despesa_imposto.tipo_transacao ? resp.despesa_imposto.tipo_transacao : "",
-                        documento_transacao: resp && resp.despesa_imposto && resp.despesa_imposto.documento_transacao ? resp.despesa_imposto.documento_transacao : "",
-                        data_transacao: resp && resp.despesa_imposto && resp.despesa_imposto.data_transacao ? moment(resp.despesa_imposto.data_transacao, "YYYY-MM-DD"): null,
-                        rateios: resp && resp.despesa_imposto && resp.despesa_imposto.rateios && resp.despesa_imposto.rateios.length > 0 ?
-                            [{
-                                uuid: resp.despesa_imposto.rateios[0].uuid ? resp.despesa_imposto.rateios[0].uuid : null,
-                                tipo_custeio: resp.despesa_imposto.rateios[0].tipo_custeio ? resp.despesa_imposto.rateios[0].tipo_custeio : "",
-                                especificacao_material_servico: resp.despesa_imposto.rateios[0].especificacao_material_servico ? resp.despesa_imposto.rateios[0].especificacao_material_servico : "",
-                                acao_associacao: resp.despesa_imposto.rateios[0].acao_associacao ? resp.despesa_imposto.rateios[0].acao_associacao : "",
-                                aplicacao_recurso: "CUSTEIO",
-                                associacao: localStorage.getItem(ASSOCIACAO_UUID),
-                                conta_associacao: resp.despesa_imposto.rateios[0].conta_associacao ? resp.despesa_imposto.rateios[0].conta_associacao : "",
-                                escolha_tags:"",
-                                numero_processo_incorporacao_capital: resp.despesa_imposto.rateios[0].numero_processo_incorporacao_capital ? resp.despesa_imposto.rateios[0].numero_processo_incorporacao_capital : "",
-                                quantidade_itens_capital: 0,
-                                valor_item_capital: 0,
-                                valor_original: resp.despesa_imposto.rateios[0].valor_original ? Number(resp.despesa_imposto.rateios[0].valor_original).toLocaleString('pt-BR', {
-                                    style: 'currency',
-                                    currency: 'BRL'
-                                }) : "",
-                                valor_rateio: resp.despesa_imposto.rateios[0].valor_rateio ? Number(resp.despesa_imposto.rateios[0].valor_rateio).toLocaleString('pt-BR', {
-                                    style: 'currency',
-                                    currency: 'BRL'
-                                }) : ""
-                            }]:
-                            [{
-                                tipo_custeio: "",
-                                especificacao_material_servico: "",
-                                acao_associacao: "",
-                                aplicacao_recurso: "CUSTEIO",
-                                associacao: localStorage.getItem(ASSOCIACAO_UUID),
-                                conta_associacao: "",
-                                escolha_tags: "",
-                                numero_processo_incorporacao_capital: "",
-                                quantidade_itens_capital: 0,
-                                valor_item_capital: 0,
-                                valor_original: "",
-                                valor_rateio: ""
-                            }],
-                    },
-
-
                     mais_de_um_tipo_despesa : resp.rateios.length > 1 ? "sim" : "nao",
                     data_documento: resp.data_documento ?  moment(resp.data_documento, "YYYY-MM-DD"): null,
                     data_transacao: resp.data_transacao ?  moment(resp.data_transacao, "YYYY-MM-DD"): null,

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -213,6 +213,38 @@ export const periodoFechado = async (data, setReadOnlyBtnAcao, setShowPeriodoFec
   }
 }
 
+export const periodoFechadoImposto = async (despesas_impostos, setReadOnlyBtnAcao, setShowPeriodoFechadoImposto, setReadOnlyCamposImposto, setDisableBtnAdicionarImposto, onShowErroGeral) =>{  
+  for(let despesa_imposto = 0; despesa_imposto <= despesas_impostos.length-1; despesa_imposto++){
+    if(despesas_impostos[despesa_imposto].data_transacao){
+      let data = moment(despesas_impostos[despesa_imposto].data_transacao, "YYYY-MM-DD").format("YYYY-MM-DD");
+
+      try{
+        let periodo_fechado = await getPeriodoFechado(data);
+        if (!periodo_fechado.aceita_alteracoes){
+          setReadOnlyBtnAcao(true);
+          setShowPeriodoFechadoImposto(true);
+          setReadOnlyCamposImposto(prevState => ({...prevState, [despesa_imposto]: true}));
+          setDisableBtnAdicionarImposto(true);
+        }
+        else{
+          setReadOnlyBtnAcao(false);
+          setShowPeriodoFechadoImposto(false);
+          setReadOnlyCamposImposto(prevState => ({...prevState, [despesa_imposto]: false}));
+          setDisableBtnAdicionarImposto(false);
+        }
+      }
+      catch (e){
+        setReadOnlyBtnAcao(true);
+        setShowPeriodoFechadoImposto(true);
+        setReadOnlyCamposImposto(prevState => ({...prevState, [despesa_imposto]: true}));
+        setDisableBtnAdicionarImposto(true);
+        onShowErroGeral();
+        console.log("Erro ao buscar perído ", e)
+      }
+    }
+  }
+}
+
 export const validaPayloadDespesas = (values, despesasTabelas=null) => {
 
   let exibe_documento_transacao
@@ -269,20 +301,28 @@ export const validaPayloadDespesas = (values, despesasTabelas=null) => {
     values.data_transacao = null
   }
 
-  if (values.despesa_imposto.data_transacao !== "" && values.despesa_imposto.data_transacao !== null){
-    values.despesa_imposto.data_transacao  = moment(values.despesa_imposto.data_transacao).format("YYYY-MM-DD");
-  }else {
-    values.despesa_imposto.data_transacao = null
-  }
+  // validacoes da despesa imposto
+  values.despesas_impostos.map((despesa_imposto) => {
+    if(despesa_imposto.data_transacao !== "" && despesa_imposto.data_transacao !== null){
+      despesa_imposto.data_transacao = moment(despesa_imposto.data_transacao).format("YYYY-MM-DD");
+    }
+    else{
+      despesa_imposto.data_transacao = null;
+    }
 
+    if(despesa_imposto.rateios.length >= 0){
+        despesa_imposto.rateios.map((rateio) => {
+            // o valor total e original da despesa imposto, devem ser o mesmo que o dos rateios
+            despesa_imposto.valor_total = trataNumericos(rateio.valor_rateio);
+            despesa_imposto.valor_original = trataNumericos(rateio.valor_original);
 
-  values.despesa_imposto.valor_total = trataNumericos(values.despesa_imposto.rateios[0].valor_rateio);
-  values.despesa_imposto.valor_original = trataNumericos(values.despesa_imposto.rateios[0].valor_original);
-
-  values.despesa_imposto.rateios[0].quantidade_itens_capital = convertToNumber(values.despesa_imposto.rateios[0].quantidade_itens_capital)
-  values.despesa_imposto.rateios[0].valor_item_capital = trataNumericos(values.despesa_imposto.rateios[0].valor_item_capital)
-  values.despesa_imposto.rateios[0].valor_rateio = round(trataNumericos(values.despesa_imposto.rateios[0].valor_rateio),2)
-  values.despesa_imposto.rateios[0].valor_original = round(trataNumericos(values.despesa_imposto.rateios[0].valor_original),2)
+            rateio.quantidade_itens_capital = convertToNumber(rateio.quantidade_itens_capital);
+            rateio.valor_item_capital = trataNumericos(rateio.valor_item_capital);
+            rateio.valor_rateio = round(trataNumericos(rateio.valor_rateio), 2);
+            rateio.valor_original = round(trataNumericos(rateio.valor_original), 2);
+        });
+    }
+  });
 
   values.rateios.map((rateio) => {
 


### PR DESCRIPTION
feat(61290): Cadastro de mais de um imposto

Esse PR:

- Possibilita cadastro de mais de um imposto por despesa
- Altera validações de imposto
- Adiciona lista de impostos ao payload

História: [AB#61290](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/61290)