### PR TITLE
feat(67652) Reabertura seletiva, inclusão de gasto

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -308,6 +308,9 @@ export const CadastroFormFormik = ({
                                         {props.errors.data_transacao &&
                                             <span
                                                 className="span_erro text-danger mt-1"> {props.errors.data_transacao}</span>}
+                                        {formErrors.data_transacao &&
+                                            <span
+                                                className="span_erro text-danger mt-1"> {formErrors.data_transacao}</span>}
                                     </div>
 
                                     <div className="col-12 col-md-3 mt-4">
@@ -809,7 +812,7 @@ export const CadastroFormFormik = ({
                                             className="btn btn btn-outline-success mt-2 mr-2">Voltar
                                     </button>
 
-                                    {despesaContext.idDespesa && !aux.ehOperacaoAtualizacao(parametroLocation)
+                                    {aux.mostraBotaoDeletar(despesaContext.idDespesa, parametroLocation)
                                         ? 
                                             <button
                                                 disabled={readOnlyBtnAcao || !visoesService.getPermissoes(["delete_despesa"])}

--- a/src/componentes/escolas/Despesas/metodosAuxiliares.js
+++ b/src/componentes/escolas/Despesas/metodosAuxiliares.js
@@ -381,6 +381,26 @@ const bloqueiaCamposDespesaImposto = (parametroLocation, setReadOnlyCamposImpost
     }
 }
 
+const mostraBotaoDeletar = (idDespesa, parametroLocation) => {
+    if(origemAnaliseLancamento(parametroLocation)){
+        if(ehOperacaoExclusao(parametroLocation)){
+            return true;
+        }
+        else{
+            return false;
+        }
+
+    }
+    else{
+        if(idDespesa){
+            return true;
+        }
+        else{
+            return false;
+        }
+    }
+}
+
 
 
 export const metodosAuxiliares = {
@@ -411,5 +431,6 @@ export const metodosAuxiliares = {
     ehOperacaoAtualizacao,
     ehOperacaoExclusao,
     bloqueiaCamposDespesaPrincipal,
-    bloqueiaCamposDespesaImposto
+    bloqueiaCamposDespesaImposto,
+    mostraBotaoDeletar
 };

--- a/src/services/escolas/Despesas.service.js
+++ b/src/services/escolas/Despesas.service.js
@@ -112,3 +112,7 @@ export const marcarLancamentoAtualizado = async (uuid_analise_lancamento) => {
 export const marcarLancamentoExcluido = async (uuid_analise_lancamento) => {
     return (await api.post(`/api/analises-lancamento-prestacao-conta/${uuid_analise_lancamento}/marcar-lancamento-excluido/`, {}, authHeader)).data
 };
+
+export const marcarGastoIncluido = async (uuid_analise_documento, payload) => {
+    return (await api.post(`/api/analises-documento-prestacao-conta/${uuid_analise_documento}/marcar-como-gasto-incluido/`, payload, authHeader)).data
+};

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -425,6 +425,20 @@ export const PeriodoFechadoImposto = (propriedades) => {
     )
 };
 
+export const DespesaIncompletaNaoPermitida = (propriedades) => {
+    return (
+        <ModalBootstrap
+            show={propriedades.show}
+            onHide={propriedades.handleClose}
+            titulo="Despesa incompleta"
+            bodyText="Não é possível cadastrar uma despesa incompleta através de uma solicitação de inclusão ou ajuste da DRE."
+            primeiroBotaoOnclick={propriedades.handleClose}
+            primeiroBotaoTexto="Fechar"
+            primeiroBotaoCss="success"
+        />
+    )
+};
+
 export const ExcluirImposto = (propriedades) => {
     return (
         <ModalBootstrap


### PR DESCRIPTION
feat(67652) Reabertura seletiva, inclusão de gasto

Esse PR:

- Altera formulario de gasto para permitir inclusao de gasto mesmo com periodo fechado
- Adiciona chamada a API para marcar inclusao de um gasto no ajuste do documento
- Adiciona regra para não permitir inclusão de gasto incompleto quando feito pelo ajuste do documento
- Adiciona modal de aviso para despesa incompleta

História: [AB#67652](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/67652)