### PR TITLE
feat(74825): Marcar documentos como corretos

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/FormularioAcertos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/FormularioAcertos.js
@@ -2,9 +2,9 @@ import React, {memo} from "react";
 import {FieldArray, Formik} from "formik";
 import {YupSignupSchemaDetalharAcertosDocumentos} from './YupSignupSchemaDetalharAcertosDocumentos'
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faTimesCircle, faExclamationCircle} from "@fortawesome/free-solid-svg-icons";
+import {faTimesCircle, faExclamationCircle, faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 
-const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, tiposDeAcertoDocumentosAgrupados, handleChangeTipoDeAcertoDocumento, textoCategoria, corTextoCategoria, adicionaTextoECorCategoriaVazio, removeTextoECorCategoriaTipoDeAcertoJaCadastrado}) =>{
+const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, tiposDeAcertoDocumentosAgrupados, handleChangeTipoDeAcertoDocumento, textoCategoria, corTextoCategoria, adicionaTextoECorCategoriaVazio, removeTextoECorCategoriaTipoDeAcertoJaCadastrado, ehSolicitacaoCopiada}) =>{
     return(
         <div className='mt-3'>
             <Formik
@@ -37,7 +37,7 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                                                 <strong>Item {index + 1}</strong></p>
                                                             <button
                                                                 type="button"
-                                                                className="btn btn-link btn-remover-despesa mr-2 p-0 d-flex align-items-center"
+                                                                className={`btn btn-link ${ehSolicitacaoCopiada(acerto) ? 'btn-remover-ajuste-documento-copia' : 'btn-remover-ajuste-documento'} mr-2 p-0 d-flex align-items-center`}
                                                                 onClick={() => {
                                                                     remove(index)
                                                                     removeTextoECorCategoriaTipoDeAcertoJaCadastrado(index)
@@ -47,11 +47,11 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                                                     style={{
                                                                         fontSize: '17px',
                                                                         marginRight: "4px",
-                                                                        color: "#B40C02"
+                                                                        color: ehSolicitacaoCopiada(acerto) ? "#297805" : "#B40C02"
                                                                     }}
-                                                                    icon={faTimesCircle}
+                                                                    icon={ ehSolicitacaoCopiada(acerto) ? faCheckCircle : faTimesCircle }
                                                                 />
-                                                                Remover item
+                                                                { ehSolicitacaoCopiada(acerto) ? "Considerar correto" : "Remover item" }
                                                             </button>
                                                         </div>
 
@@ -67,6 +67,7 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                                                         props.handleChange(e);
                                                                         handleChangeTipoDeAcertoDocumento(e, index);
                                                                     }}
+                                                                    disabled={acerto.uuid ? true : false}
                                                                 >
                                                                     <option key='' value="">Selecione a especificação do acerto</option>
                                                                     {tiposDeAcertoDocumentosAgrupados && tiposDeAcertoDocumentosAgrupados.length > 0 && tiposDeAcertoDocumentosAgrupados.map(item => (
@@ -116,6 +117,8 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                                     className="btn btn btn-outline-success mt-2 mr-2"
                                                     onClick={() => {
                                                         push({
+                                                            uuid: null,
+                                                            copiado: false,
                                                             tipo_acerto: '',
                                                             detalhamento: '',
                                                         });

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/index.js
@@ -66,6 +66,8 @@ const DetalharAcertosDocumentos = () =>{
             if (acertos && acertos.solicitacoes_de_ajuste_da_analise && acertos.solicitacoes_de_ajuste_da_analise.length > 0) {
                 acertos.solicitacoes_de_ajuste_da_analise.map((acerto) =>
                     _acertos.push({
+                        uuid: acerto.uuid,
+                        copiado: acerto.copiado,
                         tipo_acerto: acerto.tipo_acerto.uuid,
                         detalhamento: acerto.detalhamento,
                     })
@@ -178,6 +180,14 @@ const DetalharAcertosDocumentos = () =>{
         changeTextoECorCategoria(info_categoria, index);
     }
 
+    const ehSolicitacaoCopiada = (acerto) => {
+        if(acerto.copiado){
+            return true;
+        }
+        
+        return false;
+    }
+
     return(
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Acompanhamento das Prestações de Contas</h1>
@@ -200,6 +210,7 @@ const DetalharAcertosDocumentos = () =>{
                         corTextoCategoria={corTextoCategoria}
                         adicionaTextoECorCategoriaVazio={adicionaTextoECorCategoriaVazio}
                         removeTextoECorCategoriaTipoDeAcertoJaCadastrado={removeTextoECorCategoriaTipoDeAcertoJaCadastrado}
+                        ehSolicitacaoCopiada={ehSolicitacaoCopiada}
                     />
                 </div>
             ):

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/TabelaConferenciaDeDocumentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/TabelaConferenciaDeDocumentos.js
@@ -77,6 +77,7 @@ const TabelaConferenciaDeDocumentos = ({carregaListaDeDocumentosParaConferencia,
 
                     <Dropdown.Menu>
                         <Dropdown.Item onClick={(e) => selecionarPorStatus(e, "CORRETO")}>Selecionar todos corretos</Dropdown.Item>
+                        <Dropdown.Item onClick={(e) => selecionarPorStatus(e, "AJUSTE")}>Selecionar todos com solicitação de ajuste</Dropdown.Item>
                         <Dropdown.Item onClick={(e) => selecionarPorStatus(e, null)}>Selecionar todos não conferidos</Dropdown.Item>
                         <Dropdown.Item onClick={(e) => desmarcarTodos(e)}>Desmarcar todos</Dropdown.Item>
                     </Dropdown.Menu>
@@ -108,8 +109,15 @@ const TabelaConferenciaDeDocumentos = ({carregaListaDeDocumentosParaConferencia,
         let cont = 0;
         let result
         if (status) {
-            setExibirBtnMarcarComoCorreto(false)
-            setExibirBtnMarcarComoNaoConferido(true)
+            if(status === "CORRETO"){
+                setExibirBtnMarcarComoCorreto(false)
+                setExibirBtnMarcarComoNaoConferido(true)
+            }
+            else if(status === "AJUSTE"){
+                setExibirBtnMarcarComoCorreto(true)
+                setExibirBtnMarcarComoNaoConferido(false)
+            }
+
             result = listaDeDocumentosParaConferencia.reduce((acc, o) => {
                 let obj = o.analise_documento && o.analise_documento.resultado && o.analise_documento.resultado === status ? Object.assign(o, {selecionado: true}) : o;
                 if (obj.selecionado) {
@@ -157,37 +165,30 @@ const TabelaConferenciaDeDocumentos = ({carregaListaDeDocumentosParaConferencia,
     }
 
     const verificaSePodeSerCheckado = (e, rowData) => {
-
         let selecionados = getDocumentosSelecionados()
         let status_permitido = []
-
         if (selecionados.length > 0) {
             if (!selecionados[0].analise_documento || (selecionados[0].analise_documento && selecionados[0].analise_documento.resultado && selecionados[0].analise_documento.resultado === "AJUSTE")) {
-                status_permitido = [null]
+                status_permitido = [null, 'AJUSTE']
             } else {
                 status_permitido = ['CORRETO']
             }
         }
 
-        if (e.target.checked && rowData.analise_documento && rowData.analise_documento.resultado && rowData.analise_documento.resultado === "AJUSTE") {
-            setTextoModalCheckNaoPermitido('<p>Documentos com status de ajuste solicitado não podem ser selecionados!</p>')
-            setShowModalCheckNaoPermitido(true)
-            return false
-        }else {
-            if (e.target.checked && status_permitido.length > 0) {
-                if (status_permitido.includes(rowData.analise_documento) || (rowData.analise_documento && rowData.analise_documento.resultado && status_permitido.includes(rowData.analise_documento.resultado))) {
-                    setTextoModalCheckNaoPermitido('')
-                    return true
-                } else {
-                    setTextoModalCheckNaoPermitido('<p>Esse documento tem um status de conferência que não pode ser selecionado em conjunto com os demais status já selecionados.</p>')
-                    setShowModalCheckNaoPermitido(true)
-                    return false
-                }
-            } else {
+        if (e.target.checked && status_permitido.length > 0) {
+            if (status_permitido.includes(rowData.analise_documento) || (rowData.analise_documento && rowData.analise_documento.resultado && status_permitido.includes(rowData.analise_documento.resultado))) {
                 setTextoModalCheckNaoPermitido('')
                 return true
+            } else {
+                setTextoModalCheckNaoPermitido('<p>Esse documento tem um status de conferência que não pode ser selecionado em conjunto com os demais status já selecionados.</p>')
+                setShowModalCheckNaoPermitido(true)
+                return false
             }
+        } else {
+            setTextoModalCheckNaoPermitido('')
+            return true
         }
+
     }
 
     const tratarSelecionado = (e, lancamentosParaConferenciaUuid, rowData) => {

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
@@ -313,8 +313,6 @@ export const DetalharAcertos = () => {
     }
 
     const ehSolicitacaoCopiada = (acerto) => {
-        console.log("acerto", acerto)
-
         if(acerto.copiado){
             return true;
         }

--- a/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
+++ b/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
@@ -547,3 +547,13 @@
   color: #297805;
   font-weight: bold;
 }
+
+.btn-remover-ajuste-documento, .btn-remover-ajuste-documento:hover, .btn-remover-ajuste-documento:active, .btn-remover-ajuste-documento:focus, .btn-remover-ajuste-documento:visited{
+  color: #B40C02;
+  font-weight: bold;
+}
+
+.btn-remover-ajuste-documento-copia, .btn-remover-ajuste-documento-copia:hover, .btn-remover-ajuste-documento-copia:active, .btn-remover-ajuste-documento-copia:focus, .btn-remover-ajuste-documento-copia:visited{
+  color: #297805;
+  font-weight: bold;
+}


### PR DESCRIPTION
feat(74825): Marcar documentos como corretos

Esse PR:

- Adiciona "Selecionar todos com solicitação de ajuste" ao menu de seleção
- Permite marcar como correto documentos com ajuste
- Exibe link para remover item ou considerar correto, dependendo se é uma copia ou não
- Adiciona uuid e copiado ao payload

História: [AB#74825](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/74825)