### PR TITLE
feat(67647): Reabertura seletiva, exclusao de credito

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -595,7 +595,7 @@ export const CadastroFormFormik = ({
                                                             </div>
                                                             <div className="bd-highlight">
                                                                 <div className="d-flex justify-content-start">
-                                                                    {rateio && rateio.uuid && (
+                                                                    {rateio && rateio.uuid && !aux.origemAnaliseLancamento(parametroLocation) && (
                                                                         rateio.estorno && rateio.estorno.uuid
                                                                             ?
                                                                             <Link

--- a/src/componentes/escolas/Receitas/CancelarModalReceitas.js
+++ b/src/componentes/escolas/Receitas/CancelarModalReceitas.js
@@ -6,7 +6,7 @@ export const CancelarModalReceitas = (propriedades) =>{
         <ModalBootstrap
             show={propriedades.show}
             onHide={propriedades.handleClose}
-            titulo={propriedades.uuid ? 'Deseja cancelar as alterações feitas no crédito?' :'Deseja cancelar a inclusão de crédito?'}
+            titulo={propriedades.titulo}
             bodyText=""
             primeiroBotaoOnclick={propriedades.onCancelarTrue}
             primeiroBotaoTexto="OK"

--- a/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
+++ b/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
@@ -68,6 +68,9 @@ export const ReceitaFormFormik = ({
                                       txtOutrosMotivosEstorno,
                                       handleChangeCheckBoxOutrosMotivosEstorno,
                                       handleChangeTxtOutrosMotivosEstorno,
+                                      readOnlyReaberturaSeletiva,
+                                      ehOperacaoExclusaoReaberturaSeletiva,
+                                      origemAnaliseLancamento
                                   }) => {
 
     return (
@@ -141,7 +144,7 @@ export const ReceitaFormFormik = ({
                                                 <select
                                                     id="detalhe_tipo_receita"
                                                     name="detalhe_tipo_receita"
-                                                    //disabled={readOnlyEstorno || readOnlyCampos || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                                    disabled={readOnlyReaberturaSeletiva}
                                                     value={props.values.detalhe_tipo_receita ? props.values.detalhe_tipo_receita.id : ""}
                                                     onChange={(e) => {
                                                         props.handleChange(e);
@@ -219,7 +222,7 @@ export const ReceitaFormFormik = ({
                                         value={values.data}
                                         onChange={setFieldValue}
                                         onBlur={props.handleBlur}
-                                        disabled={![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                        disabled={readOnlyReaberturaSeletiva || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
                                         maxDate={new Date()}
                                     />
                                     {props.touched.data && props.errors.data &&
@@ -331,7 +334,7 @@ export const ReceitaFormFormik = ({
 
                             {/*Botões*/}
                             <div className="d-flex justify-content-end pb-3" style={{marginTop: '60px'}}>
-                                {showEditarSaida &&
+                                {showEditarSaida && !origemAnaliseLancamento() &&
                                     <button
                                         type="submit"
                                         onClick={() => {
@@ -343,7 +346,7 @@ export const ReceitaFormFormik = ({
                                         Editar saída
                                     </button>
                                 }
-                                {showCadastrarSaida && !showEditarSaida ?
+                                {showCadastrarSaida && !showEditarSaida && !origemAnaliseLancamento() ?
                                     <button
                                         type="submit"
                                         onClick={() => {
@@ -362,7 +365,7 @@ export const ReceitaFormFormik = ({
                                 >
                                     Voltar
                                 </button>
-                                {uuid && despesa && despesa.uuid &&
+                                {uuid && despesa && despesa.uuid && !origemAnaliseLancamento() &&
                                     <Link
                                         to={`/edicao-de-despesa/${despesa.uuid}`}
                                         className="btn btn btn-outline-success mt-2 mr-2"
@@ -382,14 +385,17 @@ export const ReceitaFormFormik = ({
                                     </button> :
                                     null
                                 }
-                                <button
-                                    onClick={(e) => servicoDeVerificacoes(e, values, errors)}
-                                    disabled={readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
-                                    type="submit"
-                                    className="btn btn-success mt-2"
-                                >
-                                    Salvar
-                                </button>
+
+                                {!ehOperacaoExclusaoReaberturaSeletiva() &&
+                                    <button
+                                        onClick={(e) => servicoDeVerificacoes(e, values, errors)}
+                                        disabled={readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                        type="submit"
+                                        className="btn btn-success mt-2"
+                                    >
+                                        Salvar
+                                    </button>
+                                }
 
                             </div>
                             {/*Fim Botões*/}

--- a/src/services/escolas/Receitas.service.js
+++ b/src/services/escolas/Receitas.service.js
@@ -20,8 +20,9 @@ export const getTabelasReceita = async () => {
         });
 };
 
-export const getTabelasReceitaReceita = async () => {
-    return (await api.get(`api/receitas/tabelas/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, authHeader)).data
+export const getTabelasReceitaReceita = async (associacao=null) => {
+    let associacao_uuid = associacao ? associacao : localStorage.getItem(ASSOCIACAO_UUID);
+    return (await api.get(`api/receitas/tabelas/?associacao_uuid=${associacao_uuid}`, authHeader)).data
 };
 
 
@@ -36,9 +37,11 @@ export const criarReceita = async payload => {
         });
 };
 
-export const getReceita = async (uuid) => {
+export const getReceita = async (uuid, associacao=null) => {
+    let associacao_uuid = associacao ? associacao : localStorage.getItem(ASSOCIACAO_UUID)
+
     return api
-        .get(`api/receitas/${uuid}/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, authHeader)
+        .get(`api/receitas/${uuid}/?associacao_uuid=${associacao_uuid}`, authHeader)
         .then(response => {
             return response;
         })
@@ -92,4 +95,8 @@ export const getPeriodoFechadoReceita = async (palavra, aplicacao_recurso, acao_
 
 export const getListaMotivosEstorno = async () => {
     return (await api.get(`/api/motivos-estorno/`, authHeader)).data
+};
+
+export const marcarLancamentoExcluido = async (uuid_analise_lancamento) => {
+    return (await api.post(`/api/analises-lancamento-prestacao-conta/${uuid_analise_lancamento}/marcar-lancamento-excluido/`, {}, authHeader)).data
 };

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -112,6 +112,19 @@ export const AvisoTipoReceita = (propriedades) => {
     )
 };
 
+export const AvisoTipoReceitaEstorno = (propriedades) => {
+    return (
+        <ModalBootstrap
+            show={propriedades.show}
+            onHide={propriedades.handleClose}
+            titulo="Exclusão não permitida"
+            bodyText={`<p>${propriedades.texto}</p>`}
+            primeiroBotaoOnclick={propriedades.handleClose}
+            primeiroBotaoTexto="Ok"
+        />
+    )
+};
+
 export const RedirectModalTabelaLancamentos = (propriedades) => {
     return (
         <ModalBootstrap


### PR DESCRIPTION
feat(67647): Reabertura seletiva, exclusao de credito

Esse PR:

- Permite acessar formulario de receitas a partir da analise de acertos
- Remove validação de periodo fechado quando acessado pela analise
- Esconde botão de salvar quando exclusao
- Permite acessar formulario de receitar a partir da analise de acertos pela DRE
- Adiciona chamada de API para marcar lancamento como excluido

História: [AB#67647](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/67647)