### PR TITLE
feat(63307): Geração de ata no momento da publicação

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const TextoDinamicoSuperior = ({dadosAta, retornaDadosAtaFormatado}) => {
+export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado}) => {
     
     return(
         <>

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TopoComBotoes/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TopoComBotoes/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { visoesService } from "../../../../../../services/visoes.service";
 
-export const TopoComBotoes = ({dadosAta, retornaDadosAtaFormatado, handleClickFecharAtaParecerTecnico, handleClickEditarAta, handleClickGerarAta, textoBtnGerar, downloadAtaParecerTecnico}) =>{
+export const TopoComBotoes = ({dadosAta, retornaDadosAtaFormatado, handleClickFecharAtaParecerTecnico, handleClickEditarAta, downloadAtaParecerTecnico}) =>{
     const podeEditarAta = [['change_ata_parecer_tecnico']].some(visoesService.getPermissoes)
 
     return(
@@ -16,20 +16,9 @@ export const TopoComBotoes = ({dadosAta, retornaDadosAtaFormatado, handleClickFe
             </div>
 
             <div className='col-12 col-md-7 align-self-center text-right'>
-                <button onClick={handleClickEditarAta} type="button" disabled={!podeEditarAta || textoBtnGerar() === 'Ata sendo gerada...'} className="btn btn-success mr-2 mt-2"><strong>Editar ata</strong></button>
-                
-                {dadosAta && dadosAta.alterado_em &&
-                    <button 
-                        onClick={handleClickGerarAta} 
-                        type="button" 
-                        disabled={textoBtnGerar() === 'Ata sendo gerada...'} 
-                        className="btn btn-outline-success mr-2 mt-2"
-                    >
-                        <strong>{textoBtnGerar()}</strong>
-                    </button>
-                }
+                <button onClick={handleClickEditarAta} type="button" disabled={!podeEditarAta} className="btn btn-success mr-2 mt-2"><strong>Editar ata</strong></button>
 
-                {dadosAta && dadosAta.arquivo_pdf && textoBtnGerar() !== 'Ata sendo gerada...' &&
+                {dadosAta && dadosAta.arquivo_pdf &&
                     <button 
                         onClick={downloadAtaParecerTecnico} 
                         type="button" 

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
@@ -4,10 +4,9 @@ import { TopoComBotoes } from "./TopoComBotoes";
 import { TextoDinamicoSuperior } from "./TextoDinamicoSuperior";
 import { TabelaAprovadas } from "./TabelaAprovadas";
 import { Assinaturas } from "./Assinaturas";
-import {getAtaParecerTecnico, getInfoContas, getGerarAta, getStatusAta, getDownloadAtaParecerTecnico} from "../../../../../services/dres/AtasParecerTecnico.service";
+import {getAtaParecerTecnico, getInfoContas, getDownloadAtaParecerTecnico} from "../../../../../services/dres/AtasParecerTecnico.service";
 import moment from "moment";
 import Loading from "../../../../../utils/Loading"
-import {toastCustom} from "../../../../Globais/ToastCustom";
 
 moment.updateLocale('pt', {
     months: [
@@ -24,17 +23,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
     const [dadosAta, setDadosAta] = useState({});
     const [infoContas, setInfoContas] = useState([])
     const [loading, setLoading] = useState(true);
-    const [statusAta, setStatusAta] = useState(false);
-
-    useEffect(() => {
-        if (statusAta && statusAta.status_geracao_pdf && statusAta.status_geracao_pdf === "EM_PROCESSAMENTO") {
-            const timer = setInterval(() => {
-                consultarStatus();
-            }, 5000);
-            // clearing interval
-            return () => clearInterval(timer);
-        }
-    }, [statusAta]);
 
     useEffect(() => {
         getDadosAta();
@@ -43,10 +31,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
     useEffect(() => {
         consultaInfoContas();
     }, [dadosAta]);
-
-    useEffect(() => {
-        consultarStatus();
-    },[dadosAta]);
 
     const getDadosAta = async () => {
         let dados_ata = await getAtaParecerTecnico(uuid_ata);
@@ -61,13 +45,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
         }
         
     }
-
-    const consultarStatus = async () => {
-        if (dadosAta && dadosAta.uuid && dadosAta.dre.uuid && dadosAta.periodo.uuid) {
-            let status = await getStatusAta(dadosAta.dre.uuid, dadosAta.periodo.uuid);
-            setStatusAta(status);
-        }
-    };
 
     const dataPorExtenso = (data) => {
         if (!data) {
@@ -182,31 +159,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
         window.location.assign(path)
     }
 
-    const handleClickGerarAta = async () => {
-        try {
-            await getGerarAta(dadosAta.uuid, dadosAta.dre.uuid, dadosAta.periodo.uuid);
-            let mensagem_parte_1 = "Quando a geração for concluída um botão para download ficará"
-            let mensagem_parte_2 = "disponível na área da Ata na página anterior de Relatórios."
-            toastCustom.ToastCustomInfo('Ata sendo gerada', <span>{mensagem_parte_1} <br/> {mensagem_parte_2}</span>)
-            setStatusAta({
-                ...statusAta,
-                status_geracao_pdf: "EM_PROCESSAMENTO"
-            })
-        }
-        catch (e) {
-            console.log('Erro ao gerar ata ', e.response.data);
-        }
-    }
-
-    const textoBtnGerar = () =>{
-        if (statusAta.status_geracao_pdf === 'EM_PROCESSAMENTO'){
-            return 'Ata sendo gerada...'
-        } else{
-            return 'Gerar Ata'
-        }
-    };
-
-
     const downloadAtaParecerTecnico = async () =>{
         await getDownloadAtaParecerTecnico(dadosAta.uuid);
     };
@@ -232,8 +184,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
                             retornaDadosAtaFormatado={retornaDadosAtaFormatado}
                             handleClickFecharAtaParecerTecnico={handleClickFecharAtaParecerTecnico}
                             handleClickEditarAta={handleClickEditarAta}
-                            handleClickGerarAta={handleClickGerarAta}
-                            textoBtnGerar={textoBtnGerar}
                             downloadAtaParecerTecnico={downloadAtaParecerTecnico}
                         />
                     }
@@ -242,7 +192,6 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
                 <div className="col-12">
                     {dadosAta && Object.entries(dadosAta).length > 0 &&
                         <TextoDinamicoSuperior
-                            dadosAta={dadosAta}
                             retornaDadosAtaFormatado={retornaDadosAtaFormatado}
                         />
                     }

--- a/src/services/dres/AtasParecerTecnico.service.js
+++ b/src/services/dres/AtasParecerTecnico.service.js
@@ -24,17 +24,13 @@ export const postEdicaoAtaParecerTecnico = async (ata_uuid, payload) => {
     return (await api.patch(`/api/ata-parecer-tecnico/${ata_uuid}/`, payload, authHeader)).data
 };
 
-export const getGerarAta = async (ata_uuid, dre_uuid, periodo_uuid) => {
-    return (await api.get(`api/ata-parecer-tecnico/gerar-ata-parecer-tecnico/?ata=${ata_uuid}&dre=${dre_uuid}&periodo=${periodo_uuid}`, authHeader)).data
-}
-
 export const getStatusAta = async (dre_uuid, periodo_uuid) => {
     return (await api.get(`api/ata-parecer-tecnico/status-ata/?dre=${dre_uuid}&periodo=${periodo_uuid}`, authHeader)).data
 }
 
 export const getDownloadAtaParecerTecnico = async (ata_uuid) => {
     return api
-    .get(`api/ata-parecer-tecnico/download-ata-parecer-tecnico/?ata=${ata_uuid}`, {
+    .get(`api/consolidados-dre/download-ata-parecer-tecnico/?ata=${ata_uuid}`, {
         responseType: 'blob',
         timeout: 30000,
         headers: {

--- a/src/services/dres/RelatorioConsolidado.service.js
+++ b/src/services/dres/RelatorioConsolidado.service.js
@@ -29,7 +29,7 @@ export const postPublicarConsolidadoDre = async (payload) => {
 
 export const getDownloadRelatorio = async (relatorio_uuid, versao) => {
     return api
-        .get(`/api/consolidados-dre/${relatorio_uuid}/download/`, {
+        .get(`/api/consolidados-dre/${relatorio_uuid}/download-relatorio-consolidado`, {
             responseType: 'blob',
             timeout: 30000,
             headers: {

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -596,3 +596,17 @@ export const ModalConfirmarExportacao = (propriedades) => {
         />
     )
 };
+
+export const ModalAtaNaoPreenchida = (propriedades) => {
+    return (
+        <ModalBootstrap
+            show={propriedades.show}
+            onHide={propriedades.handleClose}
+            titulo="Ata não preenchida"
+            bodyText="Para fazer a publicação você precisa preencher as informações da ata."
+            primeiroBotaoOnclick={propriedades.handleClose}
+            primeiroBotaoTexto="Fechar"
+            primeiroBotaoCss="success"
+        />
+    )
+};


### PR DESCRIPTION
Esse PR:

- Exibe mensagem caso ata não esteja preenchida
- Remove botões de gerar ata
- Refatora componentes da ata
- Altera nome dos endpoints de download da ata e relatorio consolidado
- Remove chamada ao endpoint de gerar ata

História: [AB#63307](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/63307)