### PR TITLE
fix(65643): O saldo das PCs 2022.1 e 2021.3 da DRE Ipiranga exibe os dados da PC 2021.2

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
@@ -11,10 +11,9 @@ import moment from "moment";
 export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao, handleChangeAnalisesDeContaDaPrestacao, getObjetoIndexAnalise, editavel, prestacaoDeContas, adicaoAjusteSaldo, setAdicaoAjusteSaldo, onClickAdicionarAcertoSaldo, onClickDescartarAcerto, formErrosAjusteSaldo, validaAjustesSaldo, handleOnKeyDownAjusteSaldo, onClickSalvarAcertoSaldo, ajusteSaldoSalvoComSucesso, onClickDeletarAcertoSaldo}) => {
     let index = getObjetoIndexAnalise().analise_index;
     const tooltip_1 = 'A diferença entre o saldo bancário e o saldo reprogramado <br/> pode ocorrer em virtude de cheques não compensados, <br/> despesas/créditos não lançados ou lançados com erro ou <br/> estornos ainda não realizados.'
-    
 
     const informacoes_conciliacao_ue = () => {
-        let info = prestacaoDeContas.informacoes_conciliacao_ue.find(element => element.conta_uuid === infoAta.conta_associacao.uuid);
+        let info = prestacaoDeContas.informacoes_conciliacao_ue.find(element => element.periodo_uuid === prestacaoDeContas.periodo_uuid);
 
         let dados = {
             saldo_extrato: '-',


### PR DESCRIPTION
Corrige: [AB#65643](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/65643)