### PR TITLE
Feat(73292) dre lancamentos inativos front

### DIFF
--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -8,7 +8,7 @@
   color: #FFFFFF;
   border-radius: 4px;
   @if 'barra-mensagem-info-inativa' {
-    margin-top: 16px !important;
+    margin-top: 10px !important;
   }@else {
     margin-top: 32px !important;
   }

--- a/src/componentes/Globais/ModalBootstrap/index.js
+++ b/src/componentes/Globais/ModalBootstrap/index.js
@@ -423,7 +423,8 @@ export const ModalBootstrapLegendaInformacao = (propriedades) => {
         2: 'tag-darkblue',
         3: 'tag-orange',
         4: 'tag-green',
-        5: 'tag-blank'
+        5: 'tag-blank',
+        6: 'tag-red-white'
     }
 
     const handleTagInformacao = useCallback(async () => {

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
@@ -636,7 +636,7 @@ const TabelaConferenciaDeLancamentos = ({
                             header='Informações'
                             className="align-middle text-left borda-coluna"
                             body={tagInformacao}
-                            style={{width: '12%'}}/>
+                            style={{width: '15%'}}/>
                         <Column
                             field='valor_transacao_total'
                             header='Valor (R$)'

--- a/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/scss/tagInformacaoTemplate.scss
+++ b/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/scss/tagInformacaoTemplate.scss
@@ -26,10 +26,16 @@
     background-color: #198459
 }
 
-.tag-blank{
+.tag-blank {
     border: 2px solid #198459;
     color: #198459;
     background: inherit;
+}
+
+.tag-red-white{
+    border: 2px solid #B40C02;
+    color: #fafafa;
+    background: #B40C02;
 }
 
 #vinculo-atividade + span {

--- a/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useRowExpansionDespesaTemplate.js
+++ b/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useRowExpansionDespesaTemplate.js
@@ -7,6 +7,7 @@ import useConferidoRateioTemplate from "./useConferidoRateioTemplate";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faInfoCircle} from "@fortawesome/free-solid-svg-icons";
 import ReactTooltip from "react-tooltip";
+import { barraMensagemCustom } from "./../../../../componentes/Globais/BarraMensagem";
 import './scss/rowExpansionTable.scss';
 
 
@@ -37,6 +38,13 @@ const useRowExpansionDespesaTemplate = (prestacaoDeContas) =>{
     return (data) => {
         return (
             <div className='col-12 px-4 py-2'>
+                {data.documento_mestre.mensagem_inativa &&
+                    <div className='row'>
+                            <div className='col-12 p-1 px-1'>
+                            {barraMensagemCustom.BarraMensagemSucessVermelho(data.documento_mestre.mensagem_inativa)}
+                            </div>
+                    </div>
+                    }
                 <div className='row'>
                     <div className='col border'>
                         <p className='mt-2 mb-0'><strong>CNPJ / CPF</strong></p>

--- a/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useRowExpansionReceitaTemplate.js
+++ b/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useRowExpansionReceitaTemplate.js
@@ -1,15 +1,22 @@
 import React from "react";
 import {useCarregaTabelaReceita} from "../../../Globais/useCarregaTabelaReceita";
+import { barraMensagemCustom } from "./../../../../componentes/Globais/BarraMensagem";
 import './scss/rowExpansionTable.scss';
 
 
 const useRowExpansionDespesaTemplate = (prestacaoDeContas) =>{
 
     const tabelaReceita = useCarregaTabelaReceita()
-
     return (data) => {
         return (
             <div className='col-12 px-4 py-2'>
+                {data.documento_mestre.mensagem_inativa &&
+                    <div className='row'>
+                            <div className='col-12 p-1 px-1'>
+                            {barraMensagemCustom.BarraMensagemSucessVermelho(data.documento_mestre.mensagem_inativa)}
+                            </div>
+                    </div>
+                    }
                 <div className='row'>
                     <div className='col-4 border'>
                         <p className='mt-2 mb-0'><strong>Detalhamento do crédito</strong></p>

--- a/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useTagInformacaoTemplate.js
+++ b/src/hooks/dres/PrestacaoDeContas/ConferenciaDeLancamentos/useTagInformacaoTemplate.js
@@ -7,7 +7,8 @@ const types = {
     2: 'tag-darkblue',
     3: 'tag-orange',
     4: 'tag-green',
-    5: 'tag-blank'
+    5: 'tag-blank',
+    6: 'tag-red-white'
 }
 
 function useTagInformacaoTemplate (){


### PR DESCRIPTION
Esse PR:

- [x] Nos lançamentos de tipo crédito que estejam inativos, deve ser apresentada, no topo da área de detalhes (expansão), uma tarja vermelha fixa com a mensagem "Este crédito foi inativado em DD/MM/AAAA HH:MM:SS."

- [x] Nos lançamentos de tipo gasto que estejam inativos, deve ser apresentada, no topo da área de detalhes (expansão), uma tarja vermelha fixa com a mensagem "Este gasto foi inativado em DD/MM/AAAA HH:MM:SS."

- [x] Estilizar Exibição da nova tag em fundo vermelho e letras brancas

- [x] No quadro de legenda estilizar a nova tag

História: [AB#73292](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/73292)