### PR TITLE
fix(76006): Análise DRE: Ícone de detalhamento deve ser exibido também para os demais status

### DIFF
--- a/hotfixes.md
+++ b/hotfixes.md
@@ -1,3 +1,6 @@
+### 1.33.4 - 14/10/2022 - Hotfix - Soluções de bugs urgentes durante a sprint 51
+* (76006) Análise DRE: Ícone de detalhamento deve ser exibido também para os demais status
+
 ### 1.33.3 - 22/09/2022 - Hotfix - Soluções de bugs urgentes durante a sprint 50
 * (74773) Resolve problema de visualização de devolução ao tesouro de despesa sem tipo definido
 

--- a/src/componentes/escolas/AnaliseDre/index.js
+++ b/src/componentes/escolas/AnaliseDre/index.js
@@ -101,7 +101,7 @@ export const AnaliseDre = () =>{
     const acoesTemplate = (rowData) =>{
         return (
             <>
-                {rowData.status_pc === 'APROVADA' || rowData.status_pc === 'APROVADA_RESSALVA' || rowData.status_pc === 'REPROVADA' || rowData.status_pc === 'DEVOLVIDA' ? (
+                {rowData.pode_habilitar_botao_ver_acertos_em_analise_da_dre ? (
                     <Link to={{pathname: `consulta-detalhamento-analise-da-dre/${rowData.prestacao_de_contas_uuid}`,
                             state: {
                                 periodoFormatado: retornaObjetoPeriodo(rowData),


### PR DESCRIPTION
Esse PR:

- Corrige exibição ícone de detalhamento em Análise da DRE

História: [AB#76006](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/76006)