### PR TITLE
feat(62837): Suporte às Unidades: Encerrar acesso de suporte - Parte 2

### DIFF
--- a/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
+++ b/src/componentes/Globais/BarraMensagemUnidadeEmSuporte/index.js
@@ -35,10 +35,16 @@ export const BarraMensagemUnidadeEmSuporte = () => {
     }, []);
     const handleConfirmaEncerramentoSuporte = useCallback(() => {
         encerrarAcessoSuporte(dadosUsuarioLogado.usuario_logado.login, dadosUsuarioLogado.unidade_selecionada.uuid)
-        setUnidadeEstaEmSuporte(false)
-        setShowModalConfirmaEncerramentoSuporte(false)
-        localStorage.removeItem('DADOS_USUARIO_LOGADO');
-        authService.logout()
+            .then((result) => {
+                setUnidadeEstaEmSuporte(false)
+                setShowModalConfirmaEncerramentoSuporte(false)
+                localStorage.removeItem('DADOS_USUARIO_LOGADO');
+                authService.logout()
+            })
+            .catch((erro) => {
+                console.error('Erro ao encerrar acesso de suporte.', erro)
+            })
+
     }, []);
 
     return (

--- a/src/componentes/Globais/SuporteAsUnidades/index.js
+++ b/src/componentes/Globais/SuporteAsUnidades/index.js
@@ -24,16 +24,22 @@ export const SuporteAsUnidades = (props) =>{
 
     const handleConfirmaSuporte = useCallback(() => {
         viabilizarAcessoSuporte(getUsuarioLogado().login, {codigo_eol: unidadeSuporteSelecionada.codigo_eol})
-        setarUnidadeProximoLoginAcessoSuporte(
-            unidadeSuporteSelecionada.visao,
-            unidadeSuporteSelecionada.uuid,
-            unidadeSuporteSelecionada.associacao_uuid,
-            unidadeSuporteSelecionada.associacao_nome,
-            unidadeSuporteSelecionada.tipo_unidade,
-            unidadeSuporteSelecionada.nome
-        )
-        authService.logout()
-        setShowModalConfirmaSuporte(false)
+            .then((result) => {
+                setarUnidadeProximoLoginAcessoSuporte(
+                    unidadeSuporteSelecionada.visao,
+                    unidadeSuporteSelecionada.uuid,
+                    unidadeSuporteSelecionada.associacao_uuid,
+                    unidadeSuporteSelecionada.associacao_nome,
+                    unidadeSuporteSelecionada.tipo_unidade,
+                    unidadeSuporteSelecionada.nome
+                )
+                authService.logout()
+                setShowModalConfirmaSuporte(false)
+            })
+            .catch((erro) => {
+                console.error('Erro ao viabilizar acesso de suporte.', erro)
+            })
+
     }, [unidadeSuporteSelecionada]);
 
     const handleSelecaoUnidadeSuporte = useCallback((unidadeSelecionada) => {


### PR DESCRIPTION
Esse PR altera as chamadas a API para iniciar e encerrar o acesso de suporte para só efetivar as alterações no front após API retornar com sucesso.

História AB#62837