### PR TITLE
feat(62837): Suporte às Unidades: Encerrar acesso de suporte

### DIFF
--- a/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/ModalConfirmaEncerramentoSuporte.js
+++ b/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/ModalConfirmaEncerramentoSuporte.js
@@ -1,0 +1,19 @@
+import {ModalBootstrap} from "../ModalBootstrap";
+import React from "react";
+
+export const ModalConfirmaEncerramentoSuporte = (props) => {
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={()=>{}}
+            titulo={"Confirmação de encerramento de suporte"}
+            bodyText={"<p>Deseja encerrar o suporte a essa unidade?</p> <p>Ao confirmar, você será direcionado para a página de acesso ao sistema e ao acessá-lo, não visualizará mais essa unidade.</p>"}
+            primeiroBotaoTexto={"Não"}
+            primeiroBotaoCss={"outline-success"}
+            primeiroBotaoOnclick={props.handleNaoConfirmaEncerramentoSuporte}
+            segundoBotaoTexto={"Sim"}
+            segundoBotaoCss={"danger"}
+            segundoBotaoOnclick={props.handleConfirmaEncerramentoSuporte}
+        />
+    )
+};

--- a/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
+++ b/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
@@ -2,19 +2,22 @@ import React, {useCallback, useEffect, useState} from "react";
 import { barraMensagemCustom } from "../BarraMensagem";
 import {visoesService} from "../../../services/visoes.service"
 import {ModalConfirmaEncerramentoSuporte} from "./ModalConfirmaEncerramentoSuporte";
