### PR TITLE
feat(60431): Altera seletor de período do Resumo de Recursos

### DIFF
--- a/src/componentes/Globais/Dashborard/index.js
+++ b/src/componentes/Globais/Dashborard/index.js
@@ -40,8 +40,7 @@ export const Dashboard = () => {
     }, [uuid_associacao]);
 
     const buscaPeriodos = useCallback(async () => {
-        // let periodos = await getPeriodosAteAgoraForaImplantacaoDaAssociacao(uuid_associacao);
-        let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao();
+        let periodos = await getPeriodosAteAgoraForaImplantacaoDaAssociacao(uuid_associacao);
         setSelectPeriodo(periodos[0].uuid)
         setPeriodosAssociacao(periodos);
     }, []);


### PR DESCRIPTION
Esse PR:
- Alterar o seletor de período do resumo de recursos para permitir a escolha de períodos além dos fechados e último em aberto.

História: [AB#60431](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/60431)