### PR TITLE
feat(63021): Altera tootip despesa acompanhamento de PC

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
@@ -511,7 +511,7 @@ const TabelaConferenciaDeLancamentos = ({
 
     const retornaToolTipCredito = (rowData) => {
         if (rowData.documento_mestre && rowData.documento_mestre.rateio_estornado && rowData.documento_mestre.rateio_estornado.uuid) {
-            let data_rateio = dataTemplate(null, null, rowData.documento_mestre.rateio_estornado.data_documento)
+            let data_rateio = dataTemplate(null, null, rowData.documento_mestre.rateio_estornado.data_transacao)
             let texto_tooltip = `Esse estorno está vinculado <br/> à despesa do dia ${data_rateio}.`
             return (
                 <>


### PR DESCRIPTION
Esse PR,  na conferência de lançamentos no acompanhamento de PCs, altera o tooltip
de estorno para exibir a data de transação em vez da data do documento.

História: [AB#63021](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/63021)