### PR TITLE
feat(59547): Altera status ata de apresentação da ata

### DIFF
--- a/src/componentes/escolas/GeracaoAtaRetificadora/index.js
+++ b/src/componentes/escolas/GeracaoAtaRetificadora/index.js
@@ -28,6 +28,11 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
                 setDataBoxAtaRetificadora("Ata não preenchida");
                 setGerarAtaRetificadora(false)
             }
+            else if (!dados.completa) {
+                setCorBoxAtaRetificadora("vermelho");
+                setDataBoxAtaRetificadora("Ata incompleta");
+                setGerarAtaRetificadora(false)
+            }
             else {
                 setCorBoxAtaRetificadora("verde");
                 setDataBoxAtaRetificadora("Último preenchimento em "+exibeDateTimePT_BR_Ata(dados.alterado_em));
@@ -41,6 +46,11 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
                 if (dados.alterado_em === null){
                     setCorBoxAtaRetificadora("vermelho");
                     setDataBoxAtaRetificadora("Ata não preenchida");
+                    setGerarAtaRetificadora(false)
+                }
+                else if (!dados.completa) {
+                    setCorBoxAtaRetificadora("vermelho");
+                    setDataBoxAtaRetificadora("Ata incompleta");
                     setGerarAtaRetificadora(false)
                 }
                 else {

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/FormularioEditaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/FormularioEditaAta/index.js
@@ -564,7 +564,7 @@ export const FormularioEditaAta = ({
                                             </div>
                                             <div className='row'>
                                                 <div className="col">
-                                                    <label htmlFor="stateFormEditarAta.cargo_secretaria_reuniao" className="mt-3">Justificativa <span className='text-danger'><i>(obrigatório)</i></span></label>
+                                                    <label htmlFor="stateFormEditarAta.cargo_secretaria_reuniao" className="mt-3">Justificativa</label>
                                                     <textarea
                                                         value={values.stateFormEditarAta.justificativa_repasses_pendentes}
                                                         onChange={props.handleChange}

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
@@ -127,15 +127,7 @@ export const EdicaoAta = () => {
     };
 
     const temErros = (dadosForm) => {
-        let erros;
-        let justificativas = dadosForm.stateFormEditarAta.justificativa_repasses_pendentes.trim()
-        if (repassesPendentes && repassesPendentes.length > 0 && !justificativas){
-            erros = {
-                justificativa_repasses_pendentes : "Campo obrigatório"
-            }
-        }else {
-            erros = {}
-        }
+        let erros = {};
         setErros(erros)
         return erros;
     };

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -218,6 +218,10 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                     setdataBoxAtaApresentacao("Ata não preenchida");
                     setGerarAta(false)
                 }
+                else if (!data_preenchimento.completa) {
+                    setcorBoxAtaApresentacao("vermelho");
+                    setdataBoxAtaApresentacao("Ata incompleta");
+                    setGerarAta(false)                }
                 else {
                     setcorBoxAtaApresentacao("verde");
                     setdataBoxAtaApresentacao("Último preenchimento em "+exibeDateTimePT_BR_Ata(data_preenchimento.alterado_em));


### PR DESCRIPTION
Esse PR altera a exibição e emissão de atas de apresentação e retificação de prestação de contas para passarem a informar quando a ata estiver incompleta e só permitir a emissão de PDF quando ela estiver completa.

História: [AB#59547](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/59547)