### PR TITLE
feature(72442) Adiciona mensagem de inativa em row expansivo.

### DIFF
--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -7,7 +7,7 @@
   line-height: 24px;
   color: #FFFFFF;
   border-radius: 4px;
-  @if $barra-mensagem-info-inativa {
+  @if 'barra-mensagem-info-inativa' {
     margin-top: 16px !important;
   }@else {
     margin-top: 32px !important;

--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -7,7 +7,15 @@
   line-height: 24px;
   color: #FFFFFF;
   border-radius: 4px;
-  margin-top: 32px !important;
+  @if $barra-mensagem-info-inativa {
+    margin-top: 16px !important;
+  }@else {
+    margin-top: 32px !important;
+  }
+}
+
+.barra-mensagem-info-inativa {
+  background-color: #B40C02;
 }
 
 .btn-barra-mensagem{
@@ -31,4 +39,8 @@
 
 .sucess-laranja {
   color: #EAAA5E !important
+}
+
+.info-branco {
+  color: #FFFFFF !important
 }

--- a/src/componentes/Globais/BarraMensagem/index.js
+++ b/src/componentes/Globais/BarraMensagem/index.js
@@ -1,21 +1,21 @@
 import React from "react";
 import "./barraMensagem.scss"
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faExclamationCircle} from "@fortawesome/free-solid-svg-icons";
+import {faExclamationCircle, faInfoCircle} from "@fortawesome/free-solid-svg-icons";
 
 
 const BarraMensagemCustom = (mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone) => {
     
     return (
         <>
-            <div className={`col-12 mt-3 barra-mensagem d-flex`}>
+            <div className={`col-12 mt-3 barra-mensagem d-flex ${tipo === 'info-branco' ? 'barra-mensagem-info-inativa' : ''}`}>
                 <div className='col-auto align-self-center'>
                     <FontAwesomeIcon className={`icone-alert-barra-mensagem ${tipo}`}
                         icon={icone}
                     />
                 </div>
                 <div className="flex-grow-1 bd-highlight align-self-center">
-                    <p className="mb-0">{mensagem}</p>
+                    <p className="mb-0">{tipo === 'info-branco' ? <strong> {mensagem}</strong> : mensagem}</p>
                 </div>
                 <div className="bd-highlight">
                     { mostraBotao
@@ -45,8 +45,14 @@ const BarraMensagemSucessLaranja = (mensagem, textoBotao, handleClickBotao, most
     return BarraMensagemCustom(mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone)
 }
 
+const BarraMensagemSucessVermelho = (mensagem, textoBotao, handleClickBotao, mostraBotao, tipo='info-branco', icone=faInfoCircle) =>{
+    return BarraMensagemCustom(mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone)
+}
+
+
 export const barraMensagemCustom = {
     BarraMensagemSucessAzul,
-    BarraMensagemSucessLaranja
+    BarraMensagemSucessLaranja,
+    BarraMensagemSucessVermelho
 }
 

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
@@ -343,6 +343,13 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
             const salvarDesabilitadosEsclarecimento = !txtEsclarecimentoLancamento?.[data.analise_lancamento.uuid] || txtEsclarecimentoLancamento?.[data.analise_lancamento.uuid] === data.analise_lancamento.esclarecimentos || showSalvarEsclarecimento?.[data.analise_lancamento.uuid]
             return (
                 <>
+                    {data.documento_mestre.mensagem_inativa &&
+                    <div className='row'>
+                            <div className='col-12 p-1 px-4 py-1'>
+                            {barraMensagemCustom.BarraMensagemSucessVermelho(data.documento_mestre.mensagem_inativa)}
+                            </div>
+                    </div>
+                    }
                     {data.analise_lancamento.justificativa?.length > 0 && (
                         <Fragment>
                             <div className="row">


### PR DESCRIPTION
Esse PR:

- [x] Nos lançamentos de tipo crédito que estejam inativos, deve ser apresentada, no topo da área de detalhes (expansão), uma tarja vermelha fixa com a mensagem "Este crédito foi desativado em DD/MM/AAAA HH:MM:SS."

- [x] Nos lançamentos de tipo gasto que estejam inativos, deve ser apresentada, no topo da área de detalhes (expansão), uma tarja vermelha fixa com a mensagem "Este gasto foi desativado em DD/MM/AAAA HH:MM:SS."

História: [AB#72442](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/72442)
