### PR TITLE
feat(63315): Geração de prévias dos demonstrativos e ata

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,10 +1,16 @@
 import React from "react";
 
-export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado}) => {
+export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia}) => {
     
     return(
         <>
-            <p className="titulo-texto-dinamico-superior mb-2">ATA DE PARECER TÉCNICO CONCLUSIVO {retornaDadosAtaFormatado("numero_ata")}</p>
+            <p className="titulo-texto-dinamico-superior mb-2">{retornaTituloCorpoAta()} {retornaDadosAtaFormatado("numero_ata")}</p>
+            {ehPrevia() &&
+                <p className="texto-atencao">
+                    Atenção! Essa é apenas uma prévia da ata. As informações aqui exibidas podem mudar até a publicação do relatório consolidado. A ata final só poderá ser criada após a publicação.
+                </p>
+            }
+            
             <p className="texto-dinamico-superior">
                 {retornaDadosAtaFormatado("data_reuniao")}, às {retornaDadosAtaFormatado("hora_reuniao")}, reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de Educação {retornaDadosAtaFormatado("nome_dre")},
                 instituída pela Portaria DRE-{retornaDadosAtaFormatado("nome_dre")} nº {retornaDadosAtaFormatado("numero_portaria")} de {retornaDadosAtaFormatado("data_portaria")}, para análise das prestações de contas dos recursos transferidos pelo

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TopoComBotoes/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TopoComBotoes/index.js
@@ -1,14 +1,21 @@
 import React from "react";
 import { visoesService } from "../../../../../../services/visoes.service";
 
-export const TopoComBotoes = ({dadosAta, retornaDadosAtaFormatado, handleClickFecharAtaParecerTecnico, handleClickEditarAta, downloadAtaParecerTecnico}) =>{
+export const TopoComBotoes = ({
+    dadosAta, 
+    retornaDadosAtaFormatado, 
+    handleClickFecharAtaParecerTecnico, 
+    handleClickEditarAta, 
+    downloadAtaParecerTecnico,
+    retornaTituloCabecalhoAta
+}) =>{
     const podeEditarAta = [['change_ata_parecer_tecnico']].some(visoesService.getPermissoes)
 
     return(
         <>
         <div className="row">
             <div className='col-12 col-md-5 mt-2 align-self-center'>
-                <p className='titulo-visualizacao-da-ata-parecer-tecnico mb-0'>Visualização da ata</p>
+                <p className='titulo-visualizacao-da-ata-parecer-tecnico mb-0'>{retornaTituloCabecalhoAta()}</p>
                 <span className="subtitulo-visualizacao-da-ata-parecer-tecnico">
                     Período {dadosAta.periodo.referencia} - 
                     {retornaDadosAtaFormatado('periodo.data_inicio_realizacao_despesas')} até {retornaDadosAtaFormatado('periodo.data_fim_realizacao_despesas')}

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/ata-parecer-tecnico.scss
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/ata-parecer-tecnico.scss
@@ -53,6 +53,12 @@
     font-size: 16px;
 }
 
+.texto-atencao {
+    color: #42474A;
+    font-size: 16px;
+    font-weight: bold;
+}
+
 .tabela-status-pc tbody:nth-child(odd) {
     background-color: #F3F3F3;
 }

--- a/src/componentes/dres/RelatorioConsolidado/PreviaDocumento.js
+++ b/src/componentes/dres/RelatorioConsolidado/PreviaDocumento.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+const PreviaDocumentos = ({gerarPreviaConsolidadoDre}) => {
+    return(
+        <button onClick={() => gerarPreviaConsolidadoDre()} className="btn btn-outline-success">
+            Prévias
+        </button>   
+    )
+}
+export default PreviaDocumentos

--- a/src/componentes/dres/RelatorioConsolidado/PublicarDocumentos.js
+++ b/src/componentes/dres/RelatorioConsolidado/PublicarDocumentos.js
@@ -1,10 +1,16 @@
 import React, {memo} from "react";
 
-const PublicarDocumentos = ({publicarConsolidadoDre}) => {
-
+const PublicarDocumentos = ({publicarConsolidadoDre, podeGerarPrevia, children}) => {
     return(
         <div className="d-flex bd-highlight align-items-center container-publicar-cabecalho text-dark rounded-top border font-weight-bold">
             <div className="p-2 flex-grow-1 bd-highlight fonte-16">Relatórios</div>
+
+            {podeGerarPrevia() &&
+                <div className="p-2 bd-highlight">
+                    {children}
+                </div>
+            }
+
             <div className="p-2 bd-highlight">
                 <button onClick={() => publicarConsolidadoDre()} className="btn btn btn btn-success">Publicar</button>
             </div>

--- a/src/componentes/dres/RelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/index.js
@@ -6,7 +6,8 @@ import {
     postPublicarConsolidadoDre,
     getConsolidadoDre,
     getTrilhaStatus,
-    getStatusAta
+    getStatusAta,
+    postGerarPreviaConsolidadoDre
 } from "../../../services/dres/RelatorioConsolidado.service";
 import {getPeriodos} from "../../../services/dres/Dashboard.service";
 import {SelectPeriodo} from "./SelectPeriodo";
@@ -25,6 +26,7 @@ import { ModalAtaNaoPreenchida } from "../../../utils/Modais";
 import {
     getDocumentosConsolidadoDre,
 } from "../../../services/dres/RelatorioConsolidado.service";
+import PreviaDocumentos from "./PreviaDocumento";
 
 const RelatorioConsolidado = () => {
 
@@ -221,6 +223,17 @@ const RelatorioConsolidado = () => {
         return trilhaStatus.cards.filter((item) => item.status !== "APROVADA" && item.status !== "REPROVADA")
     }
 
+    const podeGerarPrevia = () => {
+        if(!consolidadoDre){
+            return true;
+        }
+        else if(consolidadoDre && consolidadoDre.versao !== "FINAL"){
+            return true;
+        }
+
+        return false;
+    }
+
     const publicarConsolidadoDre = async () => {
         let payload = {
             dre_uuid: dre_uuid,
@@ -238,6 +251,21 @@ const RelatorioConsolidado = () => {
         }catch (e) {
             console.log("Erro ao publicar Consolidado Dre ", e)
         }
+    }
+
+    const gerarPreviaConsolidadoDre = async () =>{
+        let payload = {
+            dre_uuid: dre_uuid,
+            periodo_uuid: periodoEscolhido
+        }
+
+        try {
+            let previa = await postGerarPreviaConsolidadoDre(payload);
+            setStatusProcessamentoConsolidadoDre(previa.status);
+            setConsolidadoDre(previa);
+        }catch (e) {
+            console.log("Erro ao publicar Prévia Consolidado Dre ", e)
+        } 
     }
 
     return (
@@ -284,7 +312,13 @@ const RelatorioConsolidado = () => {
                                                 <>
                                                     <PublicarDocumentos
                                                         publicarConsolidadoDre={publicarConsolidadoDre}
-                                                    />
+                                                        podeGerarPrevia={podeGerarPrevia}
+                                                    >
+                                                        <PreviaDocumentos
+                                                            gerarPreviaConsolidadoDre={gerarPreviaConsolidadoDre}
+                                                        />
+                                                    </PublicarDocumentos>
+
                                                     <DemonstrativoDaExecucaoFisicoFinanceira
                                                         consolidadoDre={consolidadoDre}
                                                         statusConsolidadoDre={statusConsolidadoDre}

--- a/src/services/dres/RelatorioConsolidado.service.js
+++ b/src/services/dres/RelatorioConsolidado.service.js
@@ -27,6 +27,10 @@ export const postPublicarConsolidadoDre = async (payload) => {
     return (await api.post(`/api/consolidados-dre/publicar/`, payload, authHeader)).data
 };
 
+export const postGerarPreviaConsolidadoDre = async (payload) => {
+    return (await api.post(`/api/consolidados-dre/gerar-previa/`, payload, authHeader)).data
+};
+
 export const getDownloadRelatorio = async (relatorio_uuid, versao) => {
     return api
         .get(`/api/consolidados-dre/${relatorio_uuid}/download-relatorio-consolidado`, {


### PR DESCRIPTION
feat(63315): Geração de prévias dos demonstrativos e ata

Esse PR:

- Adiciona botão para gerar prévia dos demonstrativos
- Adiciona regra para não exibir botão de prévia caso relatório ja esteja publicado
- Realiza chamada a API para iniciar geração da prévia
- Altera component de visualização da ata, informando quando é uma prévia

História: AB#63315
