### PR TITLE
feat(62851): Suporte às Unidades: Viabilizar acesso de suporte - Parte 2

### DIFF
--- a/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
+++ b/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
@@ -18,7 +18,8 @@ export const ListaDeUnidades = ({listaUnidades, rowsPerPage, acaoAoEscolherUnida
         const unidadeSelecionada = {
             uuid: rowData.uuid,
             nome: rowData.nome,
-            codigo_eol: rowData.codigo_eol
+            codigo_eol: rowData.codigo_eol,
+            tipo_unidade: rowData.tipo_unidade
         }
         acaoAoEscolherUnidade(unidadeSelecionada)
     };

--- a/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
+++ b/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
@@ -19,7 +19,10 @@ export const ListaDeUnidades = ({listaUnidades, rowsPerPage, acaoAoEscolherUnida
             uuid: rowData.uuid,
             nome: rowData.nome,
             codigo_eol: rowData.codigo_eol,
-            tipo_unidade: rowData.tipo_unidade
+            tipo_unidade: rowData.tipo_unidade,
+            associacao_nome: rowData.associacao_nome,
+            associacao_uuid: rowData.associacao_uuid,
+            visao: rowData.visao
         }
         acaoAoEscolherUnidade(unidadeSelecionada)
     };

--- a/src/componentes/Globais/EscolheUnidade/index.js
+++ b/src/componentes/Globais/EscolheUnidade/index.js
@@ -37,16 +37,9 @@ export const EscolheUnidade = (props) =>{
         }
     };
 
-    const escolherUnidade = (uuidUnidade) => {
-        props.onSelecionaUnidade(uuidUnidade)
+    const escolherUnidade = (unidadeSelecionada) => {
+        props.onSelecionaUnidade(unidadeSelecionada)
     }
-
-    const handleChangeFiltros = (name, value) => {
-        setStateFiltros({
-            ...stateFiltros,
-            [name]: value
-        });
-    };
 
     const handleSubmitFiltros = (event, filtros)=>{
         event.preventDefault();

--- a/src/componentes/Globais/SuporteAsUnidades/index.js
+++ b/src/componentes/Globais/SuporteAsUnidades/index.js
@@ -4,6 +4,7 @@ import {EscolheUnidade} from "../EscolheUnidade";
 import {visoesService} from "../../../services/visoes.service";
 import {ModalConfirmaInicioSuporte} from "./ModalConfirmaInicioSuporte";
 import {getUsuarioLogado, viabilizarAcessoSuporte, authService} from "../../../services/auth.service"
+import {setarUnidadeProximoLoginAcessoSuporte} from "../../../services/visoes.service"
 
 export const SuporteAsUnidades = (props) =>{
 
@@ -23,6 +24,14 @@ export const SuporteAsUnidades = (props) =>{
 
     const handleConfirmaSuporte = useCallback(() => {
         viabilizarAcessoSuporte(getUsuarioLogado().login, {codigo_eol: unidadeSuporteSelecionada.codigo_eol})
+        setarUnidadeProximoLoginAcessoSuporte(
+            unidadeSuporteSelecionada.visao,
+            unidadeSuporteSelecionada.uuid,
+            unidadeSuporteSelecionada.associacao_uuid,
+            unidadeSuporteSelecionada.associacao_nome,
+            unidadeSuporteSelecionada.tipo_unidade,
+            unidadeSuporteSelecionada.nome
+        )
         authService.logout()
         setShowModalConfirmaSuporte(false)
     }, [unidadeSuporteSelecionada]);

--- a/src/services/visoes.service.js
+++ b/src/services/visoes.service.js
@@ -253,6 +253,39 @@ const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, un
     }
 };
 
+
+export const setarUnidadeProximoLoginAcessoSuporte = (visao, uuid_unidade, uuid_associacao, nome_associacao, unidade_tipo, unidade_nome) => {
+    let todos_os_dados_usuario_logado = localStorage.getItem(DADOS_USUARIO_LOGADO) ? JSON.parse(localStorage.getItem(DADOS_USUARIO_LOGADO)) : null;
+    let dados_usuario_logado = getDadosDoUsuarioLogado();
+
+    if (dados_usuario_logado) {
+        let novos_dados_usuario_logado = {
+            ...todos_os_dados_usuario_logado,
+            [`usuario_${getUsuarioLogin()}`]: {
+                ...dados_usuario_logado,
+                visao_selecionada: {
+                    nome: converteNomeVisao(visao)
+                },
+                unidade_selecionada: {
+                    uuid: uuid_unidade,
+                    tipo_unidade:unidade_tipo,
+                    nome:unidade_nome,
+                    notificar_devolucao_referencia:null,
+                    notificar_devolucao_pc_uuid:null,
+                    notificacao_uuid: null,
+                },
+
+                associacao_selecionada: {
+                    uuid: unidade_tipo === "DRE" ? uuid_unidade: uuid_associacao,
+                    nome: unidade_tipo === "DRE" ? unidade_nome: nome_associacao,
+                },
+            }
+        };
+        localStorage.setItem(DADOS_USUARIO_LOGADO, JSON.stringify(novos_dados_usuario_logado));
+    }
+};
+
+
 const redirectVisao = (visao = null) => {
     let dados_usuario_logado = visoesService.getDadosDoUsuarioLogado();
     if (visao === 'SME') {
@@ -294,4 +327,3 @@ export const visoesService = {
     getItemUsuarioLogado,
     getUsuarioLogin,
 };
-


### PR DESCRIPTION
Esse PR:
[X] Adiciona o tipo de unidade na seleção da unidade para acesso
[X] Adiciona Nome e UUID da Associação e visão na seleção de unidade para acesso
[X] Grava unidade do suporte como unidade do próximo acesso do usuário

História: [AB#62851](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/62851)