### PR TITLE
feat(67886) Suporte às unidades: Melhorias na escolha de unidade

### DIFF
--- a/src/componentes/Globais/EscolheUnidade/index.js
+++ b/src/componentes/Globais/EscolheUnidade/index.js
@@ -51,7 +51,7 @@ export const EscolheUnidade = (props) =>{
     };
 
     return(
-        <div>
+        <div style={{paddingTop: "15px"}}>
             <FiltroDeUnidades
                 stateFiltros={stateFiltros}
                 handleSubmitFiltros={handleSubmitFiltros}

--- a/src/componentes/Globais/EscolheUnidade/index.js
+++ b/src/componentes/Globais/EscolheUnidade/index.js
@@ -3,22 +3,37 @@ import {getUnidades} from "../../../services/dres/Unidades.service"
 import {ListaDeUnidades} from "./ListaDeUnidades";
 import Loading from "../../../utils/Loading";
 import {FiltroDeUnidades} from "./FiltroDeUnidades";
+import Img404 from "../../../assets/img/img-404.svg";
+import {MsgImgCentralizada} from "../Mensagens/MsgImgCentralizada";
 
 export const EscolheUnidade = (props) =>{
 
-    const {dre_uuid} = props
+    const {dre_uuid, visao} = props
 
     const initialStateFiltros = {
         nome_ou_codigo: "",
     };
 
+    const mensagemListaVaziaSemFiltroAplicado = 'Use parte do nome ou código EOL para localizar a unidade para qual você deseja viabilizar o acesso de suporte.'
+    const mensagemListaVaziaComFiltroAplicadoDRE = 'Não foi encontrada nenhuma unidade que corresponda ao filtro aplicado. Certifique-se que a unidade procurada é uma unidade subordinada à sua DRE.'
+    const mensagemListaVaziaComFiltroAplicadoSME = 'Não foi encontrada nenhuma unidade que corresponda ao filtro aplicado.'
 
     const [loading, setLoading] = useState(false);
     const [listaUnidades, setListaUnidades] = useState([]);
     const [stateFiltros, setStateFiltros] = useState(initialStateFiltros);
+    const [mensagemListaVazia, setMensagemListaVazia] = useState(mensagemListaVaziaSemFiltroAplicado)
 
     useEffect(()=>{
         carregaListaUnidades();
+    }, [stateFiltros]);
+
+    useEffect( () => {
+        if (stateFiltros.nome_ou_codigo === "") {
+            setMensagemListaVazia(mensagemListaVaziaSemFiltroAplicado);
+        } else {
+            if (visao === 'DRE') setMensagemListaVazia(mensagemListaVaziaComFiltroAplicadoDRE);
+            if (visao === 'SME') setMensagemListaVazia(mensagemListaVaziaComFiltroAplicadoSME);
+        }
     }, [stateFiltros]);
 
     const carregaListaUnidades = async ()=>{
@@ -59,15 +74,22 @@ export const EscolheUnidade = (props) =>{
                 filtroInicial={initialStateFiltros}
             />
 
-            {loading ? (
-                <Loading
-                    corGrafico="black"
-                    corFonte="dark"
-                    marginTop="0"
-                    marginBottom="0"
+            {loading && <Loading corGrafico="black" corFonte="dark" marginTop="0" marginBottom="0"/>}
+
+            {!loading && listaUnidades && listaUnidades.length > 0 &&
+                <ListaDeUnidades
+                    listaUnidades={listaUnidades}
+                    rowsPerPage={10}
+                    acaoAoEscolherUnidade={escolherUnidade}
+                    textoAcaoEscolher={"Viabilizar acesso"}
                 />
-            ) : listaUnidades && listaUnidades.length > 0 ? (<ListaDeUnidades listaUnidades={listaUnidades} rowsPerPage={10}
-                                 acaoAoEscolherUnidade={escolherUnidade} textoAcaoEscolher={"Viabilizar acesso"}/>) : <span> </span>
+            }
+
+            {!loading && (!listaUnidades || listaUnidades.length === 0) &&
+                <MsgImgCentralizada
+                    texto={mensagemListaVazia}
+                    img={Img404}
+                />
             }
 
         </div>

--- a/src/componentes/Globais/SuporteAsUnidades/index.js
+++ b/src/componentes/Globais/SuporteAsUnidades/index.js
@@ -56,7 +56,7 @@ export const SuporteAsUnidades = (props) =>{
         <div>
             <TextoExplicativo visao={visao}/>
             <div className="page-content-inner pt-0">
-                <EscolheUnidade dre_uuid={dreUuid} onSelecionaUnidade={handleSelecaoUnidadeSuporte}/>
+                <EscolheUnidade dre_uuid={dreUuid} onSelecionaUnidade={handleSelecaoUnidadeSuporte} visao={visao}/>
                 <section>
                     <ModalConfirmaInicioSuporte
                         show={showModalConfirmaSuporte}

--- a/src/componentes/Globais/SuporteAsUnidades/index.js
+++ b/src/componentes/Globais/SuporteAsUnidades/index.js
@@ -55,15 +55,17 @@ export const SuporteAsUnidades = (props) =>{
     return(
         <div>
             <TextoExplicativo visao={visao}/>
-            <EscolheUnidade dre_uuid={dreUuid} onSelecionaUnidade={handleSelecaoUnidadeSuporte}/>
-            <section>
-                <ModalConfirmaInicioSuporte
-                    show={showModalConfirmaSuporte}
-                    handleNaoConfirmaSuporte={handleNaoConfirmaSuporte}
-                    handleConfirmaSuporte={handleConfirmaSuporte}
-                    texto={textoConfirmacaoSuporte}
-                />
-            </section>
+            <div className="page-content-inner pt-0">
+                <EscolheUnidade dre_uuid={dreUuid} onSelecionaUnidade={handleSelecaoUnidadeSuporte}/>
+                <section>
+                    <ModalConfirmaInicioSuporte
+                        show={showModalConfirmaSuporte}
+                        handleNaoConfirmaSuporte={handleNaoConfirmaSuporte}
+                        handleConfirmaSuporte={handleConfirmaSuporte}
+                        texto={textoConfirmacaoSuporte}
+                    />
+                </section>
+            </div>
         </div>
 
     )

--- a/src/componentes/Globais/SuporteAsUnidades/suporte-as-unidades.scss
+++ b/src/componentes/Globais/SuporteAsUnidades/suporte-as-unidades.scss
@@ -1,4 +1,5 @@
 .container-texto-explicativo {
-  margin-top: 5px;
-  padding: 0px;
+  background-color: #D3F1F3;
+  padding-top: 16px;
+  padding-bottom: 14px;
 }

--- a/src/paginas/SME/SuporteAsUnidades/index.js
+++ b/src/paginas/SME/SuporteAsUnidades/index.js
@@ -5,10 +5,8 @@ import {SuporteAsUnidades} from "../../../componentes/Globais/SuporteAsUnidades"
 export const SuporteAsUnidadesSme = () =>{
     return (
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Suporte às unidades da SME</h1>
-            <div className="page-content-inner">
-                <SuporteAsUnidades visao={"SME"}/>
-            </div>
+            <h1 className="titulo-itens-painel mt-5 mb-4">Suporte às unidades</h1>
+            <SuporteAsUnidades visao={"SME"}/>
         </PaginasContainer>
     )
 };

--- a/src/paginas/dres/SuporteAsUnidades/index.js
+++ b/src/paginas/dres/SuporteAsUnidades/index.js
@@ -7,9 +7,7 @@ export const SuporteAsUnidadesDre = () =>{
     return (
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Suporte às unidades da DRE</h1>
-            <div className="page-content-inner">
-                <SuporteAsUnidades visao={"DRE"}/>
-            </div>
+            <SuporteAsUnidades visao={"DRE"}/>
         </PaginasContainer>
     )
 };


### PR DESCRIPTION
Esse PR implementa algumas melhorias na página de seleção de unidade para suporte:

- [X] O texto explicativo deve ser apresentado com fundo destacado em azul, como ocorre com os textos do fique de olho;
- [X] Abaixo do filtro, quando não houver nenhum filtro digitado, deve ser apresentada a imagem de "resultado vazio" e texto
- [X] Na visão de SME, quando um filtro resultar em uma lista vazia, deve ser apresentada a imagem de "resultado vazio" e texto
- [X] Na visão de DRE, quando um filtro resultar em uma lista vazia, deve ser apresentada a imagem de "resultado vazio" e texto

História: [AB#67886](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/67886)