### PR TITLE
feat(58248): Acompanhamento de PC: Ver justificativa de falta de ajustes em PC retornada após acertos

### DIFF
--- a/src/componentes/Globais/CardsDevolucoesParaAcertoDaDre/index.js
+++ b/src/componentes/Globais/CardsDevolucoesParaAcertoDaDre/index.js
@@ -21,9 +21,10 @@ const CardsDevolucoesParaAcertoDaDre = ({prestacao_conta_uuid, analiseAtualUuid=
 
                 if (analises_pc_devolvidas && analises_pc_devolvidas.length > 0) {
                     let unis = analises_pc_devolvidas.map((analise, index) => {
+                        let data_formatada = analise && analise.devolucao_prestacao_conta && analise.devolucao_prestacao_conta.data ? exibeDataPT_BR(analise.devolucao_prestacao_conta.data) : ""
                         return {
                             ...analise,
-                            label_formatada: retornaNumeroOrdinal(index) + ' devolução ' + exibeDataPT_BR(analise.devolucao_prestacao_conta.data),
+                            label_formatada: retornaNumeroOrdinal(index) + ' devolução ' + data_formatada,
                             versao_da_devolucao: retornaNumeroOrdinal(index)
                         }
                     })

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -11,6 +11,7 @@ import DevolucaoParaAcertos from "./DevolucaoParaAcertos";
 import {BotaoSalvarRodape} from "./BotaoSalvarRodape";
 import ConferenciaDeDocumentos from "./ConferenciaDeDocumentos";
 import DevolutivaDaAssociacao from "./DevolutivaDaAssociacao";
+import JustificativaDeFaltaDeAjustes from "./JustificativaDeFaltaDeAjustes";
 
 
 export const GetComportamentoPorStatus = (
@@ -351,7 +352,9 @@ export const GetComportamentoPorStatus = (
                         dataRecebimentoDevolutiva={dataRecebimentoDevolutiva}
                         handleChangedataRecebimentoDevolutiva={handleChangedataRecebimentoDevolutiva}
                     />
-
+                    <JustificativaDeFaltaDeAjustes
+                        prestacaoDeContas={prestacaoDeContas}
+                    />
                     <InformacoesPrestacaoDeContas
                         handleChangeFormInformacoesPrestacaoDeContas={handleChangeFormInformacoesPrestacaoDeContas}
                         informacoesPrestacaoDeContas={informacoesPrestacaoDeContas}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/JustificativaDeFaltaDeAjustes.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/JustificativaDeFaltaDeAjustes.js
@@ -1,0 +1,16 @@
+import React, {memo} from "react";
+
+const JustificativaDeFaltaDeAjustes = ({prestacaoDeContas}) =>{
+    return(
+        <>
+            {prestacaoDeContas && prestacaoDeContas.justificativa_pendencia_realizacao &&
+                <div className='mt-3 mb-3'>
+                    <p className='mb-2 fonte-16'><strong>Justificativa de falta de ajustes da Associação:</strong></p>
+                    <p className='mb-0'>{prestacaoDeContas.justificativa_pendencia_realizacao}</p>
+                </div>
+            }
+        </>
+    )
+}
+
+export default memo(JustificativaDeFaltaDeAjustes)


### PR DESCRIPTION
Esse PR:

- Exibe Justificativa de Falta de Ajustes em PC 
- Trata quando não existe data de devolução em CardsDevolucoesParaAcertoDaDre

História: [AB#58248](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/58248)