+import {encerrarAcessoSuporte,authService} from "../../../services/auth.service";
 
 export const BarraMensagemUnidadeEmSuporte = () => {
-    const mensagemSuporte = "Você está acessando essa unidade em modo de suporte. Use o botão para encerrar o suporte quando concluir."
+    const mensagemSuporte = "Você está acessando essa unidade em MODO SUPORTE. Use o botão encerrar quando concluir o suporte."
     const [unidadeEstaEmSuporte, setUnidadeEstaEmSuporte] = useState(false)
 
-    const verificaSeUnidadeEstaEmSuporte = () => {
-        const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado()
+    const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado()
 
+    const verificaSeUnidadeEstaEmSuporte = () => {
         if (dadosUsuarioLogado) {
             const unidadeSelecionada = dadosUsuarioLogado.unidades.find(obj => {
                 return obj.uuid === dadosUsuarioLogado.unidade_selecionada.uuid
             })
-            setUnidadeEstaEmSuporte(unidadeSelecionada.acesso_de_suporte)
+            if (unidadeSelecionada && unidadeSelecionada.acesso_de_suporte){
+                setUnidadeEstaEmSuporte(unidadeSelecionada.acesso_de_suporte)
+            }
         }
     }
 
@@ -31,18 +34,11 @@ export const BarraMensagemUnidadeEmSuporte = () => {
         setShowModalConfirmaEncerramentoSuporte(false)
     }, []);
     const handleConfirmaEncerramentoSuporte = useCallback(() => {
-        // viabilizarAcessoSuporte(getUsuarioLogado().login, {codigo_eol: unidadeSuporteSelecionada.codigo_eol})
-        // setarUnidadeProximoLoginAcessoSuporte(
-        //     unidadeSuporteSelecionada.visao,
-        //     unidadeSuporteSelecionada.uuid,
-        //     unidadeSuporteSelecionada.associacao_uuid,
-        //     unidadeSuporteSelecionada.associacao_nome,
-        //     unidadeSuporteSelecionada.tipo_unidade,
-        //     unidadeSuporteSelecionada.nome
-        // )
-        // authService.logout()
+        encerrarAcessoSuporte(dadosUsuarioLogado.usuario_logado.login, dadosUsuarioLogado.unidade_selecionada.uuid)
         setUnidadeEstaEmSuporte(false)
         setShowModalConfirmaEncerramentoSuporte(false)
+        localStorage.removeItem('DADOS_USUARIO_LOGADO');
+        authService.logout()
     }, []);
 
     return (

--- a/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
+++ b/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
@@ -1,0 +1,63 @@
+import React, {useCallback, useEffect, useState} from "react";
+import { barraMensagemCustom } from "../BarraMensagem";
+import {visoesService} from "../../../services/visoes.service"
+import {ModalConfirmaEncerramentoSuporte} from "./ModalConfirmaEncerramentoSuporte";
+
+export const BarraMensagemUnidadeEmSuporte = () => {
+    const mensagemSuporte = "Você está acessando essa unidade em modo de suporte. Use o botão para encerrar o suporte quando concluir."
+    const [unidadeEstaEmSuporte, setUnidadeEstaEmSuporte] = useState(false)
+
+    const verificaSeUnidadeEstaEmSuporte = () => {
+        const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado()
+
+        if (dadosUsuarioLogado) {
+            const unidadeSelecionada = dadosUsuarioLogado.unidades.find(obj => {
+                return obj.uuid === dadosUsuarioLogado.unidade_selecionada.uuid
+            })
+            setUnidadeEstaEmSuporte(unidadeSelecionada.acesso_de_suporte)
+        }
+    }
+
+    useEffect(() => {
+        verificaSeUnidadeEstaEmSuporte()
+    }, []);
+
+    const handleEncerrarSuporte = () => {
+        setShowModalConfirmaEncerramentoSuporte(true)
+    }
+
+    const [showModalConfirmaEncerramentoSuporte, setShowModalConfirmaEncerramentoSuporte] = useState(false);
+    const handleNaoConfirmaEncerramentoSuporte = useCallback(() => {
+        setShowModalConfirmaEncerramentoSuporte(false)
+    }, []);
+    const handleConfirmaEncerramentoSuporte = useCallback(() => {
+        // viabilizarAcessoSuporte(getUsuarioLogado().login, {codigo_eol: unidadeSuporteSelecionada.codigo_eol})
+        // setarUnidadeProximoLoginAcessoSuporte(
+        //     unidadeSuporteSelecionada.visao,
+        //     unidadeSuporteSelecionada.uuid,
+        //     unidadeSuporteSelecionada.associacao_uuid,
+        //     unidadeSuporteSelecionada.associacao_nome,
+        //     unidadeSuporteSelecionada.tipo_unidade,
+        //     unidadeSuporteSelecionada.nome
+        // )
+        // authService.logout()
+        setUnidadeEstaEmSuporte(false)
+        setShowModalConfirmaEncerramentoSuporte(false)
+    }, []);
+
+    return (
+        <>
+
+            { unidadeEstaEmSuporte &&
+                barraMensagemCustom.BarraMensagemSucessLaranja(mensagemSuporte, "Encerrar suporte", handleEncerrarSuporte, true)
+            }
+            <section>
+                <ModalConfirmaEncerramentoSuporte
+                    show={showModalConfirmaEncerramentoSuporte}
+                    handleNaoConfirmaEncerramentoSuporte={handleNaoConfirmaEncerramentoSuporte}
+                    handleConfirmaEncerramentoSuporte={handleConfirmaEncerramentoSuporte}
+                />
+            </section>
+        </>
+    );
+}

--- a/src/paginas/PaginasContainer.js
+++ b/src/paginas/PaginasContainer.js
@@ -1,10 +1,11 @@
-import React, {useContext, useEffect, useState} from "react";
+import React, {useCallback, useContext, useEffect, useState} from "react";
 import {SidebarContext} from "../context/Sidebar";
 import {NotificacaoContext} from "../context/Notificacoes";
 import {useHistory} from "react-router-dom";
 import {notificaDevolucaoPCService} from "../services/NotificacaDevolucaoPC.service";
 import { barraMensagemCustom } from "../componentes/Globais/BarraMensagem";
-import {visoesService} from "../services/visoes.service"
+
+import {BarraMensagemUnidadeEmSuporte} from "../componentes/Globais/BarraMensagemUnidadeEmSuporte";
 
 export const PaginasContainer = ({children}) => {
     const history = useHistory();
@@ -16,30 +17,10 @@ export const PaginasContainer = ({children}) => {
         notificaDevolucaoPCService.marcaNotificacaoComoLidaERedirecianaParaVerAcertos(history)
     };
 
-    const mensagemSuporte = "Você está acessando essa unidade em modo de suporte. Use o botão para encerrar o suporte quando concluir."
-    const [unidadeEstaEmSuporte, setUnidadeEstaEmSuporte] = useState(false)
-
-    const verificaSeUnidadeEstaEmSuporte = () => {
-        const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado()
-
-        if (dadosUsuarioLogado) {
-            const unidadeSelecionada = dadosUsuarioLogado.unidades.find(obj => {
-                return obj.uuid === dadosUsuarioLogado.unidade_selecionada.uuid
-            })
-            setUnidadeEstaEmSuporte(unidadeSelecionada.acesso_de_suporte)
-        }
-    }
-
-    useEffect(() => {
-        verificaSeUnidadeEstaEmSuporte()
-    }, []);
-
     return (
         <>
             <div className={`page-content  px-5 pt-0 pb-5 ${!sidebarStatus.sideBarStatus ? "active" : ""}`} id="content">
-                { unidadeEstaEmSuporte &&
-                    barraMensagemCustom.BarraMensagemSucessLaranja(mensagemSuporte, "Encerrar suporte", onVerAcertos, true)
-                }
+                <BarraMensagemUnidadeEmSuporte/>
                 { notificacaoContext.exibeMensagemFixaTemDevolucao &&
                     barraMensagemCustom.BarraMensagemSucessLaranja(mensagem, "Ver acertos", onVerAcertos, true)
                 }

--- a/src/paginas/PaginasContainer.js
+++ b/src/paginas/PaginasContainer.js
@@ -1,24 +1,45 @@
-import React, {useContext} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {SidebarContext} from "../context/Sidebar";
 import {NotificacaoContext} from "../context/Notificacoes";
 import {useHistory} from "react-router-dom";
 import {notificaDevolucaoPCService} from "../services/NotificacaDevolucaoPC.service";
 import { barraMensagemCustom } from "../componentes/Globais/BarraMensagem";
+import {visoesService} from "../services/visoes.service"
 
 export const PaginasContainer = ({children}) => {
     const history = useHistory();
     const sidebarStatus = useContext(SidebarContext);
     const notificacaoContext = useContext(NotificacaoContext);
     const mensagem = `A prestação de contas ${localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")} foi devolvida para acertos pela DRE.`
-
     const onVerAcertos = () => {
         notificacaoContext.setExibeMensagemFixaTemDevolucao(false)
         notificaDevolucaoPCService.marcaNotificacaoComoLidaERedirecianaParaVerAcertos(history)
     };
 
+    const mensagemSuporte = "Você está acessando essa unidade em modo de suporte. Use o botão para encerrar o suporte quando concluir."
+    const [unidadeEstaEmSuporte, setUnidadeEstaEmSuporte] = useState(false)
+
+    const verificaSeUnidadeEstaEmSuporte = () => {
+        const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado()
+
+        if (dadosUsuarioLogado) {
+            const unidadeSelecionada = dadosUsuarioLogado.unidades.find(obj => {
+                return obj.uuid === dadosUsuarioLogado.unidade_selecionada.uuid
+            })
+            setUnidadeEstaEmSuporte(unidadeSelecionada.acesso_de_suporte)
+        }
+    }
+
+    useEffect(() => {
+        verificaSeUnidadeEstaEmSuporte()
+    }, []);
+
     return (
         <>
             <div className={`page-content  px-5 pt-0 pb-5 ${!sidebarStatus.sideBarStatus ? "active" : ""}`} id="content">
+                { unidadeEstaEmSuporte &&
+                    barraMensagemCustom.BarraMensagemSucessLaranja(mensagemSuporte, "Encerrar suporte", onVerAcertos, true)
+                }
                 { notificacaoContext.exibeMensagemFixaTemDevolucao &&
                     barraMensagemCustom.BarraMensagemSucessLaranja(mensagem, "Ver acertos", onVerAcertos, true)
                 }

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -169,3 +169,10 @@ export const getUsuarioLogado = () => {
 export const viabilizarAcessoSuporte = async (usuario, payload) => {
     return (await api.post(`api/usuarios/${usuario}/viabilizar-acesso-suporte/`, payload, authHeaderAuthorization))
 };
+
+export const encerrarAcessoSuporte = async (usuario, unidade_suporte_uuid) => {
+    const payload = {
+        unidade_suporte_uuid: unidade_suporte_uuid
+    }
+    return (await api.post(`api/usuarios/${usuario}/encerrar-acesso-suporte/`, payload, authHeaderAuthorization))
+};


### PR DESCRIPTION
Esse PR:

- [X] Cria barra fixa que é exibida em todas as página enquanto em uma unidade em suporte
- [X] Cria modal de confirmação do botão "Encerrar suporte"
- [X] Implementa comportamento "Encerrar suporte"


História: [AB#62837](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/62837)