### PR TITLE
feat(58241) Prestação de Contas: Justificativa de falta de ajustes em PC devolvida

### DIFF
--- a/src/componentes/Globais/ModalBootstrap/index.js
+++ b/src/componentes/Globais/ModalBootstrap/index.js
@@ -476,3 +476,20 @@ export const ModalBootstrapLegendaInformacao = (propriedades) => {
     )
  
 }
+
+export const ModalBootstrapFormConcluirPeriodo = (propriedades) =>{
+
+    // Os botões de Confirmar e Cancelar estão dentro do próprio form, pois utilizei Formik para validações
+    return (
+        <Fragment>
+            <Modal centered show={propriedades.show} onHide={propriedades.onHide} size='lg'>
+                <Modal.Header>
+                    <Modal.Title>{propriedades.titulo}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {propriedades.bodyText}
+                </Modal.Body>
+            </Modal>
+        </Fragment>
+    )
+};

--- a/src/componentes/escolas/PrestacaoDeContas/ModalConcluirPeriodo.js
+++ b/src/componentes/escolas/PrestacaoDeContas/ModalConcluirPeriodo.js
@@ -8,7 +8,7 @@ export const ModalConcluirPeriodo = (props) =>{
             onHide={props.handleClose}
             titulo={props.titulo}
             bodyText={props.texto}
-            primeiroBotaoOnclick={props.onSalvarTrue}
+            primeiroBotaoOnclick={props.onConcluir}
             primeiroBotaoTexto="Confirmar"
             primeiroBotaoCss="success"
             segundoBotaoOnclick={props.handleClose}

--- a/src/componentes/escolas/PrestacaoDeContas/ModalConcluirPeriodoComPendencias.js
+++ b/src/componentes/escolas/PrestacaoDeContas/ModalConcluirPeriodoComPendencias.js
@@ -1,0 +1,59 @@
+import React from "react";
+import {ModalBootstrapFormConcluirPeriodo} from "../../Globais/ModalBootstrap";
+
+export const ModalConcluirPeriodoComPendencias = (props) => {
+
+    const bodyTextarea = () => {
+        return (
+            <form>
+                <div className='row'>
+
+                    <div className="col-12 mt-2">
+                        <p>Ao concluir a Prestação de Contas, o sistema <strong>bloqueará</strong> o cadastro e a edição de qualquer crédito ou despesa nesse período.
+                            Para conferir as informações cadastradas, sem bloqueio do sistema nesse período, gere um
+                            documento prévio.</p>
+                        <p>Nem todos os acertos solicitados pela DRE foram realizados ou justificados. É necessário que
+                            você informe uma justificativa.</p>
+
+                        <label htmlFor="justificativa">Justificativa:</label>
+                        <textarea
+                            name='justificativa'
+                            value={props.txtJustificativa}
+                            onChange={(e) => props.handleChangeTxtJustificativa(e)}
+                            className="form-control"
+                            placeholder="Informe a justificativa (campo obrigatório)"
+                            rows="3"
+                        />
+                        <br/>
+                        <p>Você confirma a conclusão dessa Prestação de Contas?</p>
+                    </div>
+
+                    <div className='col-12'>
+                        <div className="d-flex justify-content-end pb-3 mt-3">
+                            <button
+                                onClick={props.onConcluir}
+                                type="button"
+                                className="btn btn-success mt-2 mr-2"
+                                disabled={!props.txtJustificativa}
+                            >
+                                Confirmar
+                            </button>
+                            <button onClick={props.handleClose} type="reset"
+                                    className="btn btn btn-danger mt-2 mr-2">Cancelar
+                            </button>
+                        </div>
+                    </div>
+
+                </div>
+            </form>
+        )
+    };
+    return (
+            <ModalBootstrapFormConcluirPeriodo
+                show={props.show}
+                onHide={props.handleClose}
+                titulo={props.titulo}
+                bodyText={bodyTextarea()}
+        />
+    );
+};

--- a/src/componentes/escolas/PrestacaoDeContas/TopoSelectPeriodoBotaoConcluir.js
+++ b/src/componentes/escolas/PrestacaoDeContas/TopoSelectPeriodoBotaoConcluir.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {exibeDataPT_BR} from "../../../utils/ValidacoesAdicionaisFormularios";
-import {visoesService} from "../../../services/visoes.service";
 
 export const TopoSelectPeriodoBotaoConcluir = ({
                                                    periodoPrestacaoDeConta,
@@ -9,9 +8,8 @@ export const TopoSelectPeriodoBotaoConcluir = ({
                                                    retornaObjetoPeriodoPrestacaoDeConta,
                                                    statusPrestacaoDeConta,
                                                    checkCondicaoExibicao,
-                                                   setShow,
-                                                   podeConcluir
-
+                                                   podeConcluir,
+                                                   concluirPeriodo,
                                                }) => {
 
     return (
@@ -62,7 +60,7 @@ export const TopoSelectPeriodoBotaoConcluir = ({
                         }
                     >
                         {checkCondicaoExibicao(periodoPrestacaoDeConta) && statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status && !statusPrestacaoDeConta.prestacao_contas_status.documentos_gerados &&
-                        <button onClick={() => setShow(true)}
+                        <button onClick={concluirPeriodo}
                                 disabled={statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status && statusPrestacaoDeConta.prestacao_contas_status.documentos_gerados}
                                 className='btn btn-success' type="button">Concluir período</button>
                             /*<button onClick={handleClickBtnConcluirPeriodo} disabled={statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status && statusPrestacaoDeConta.prestacao_contas_status.documentos_gerados} className='btn btn-success' type="button">Concluir período</button>*/

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -15,6 +15,7 @@ import {GeracaoAtaApresentacao} from "../GeracaoDaAta/GeracaoAtaApresentacao";
 import {GeracaoAtaRetificadora} from "../GeracaoAtaRetificadora";
 import {exibeDateTimePT_BR_Ata} from "../../../utils/ValidacoesAdicionaisFormularios";
 import {visoesService} from "../../../services/visoes.service";
+import {ModalConcluirPeriodoComPendencias} from "./ModalConcluirPeriodoComPendencias";
 
 export const PrestacaoDeContas = ({setStatusPC}) => {
 
@@ -26,7 +27,8 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
     const [contaPrestacaoDeContas, setContaPrestacaoDeContas] = useState(false);
     const [clickBtnEscolheConta, setClickBtnEscolheConta] = useState({0: true});
     const [loading, setLoading] = useState(true);
-    const [show, setShow] = useState(false);
+    const [showConcluir, setShowConcluir] = useState(false);
+    const [showConcluirComPendencia, setShowConcluirComPendencia] = useState(false);
     const [corBoxAtaApresentacao, setcorBoxAtaApresentacao] = useState("");
     const [textoBoxAtaApresentacao, settextoBoxAtaApresentacao] = useState("");
     const [dataBoxAtaApresentacao, setdataBoxAtaApresentacao] = useState("");
@@ -202,6 +204,19 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
         await setConfBoxAtaApresentacao();
     };
 
+    const handleConcluirPeriodo = () =>{
+        console.log('Handle Concluir', statusPrestacaoDeConta)
+        if (
+            statusPrestacaoDeConta &&
+            statusPrestacaoDeConta.prestacao_contas_status &&
+            statusPrestacaoDeConta.prestacao_contas_status.tem_acertos_pendentes
+        ) {
+            setShowConcluirComPendencia(true)
+        } else {
+            setShowConcluir(true)
+        }
+    }
+
     const setConfBoxAtaApresentacao = async ()=>{
         let uuid_prestacao_de_contas = localStorage.getItem('uuidPrestacaoConta');
         let data_preenchimento;
@@ -273,12 +288,16 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
     };
 
     const onSalvarTrue = () =>{
-        setShow(false);
+        setShowConcluir(false);
         concluirPeriodo();
     };
 
     const onHandleClose = () => {
-        setShow(false);
+        setShowConcluir(false);
+    };
+
+    const onHandleCloseModalConcluirPeriodoComPendencias = () => {
+        setShowConcluirComPendencia(false);
     };
 
     const podeConcluir = [['concluir_periodo_prestacao_contas']].some(visoesService.getPermissoes)
@@ -331,8 +350,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                                 retornaObjetoPeriodoPrestacaoDeConta={retornaObjetoPeriodoPrestacaoDeConta}
                                 statusPrestacaoDeConta={statusPrestacaoDeConta}
                                 checkCondicaoExibicao={checkCondicaoExibicao}
-                                concluirPeriodo={concluirPeriodo}
-                                setShow={setShow}
+                                concluirPeriodo={handleConcluirPeriodo}
                                 podeConcluir={podeConcluir}
                             />
                             {checkCondicaoExibicao(periodoPrestacaoDeConta)  ? (
@@ -398,7 +416,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                     }
                     <section>
                         <ModalConcluirPeriodo
-                            show={show}
+                            show={showConcluir}
                             handleClose={onHandleClose}
                             onSalvarTrue={onSalvarTrue}
                             titulo="Concluir Prestação de Contas"
@@ -406,6 +424,16 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                             o cadastro e a edição de qualquer crédito ou despesa nesse período.
                             Para conferir as informações cadastradas, sem bloqueio do sistema nesse período, gere um documento prévio.
                             Você confirma a conclusão dessa Prestação de Contas?</p>"
+                        />
+                    </section>
+                    <section>
+                        <ModalConcluirPeriodoComPendencias
+                            titulo="Concluir Prestação de Contas com pendências"
+                            txtJustificativa={"teste texto justificativa"}
+                            handleChangeTxtJustificativa={() => {}}
+                            handleClose={onHandleCloseModalConcluirPeriodoComPendencias}
+                            onConcluir={() => {}}
+                            show={showConcluirComPendencia}
                         />
                     </section>
                 </>

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState, Fragment, useCallback} from "react";
 import {TopoSelectPeriodoBotaoConcluir} from "./TopoSelectPeriodoBotaoConcluir";
 import {getPeriodosDePrestacaoDeContasDaAssociacao, getDataPreenchimentoPreviaAta} from "../../../services/escolas/Associacao.service"
-import {getStatusPeriodoPorData, getConcluirPeriodo, getDataPreenchimentoAta, getIniciarAta, getIniciarPreviaAta} from "../../../services/escolas/PrestacaoDeContas.service";
+import {getStatusPeriodoPorData, postConcluirPeriodo, getDataPreenchimentoAta, getIniciarAta, getIniciarPreviaAta} from "../../../services/escolas/PrestacaoDeContas.service";
 import {getTabelasReceita} from "../../../services/escolas/Receitas.service";
 import {BarraDeStatusPrestacaoDeContas} from "./BarraDeStatusPrestacaoDeContas";
 import DemonstrativoFinanceiroPorConta from "./DemonstrativoFinanceiroPorConta";
@@ -195,8 +195,8 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
         return obj && Object.entries(obj).length > 0
     };
 
-    const concluirPeriodo = async () =>{
-        let status_concluir_periodo = await getConcluirPeriodo(periodoPrestacaoDeConta.periodo_uuid);
+    const concluirPeriodo = async (justificativaPendencia='') =>{
+        let status_concluir_periodo = await postConcluirPeriodo(periodoPrestacaoDeConta.periodo_uuid, justificativaPendencia);
         setUuidPrestacaoConta(status_concluir_periodo.uuid);
         let status = await getStatusPeriodoPorData(localStorage.getItem(ASSOCIACAO_UUID), periodoPrestacaoDeConta.data_inicial);
         setStatusPrestacaoDeConta(status);
@@ -206,7 +206,6 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
     };
 
     const handleConcluirPeriodo = () =>{
-        console.log('Handle Concluir', statusPrestacaoDeConta)
         if (
             statusPrestacaoDeConta &&
             statusPrestacaoDeConta.prestacao_contas_status &&
@@ -292,9 +291,14 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
         window.location.assign(`/visualizacao-da-ata/${uuid_ata}`)
     };
 
-    const onSalvarTrue = () =>{
+    const onConcluirSemPendencias = () =>{
         setShowConcluir(false);
         concluirPeriodo();
+    };
+
+    const onConcluirComPendencias = () =>{
+        setShowConcluirComPendencia(false);
+        concluirPeriodo(txtJustificativa);
     };
 
     const onHandleClose = () => {
@@ -423,7 +427,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                         <ModalConcluirPeriodo
                             show={showConcluir}
                             handleClose={onHandleClose}
-                            onSalvarTrue={onSalvarTrue}
+                            onConcluir={onConcluirSemPendencias}
                             titulo="Concluir Prestação de Contas"
                             texto="<p>Ao concluir a Prestação de Contas, o sistema <strong>bloqueará</strong> 
                             o cadastro e a edição de qualquer crédito ou despesa nesse período.
@@ -437,7 +441,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                             txtJustificativa={txtJustificativa}
                             handleChangeTxtJustificativa={handleChangeTxtJustificativa}
                             handleClose={onHandleCloseModalConcluirPeriodoComPendencias}
-                            onConcluir={() => {}}
+                            onConcluir={onConcluirComPendencias}
                             show={showConcluirComPendencia}
                         />
                     </section>

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -33,6 +33,7 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
     const [textoBoxAtaApresentacao, settextoBoxAtaApresentacao] = useState("");
     const [dataBoxAtaApresentacao, setdataBoxAtaApresentacao] = useState("");
     const [uuidAtaApresentacao, setUuidAtaApresentacao] = useState("");
+    const [txtJustificativa, setTxtJustificativa] = useState('');
 
     const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
 
@@ -216,6 +217,10 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
             setShowConcluir(true)
         }
     }
+
+    const handleChangeTxtJustificativa = (event) =>{
+        setTxtJustificativa(event.target.value)
+    };
 
     const setConfBoxAtaApresentacao = async ()=>{
         let uuid_prestacao_de_contas = localStorage.getItem('uuidPrestacaoConta');
@@ -429,8 +434,8 @@ export const PrestacaoDeContas = ({setStatusPC}) => {
                     <section>
                         <ModalConcluirPeriodoComPendencias
                             titulo="Concluir Prestação de Contas com pendências"
-                            txtJustificativa={"teste texto justificativa"}
-                            handleChangeTxtJustificativa={() => {}}
+                            txtJustificativa={txtJustificativa}
+                            handleChangeTxtJustificativa={handleChangeTxtJustificativa}
                             handleClose={onHandleCloseModalConcluirPeriodoComPendencias}
                             onConcluir={() => {}}
                             show={showConcluirComPendencia}

--- a/src/services/escolas/PrestacaoDeContas.service.js
+++ b/src/services/escolas/PrestacaoDeContas.service.js
@@ -13,8 +13,11 @@ export const getStatusPeriodoPorData = async (uuid_associacao, data_incial_perio
   return(await api.get(`/api/associacoes/${uuid_associacao}/status-periodo/?data=${data_incial_periodo}`, authHeader)).data
 };
 
-export const getConcluirPeriodo = async (periodo_uuid) => {
-  return(await api.post(`/api/prestacoes-contas/concluir/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}&periodo_uuid=${periodo_uuid}`, {}, authHeader)).data
+export const postConcluirPeriodo = async (periodo_uuid, justificativaPendencia='') => {
+  const payLoad = {
+      justificativa_acertos_pendentes: justificativaPendencia,
+  }
+  return(await api.post(`/api/prestacoes-contas/concluir/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}&periodo_uuid=${periodo_uuid}`, payLoad, authHeader)).data
 };
 
 


### PR DESCRIPTION
Esse PR:

- [X] Altera apresentação do modal de confirmação de conclusão de PC para exibir um modal diferente para PCs com solicitações de acertos pendentes
- [X] Implementa digitação de justificativa no modal de PC com pendências
- [X] Altera a chamada do endpoint de conclusão para passar a justificativa (quando for o caso)

História: AB#58241