### PR TITLE
feat(66366):  Ata de apresentação: Exibir mensagem com os campos que faltam, ao tentar gerar o PDF  de uma ata incompleta

### DIFF
--- a/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
+++ b/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
@@ -45,8 +45,12 @@ export const BoxAtaRetificadora = ({
             getDadosAta()
         }
         catch (e) {
-            const camposInvalidos = e.response.data.campos_invalidos.join(', ');
-            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la preencha os campos ${camposInvalidos}.</p>`)
+            let mensagem = ''
+            let camposInvalidos = e.response.data.campos_invalidos
+            camposInvalidos.map((element) => {
+                mensagem += typeof(element) === 'object' ? ` ${element['msg_presente']}` : ` ${element}, `
+            })
+            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la ${camposInvalidos[0]['msg_presente'] ? mensagem :  `preencha os campo(s) ${mensagem}`}.</p>`.replace(/,(?=[^,]*$)/, '')) // Regex remove espaço em branco e virgula no final. ⮕ (/,(?=[^,]*$)/,) ''
             setShowNaoPodeGerarAta(true)
         }
     }

--- a/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
+++ b/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
@@ -11,7 +11,6 @@ export const BoxAtaRetificadora = ({
                                        onClickVisualizarAta,
                                        uuidPrestacaoConta,
                                        uuidAtaRetificacao,
-                                       gerarAtaRetificadora,
                                        statusPc
 }) => {
     const [dadosAtaRetificadora, setDadosAtaRetificadora] = useState({});
@@ -81,7 +80,6 @@ export const BoxAtaRetificadora = ({
                                     onClick={() => gerar_ata_pdf()}
                                     type="button"
                                     className="btn btn-outline-success float-right mr-2"
-                                    disabled={!uuidAtaRetificacao || !gerarAtaRetificadora}
                                 >
                                     gerar ata
                                 </button>

--- a/src/componentes/escolas/GeracaoAtaRetificadora/index.js
+++ b/src/componentes/escolas/GeracaoAtaRetificadora/index.js
@@ -9,7 +9,6 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
     const [corBoxAtaRetificadora, setCorBoxAtaRetificadora] = useState("");
     const [textoBoxAtaRetificadora, setTextoBoxAtaRetificadora] = useState("");
     const [dataBoxAtaRetificadora, setDataBoxAtaRetificadora] = useState("");
-    const [gerarAtaRetificadora, setGerarAtaRetificadora] = useState(false);
 
     const statusPC = statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status ? statusPrestacaoDeConta.prestacao_contas_status.status_prestacao : ''
 
@@ -26,17 +25,14 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
             if (dados.alterado_em === null){
                 setCorBoxAtaRetificadora("vermelho");
                 setDataBoxAtaRetificadora("Ata não preenchida");
-                setGerarAtaRetificadora(false)
             }
             else if (!dados.completa) {
                 setCorBoxAtaRetificadora("vermelho");
                 setDataBoxAtaRetificadora("Ata incompleta");
-                setGerarAtaRetificadora(false)
             }
             else {
                 setCorBoxAtaRetificadora("verde");
                 setDataBoxAtaRetificadora("Último preenchimento em "+exibeDateTimePT_BR_Ata(dados.alterado_em));
-                setGerarAtaRetificadora(true)
             }
         } catch (e) {
             if (statusPrestacaoDeConta.prestacao_contas_status.status_prestacao === "DEVOLVIDA" || statusPrestacaoDeConta.prestacao_contas_status.status_prestacao === "DEVOLVIDA_RETORNADA") {
@@ -46,17 +42,14 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
                 if (dados.alterado_em === null){
                     setCorBoxAtaRetificadora("vermelho");
                     setDataBoxAtaRetificadora("Ata não preenchida");
-                    setGerarAtaRetificadora(false)
                 }
                 else if (!dados.completa) {
                     setCorBoxAtaRetificadora("vermelho");
                     setDataBoxAtaRetificadora("Ata incompleta");
-                    setGerarAtaRetificadora(false)
                 }
                 else {
                     setCorBoxAtaRetificadora("verde");
                     setDataBoxAtaRetificadora("Último preenchimento em "+exibeDateTimePT_BR_Ata(dados.alterado_em));
-                    setGerarAtaRetificadora(true)
                 }
             }
         }
@@ -75,7 +68,6 @@ export const GeracaoAtaRetificadora = ({uuidPrestacaoConta, statusPrestacaoDeCon
                     onClickVisualizarAta={onClickVisualizarAta}
                     uuidPrestacaoConta={uuidPrestacaoConta}
                     uuidAtaRetificacao={dadosAtaRetificadora ? dadosAtaRetificadora.uuid : ""}
-                    gerarAtaRetificadora={gerarAtaRetificadora}
                     statusPc={statusPC}
                 />
             }

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -7,7 +7,6 @@ import {faDownload} from '@fortawesome/free-solid-svg-icons'
 
 export const GeracaoAtaApresentacao = (
     {
-        gerarAta,
         uuidAtaApresentacao,
         uuidPrestacaoConta,
         corBoxAtaApresentacao,
@@ -89,7 +88,6 @@ export const GeracaoAtaApresentacao = (
                                 onClick={() => gerar_ata_pdf()}
                                 type="button"
                                 className="btn btn-outline-success float-right mr-2"
-                                disabled={!uuidAtaApresentacao || !gerarAta}
                             >
                                 gerar ata
                             </button>

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -48,8 +48,11 @@ export const GeracaoAtaApresentacao = (
             await getDadosAta()
         }
         catch (e) {
-            const camposInvalidos = e.response.data.campos_invalidos.join(', ');
-            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la preencha os campos ${camposInvalidos}.</p>`)
+            let mensagem = ''
+            e.response.data.campos_invalidos.map((element) => {
+                mensagem += typeof(element) === 'object' ? ` ${element['msg_presente']}` : ` ${element} ,`
+            })
+            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la ${mensagem}</p>`)
             setShowNaoPodeGerarAta(true)
         }
     }

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useState} from "react";
 import "../geracao-da-ata.scss"
 import {getGerarAtaPdf, getAtas, getDownloadAtaPdf} from "../../../../services/escolas/AtasAssociacao.service";
+import {ModalNaoPodeGerarAta} from "../ModalNaoPodeGerarAta";
 import Spinner from "../../../../assets/img/spinner.gif";
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import {faDownload} from '@fortawesome/free-solid-svg-icons'
@@ -13,24 +14,24 @@ export const GeracaoAtaApresentacao = (
         textoBoxAtaApresentacao,
         dataBoxAtaApresentacao,
         onClickVisualizarAta,
-        uuidAssociacao,
-        uuidPeriodo,
     }
 ) => {
 
     const [dadosAta, setDadosAta] = useState({});
+    const [showNaoPodeGerarAta, setShowNaoPodeGerarAta] = useState(false);
+    const [textoModalAta, setTextoModalAta] = useState('<p>Você não pode gerar o PDF de uma ata incompleta.</p>');
 
     useEffect(() => {
         if (uuidAtaApresentacao && dadosAta && dadosAta.status_geracao_pdf && dadosAta.status_geracao_pdf === 'EM_PROCESSAMENTO'){
             const timer = setInterval(() => {
-                get_dados_ata();
+                getDadosAta();
             }, 5000);
             // clearing interval
             return () => clearInterval(timer);
         }
     });
 
-    const get_dados_ata = useCallback(async ()=>{
+    const getDadosAta = useCallback(async ()=>{
         if (uuidAtaApresentacao){
             let dados_ata = await getAtas(uuidAtaApresentacao);
             setDadosAta(dados_ata)
@@ -38,17 +39,24 @@ export const GeracaoAtaApresentacao = (
     }, [uuidAtaApresentacao])
 
     useEffect(()=>{
-        get_dados_ata()
-    }, [get_dados_ata])
+        getDadosAta()
+    }, [getDadosAta])
 
-    const gerar_ata_pdf = async () =>{
-        await getGerarAtaPdf(uuidPrestacaoConta, uuidAtaApresentacao)
-        await get_dados_ata()
+    const gerarAta = async () =>{
+        try {
+            await getGerarAtaPdf(uuidPrestacaoConta, uuidAtaApresentacao)
+            await getDadosAta()
+        }
+        catch (e) {
+            const camposInvalidos = e.response.data.campos_invalidos.join(', ');
+            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la preencha os campos ${camposInvalidos}.</p>`)
+            setShowNaoPodeGerarAta(true)
+        }
     }
 
     const download_ata_pdf = async () =>{
         await getDownloadAtaPdf(uuidAtaApresentacao)
-        await get_dados_ata()
+        await getDadosAta()
     }
 
     return (
@@ -80,12 +88,22 @@ export const GeracaoAtaApresentacao = (
                                 }
                             </p>
                         </div>
-
+                        <section>
+                        <ModalNaoPodeGerarAta 
+                            show={showNaoPodeGerarAta}
+                            handleClose={() => { setShowNaoPodeGerarAta(false) }}
+                            setShowNaoPodeGerarAta={setShowNaoPodeGerarAta}
+                            titulo="Campo em ata incompletos"
+                            texto={textoModalAta}
+                            primeiroBotaoTexto="Fechar"
+                            primeiroBotaoCss="outline-success"
+                        />
+                        </section>
                         <div className="col-12 col-md-4 align-self-center">
                             <button onClick={()=>onClickVisualizarAta()}  type="button" className="btn btn-success float-right">{uuidPrestacaoConta ? "Visualizar ata" : "Visualizar prévia da ata"}</button>
                             {uuidPrestacaoConta &&
                             <button
-                                onClick={() => gerar_ata_pdf()}
+                                onClick={() => gerarAta()}
                                 type="button"
                                 className="btn btn-outline-success float-right mr-2"
                             >

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -49,10 +49,12 @@ export const GeracaoAtaApresentacao = (
         }
         catch (e) {
             let mensagem = ''
-            e.response.data.campos_invalidos.map((element) => {
-                mensagem += typeof(element) === 'object' ? ` ${element['msg_presente']}` : ` ${element} ,`
+            let camposInvalidos = e.response.data.campos_invalidos
+            console.log(camposInvalidos.length)
+            camposInvalidos.map((element) => {
+                mensagem += typeof(element) === 'object' ? ` ${element['msg_presente']}` : ` ${element}, `
             })
-            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la ${mensagem}</p>`)
+            setTextoModalAta(`<p>Você não pode gerar o PDF de uma ata incompleta. Para completa-la ${camposInvalidos[0]['msg_presente'] ? mensagem :  `preencha os campo(s) ${mensagem}`}.</p>`.replace(/,(?=[^,]*$)/, '')) // Regex remove espaço em branco e virgula no final. ⮕ (/,(?=[^,]*$)/,) ''
             setShowNaoPodeGerarAta(true)
         }
     }

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -50,7 +50,6 @@ export const GeracaoAtaApresentacao = (
         catch (e) {
             let mensagem = ''
             let camposInvalidos = e.response.data.campos_invalidos
-            console.log(camposInvalidos.length)
             camposInvalidos.map((element) => {
                 mensagem += typeof(element) === 'object' ? ` ${element['msg_presente']}` : ` ${element}, `
             })

--- a/src/componentes/escolas/GeracaoDaAta/ModalNaoPodeGerarAta.js
+++ b/src/componentes/escolas/GeracaoDaAta/ModalNaoPodeGerarAta.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ModalBootstrap } from '../../Globais/ModalBootstrap';
+
+export const ModalNaoPodeGerarAta = (props) => {
+    return (
+        <ModalBootstrap
+        show={props.show}
+        onHide={props.handleClose}
+        titulo={props.titulo}
+        bodyText={props.texto}
+        primeiroBotaoOnclick={()=>props.setShowNaoPodeGerarAta(false)}
+        primeiroBotaoTexto={props.primeiroBotaoTexto}
+        primeiroBotaoCss={props.primeiroBotaoCss}
+        />
+    )
+}

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -31,7 +31,6 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
     const [textoBoxAtaApresentacao, settextoBoxAtaApresentacao] = useState("");
     const [dataBoxAtaApresentacao, setdataBoxAtaApresentacao] = useState("");
     const [uuidAtaApresentacao, setUuidAtaApresentacao] = useState("");
-    const [gerarAta, setGerarAta] = useState(false);
 
     const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
 
@@ -216,16 +215,14 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                 if (data_preenchimento.alterado_em === null){
                     setcorBoxAtaApresentacao("vermelho");
                     setdataBoxAtaApresentacao("Ata não preenchida");
-                    setGerarAta(false)
                 }
                 else if (!data_preenchimento.completa) {
                     setcorBoxAtaApresentacao("vermelho");
                     setdataBoxAtaApresentacao("Ata incompleta");
-                    setGerarAta(false)                }
+                }
                 else {
                     setcorBoxAtaApresentacao("verde");
-                    setdataBoxAtaApresentacao("Último preenchimento em "+exibeDateTimePT_BR_Ata(data_preenchimento.alterado_em));
-                    setGerarAta(true)
+                    setdataBoxAtaApresentacao("Último preenchimento em "+exibeDateTimePT_BR_Ata(data_preenchimento.alterado_em));   
                 }
 
             }catch (e) {
@@ -235,7 +232,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                 setcorBoxAtaApresentacao("vermelho");
                 settextoBoxAtaApresentacao(data_preenchimento.nome);
                 setdataBoxAtaApresentacao("Ata não preenchida");
-                setGerarAta(false)
+
             }
         }
 
@@ -250,11 +247,9 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                     if (data_preenchimento.alterado_em === null) {
                         setcorBoxAtaApresentacao("vermelho");
                         setdataBoxAtaApresentacao("Ata não preenchida");
-                        setGerarAta(false)
                     } else {
                         setcorBoxAtaApresentacao("verde");
                         setdataBoxAtaApresentacao("Último preenchimento em " + exibeDateTimePT_BR_Ata(data_preenchimento.alterado_em));
-                        setGerarAta(true)
                     }
 
                 } catch (e) {
@@ -264,9 +259,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                     setcorBoxAtaApresentacao("vermelho");
                     settextoBoxAtaApresentacao(data_preenchimento.nome);
                     setdataBoxAtaApresentacao("Ata não preenchida");
-                    setGerarAta(false)
                 }
-
 
             }
             setLoading(false);
@@ -387,7 +380,6 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                                             dataBoxAtaApresentacao={dataBoxAtaApresentacao}
                                             uuidAtaApresentacao={uuidAtaApresentacao}
                                             uuidPrestacaoConta={uuidPrestacaoConta}
-                                            gerarAta={gerarAta}
                                         />
 
                                         {localStorage.getItem('uuidPrestacaoConta') && exibeBoxAtaRetificadora() &&


### PR DESCRIPTION
Esse PR:
- [x] Deixa o botão do PDF habilitado
- [x] Exibi mensagem quando houver (Não chamando a geração do PDF)
- [x] Verifica se todos os campos são requiridos, menos o campo de justificativa/comentários. 
- [x] Ser necessário pelo menos 1 presidente e um secretário, para gerar a ata.
- [x] O campo justificativa é somente necessário se houver repasse.

Historia: AB#66366