### PR TITLE
fix(74773): Corrige página dev. tesouro vazia em ata retificação

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/DevolucoesAoTesouro/InformacoesDevolucaoAoTesouro.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/DevolucoesAoTesouro/InformacoesDevolucaoAoTesouro.js
@@ -30,7 +30,7 @@ export const InformacoesDevolucaoAoTesouro = ({formRef, informacoesPrestacaoDeCo
                         <tr key="xxx">
                             <td>{despesa.nome_fornecedor}</td>
                             <td>{despesa.cpf_cnpj_fornecedor}</td>
-                            <td>{despesa.tipo_documento.nome}</td>
+                            <td>{despesa.tipo_documento?.nome}</td>
                             <td>{despesa.numero_documento}</td>
                             <td>{despesa.data_documento ? exibeDataPT_BR(despesa.data_documento) : ''}</td>
                             <td>{valor_devolucao ? valor_devolucao : ''}</td>


### PR DESCRIPTION
Corrige o bug que ocorria ao clicar-se no botão devoluções ao tesouro da ata de retificação quando a devolução ao tesouro estava relacionada a uma despesa sem comprovação e que não tinha um tipo de documento definido.