### PR TITLE
Feat(76332): Altera nomenclatura das opcoes ver resumo

### DIFF
--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -1,3 +1,5 @@
+$cor_info_acertos: #0A6DDF;
+
 .barra-mensagem {
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -20,17 +22,33 @@
 
 .barra-mensagem-info-acerto {
   background-color: #E6F7FF;
-  outline: #0A6DDF solid 1px;
+  outline: $cor_info_acertos solid 1px;
   padding-top: 5px;
   padding-bottom: 5px;
   border: 1px solid;
   border-radius: 4px;
-  color: #0A6DDF;
+  color: $cor_info_acertos;
 }
 
-.barra-mensagem-info-acerto
+.barra-mensagem-info-acerto > div {
+  font-family: 'Roboto';
+  padding-left: 8px;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  color: $cor_info_acertos;
+}
 
+.barra-mensagem-info-acerto .align-self-center{
+  width: 35px;
+}
 
+.barra-mensagem-info-acerto path {
+  fill: $cor_info_acertos;
+  margin-top: 3px;
+  transform: scale(0.7) translateY(120px);
+}
 
 .btn-barra-mensagem {
   border-color: #fff !important;
@@ -52,7 +70,7 @@
 }
 
 .info-acerto {
-  color: #0A6DDF !important
+  color: $cor_info_acertos !important
 }
 
 .sucess-laranja {

--- a/src/componentes/Globais/BarraMensagem/barraMensagem.scss
+++ b/src/componentes/Globais/BarraMensagem/barraMensagem.scss
@@ -18,7 +18,21 @@
   background-color: #B40C02;
 }
 
-.btn-barra-mensagem{
+.barra-mensagem-info-acerto {
+  background-color: #E6F7FF;
+  outline: #0A6DDF solid 1px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border: 1px solid;
+  border-radius: 4px;
+  color: #0A6DDF;
+}
+
+.barra-mensagem-info-acerto
+
+
+
+.btn-barra-mensagem {
   border-color: #fff !important;
   font-weight: 700 !important;
   font-size: 14px !important;
@@ -35,6 +49,10 @@
 
 .sucess-azul {
   color: #5BBCF2 !important
+}
+
+.info-acerto {
+  color: #0A6DDF !important
 }
 
 .sucess-laranja {

--- a/src/componentes/Globais/BarraMensagem/index.js
+++ b/src/componentes/Globais/BarraMensagem/index.js
@@ -8,7 +8,6 @@ const BarraMensagemCustom = (mensagem, textoBotao, handleClickBotao, mostraBotao
     
     return (
         <>
-            {}
             <div className={`col-12 mt-3 barra-mensagem d-flex ${tipo === 'info-branco' ? 'barra-mensagem-info-inativa' : '' || tipo === 'info-acerto' ? 'barra-mensagem-info-acerto' : ''}`}>
                 <div className='col-auto align-self-center'>
                     <FontAwesomeIcon className={`icone-alert-barra-mensagem ${tipo}`}

--- a/src/componentes/Globais/BarraMensagem/index.js
+++ b/src/componentes/Globais/BarraMensagem/index.js
@@ -8,7 +8,8 @@ const BarraMensagemCustom = (mensagem, textoBotao, handleClickBotao, mostraBotao
     
     return (
         <>
-            <div className={`col-12 mt-3 barra-mensagem d-flex ${tipo === 'info-branco' ? 'barra-mensagem-info-inativa' : ''}`}>
+            {}
+            <div className={`col-12 mt-3 barra-mensagem d-flex ${tipo === 'info-branco' ? 'barra-mensagem-info-inativa' : '' || tipo === 'info-acerto' ? 'barra-mensagem-info-acerto' : ''}`}>
                 <div className='col-auto align-self-center'>
                     <FontAwesomeIcon className={`icone-alert-barra-mensagem ${tipo}`}
                         icon={icone}
@@ -41,6 +42,10 @@ const BarraMensagemSucessAzul = (mensagem, textoBotao=null, handleClickBotao=nul
     return BarraMensagemCustom(mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone)
 }
 
+const BarraMensagemAcertoExterno = (mensagem, textoBotao=null, handleClickBotao=null, mostraBotao=false, tipo='info-acerto', icone=faExclamationCircle) =>{
+    return BarraMensagemCustom(mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone)
+}
+
 const BarraMensagemSucessLaranja = (mensagem, textoBotao, handleClickBotao, mostraBotao, tipo='sucess-laranja', icone=faExclamationCircle) =>{
     return BarraMensagemCustom(mensagem, textoBotao, handleClickBotao, mostraBotao, tipo, icone)
 }
@@ -53,6 +58,7 @@ const BarraMensagemSucessVermelho = (mensagem, textoBotao, handleClickBotao, mos
 export const barraMensagemCustom = {
     BarraMensagemSucessAzul,
     BarraMensagemSucessLaranja,
-    BarraMensagemSucessVermelho
+    BarraMensagemSucessVermelho,
+    BarraMensagemAcertoExterno,
 }
 

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/BotoesDetalhesParaAcertosDeCategorias/BotaoAcertosLancamentosEdicaoGasto.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/BotoesDetalhesParaAcertosDeCategorias/BotaoAcertosLancamentosEdicaoGasto.js
@@ -22,7 +22,7 @@ const BotaoAcertosLancamentosEdicaoGasto = ({analise_lancamento, prestacaoDeCont
                     operacao='requer_atualizacao_lancamento_gasto'
                     tipo_transacao={tipo_transacao}
                 >
-                    { TEMPERMISSAO ? 'Ajustar despesa' : "Ver despesa a ajustar"}
+                    { TEMPERMISSAO ? 'Ajustar despesa' : "Ver despesa"}
                 </LinkCustom>
 
             ):

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosEmExtratosBancarios.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosEmExtratosBancarios.js
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import moment from "moment";
 import {Link, useLocation} from "react-router-dom";
 import {getPeriodos} from "../../../services/dres/Dashboard.service";
-import { getPeriodoPorUuid } from "../../../services/sme/Parametrizacoes.service";
 
 
 const TabelaAcertosEmExtratosBancarios = ({extratosBancariosAjustes, contaUuid}) => {
@@ -13,7 +12,7 @@ const TabelaAcertosEmExtratosBancarios = ({extratosBancariosAjustes, contaUuid})
     useEffect(() => {
         async function getPeriodoPorUuid(){
             let periodos = await getPeriodos();
-            const uuidPeriodo = await periodos.find(periodo => periodo.referencia === parametros.state?.periodoFormatado.referencia)?.uuid
+            const uuidPeriodo = await periodos.find(periodo => periodo.referencia === parametros.state?.periodoFormatado?.referencia)?.uuid
             setUuidPeriodo(uuidPeriodo)
         }
         getPeriodoPorUuid()

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosEmExtratosBancarios.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosEmExtratosBancarios.js
@@ -48,7 +48,7 @@ const TabelaAcertosEmExtratosBancarios = ({extratosBancariosAjustes, contaUuid})
                     }
                 </div>
             ):
-                <p className='text-center fonte-18 mt-4'><strong>Não existem ajustes para serem exibidos</strong></p>
+                <p className='text-center fonte-18 mt-4'><strong>Não existem acertos para serem exibidos</strong></p>
             }
         <Link
             to={{

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosLancamentos.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/TabelaAcertosLancamentos.js
@@ -371,7 +371,7 @@ export const TabelaAcertosLancamentos = ({lancamentosAjustes, limparStatus, marc
                 
                 
             ):
-                <p className='text-center fonte-18 mt-4'><strong>Não existem ajustes para serem exibidos</strong></p>
+                <p className='text-center fonte-18 mt-4'><strong>Não existem acertos para serem exibidos</strong></p>
             }
             <section>
                 <ModalCheckNaoPermitidoConfererenciaDeLancamentos

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
@@ -402,7 +402,7 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
                     {data.analise_lancamento.requer_ajustes_externos &&
                         <div className='row'>
                             <div className='col-12 mb-1 px-4 py-1'>
-                                {barraMensagemCustom.BarraMensagemSucessAzul("Favor realizar os ajustes solicitados que são externos ao sistema.")}
+                                {barraMensagemCustom.BarraMensagemSucessAzul("Acerto externo ao sistema.")}
                             </div>
                         </div>
                     }
@@ -541,7 +541,7 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
 
                     {data.requer_ajuste_externo &&
                         <div className='col-12 mb-3'>
-                            {barraMensagemCustom.BarraMensagemSucessAzul("Favor realizar os ajustes solicitados que são externos ao sistema.")}
+                            {barraMensagemCustom.BarraMensagemSucessAzul("Acerto externo ao sistema.")}
                         </div>
                     }
                     {data.solicitacoes_de_ajuste_da_analise.map((ajuste, index) => (
@@ -627,7 +627,7 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
             return (
                 <div className='text-right border-top pt-3 pb-2 container-botoes-ajustes'>
                     <button onClick={() => addDispatchRedireciona(lancamento)} className='btn btn-outline-success'>
-                        <strong>Ir para página de acertos</strong>
+                        <strong>Editar acertos solicitados</strong>
                     </button>
                 </div>
             )

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/index.js
@@ -402,7 +402,7 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
                     {data.analise_lancamento.requer_ajustes_externos &&
                         <div className='row'>
                             <div className='col-12 mb-1 px-4 py-1'>
-                                {barraMensagemCustom.BarraMensagemSucessAzul("Acerto externo ao sistema.")}
+                                {barraMensagemCustom.BarraMensagemAcertoExterno("Acerto externo ao sistema.")}
                             </div>
                         </div>
                     }
@@ -541,7 +541,7 @@ const ExibeAcertosEmLancamentosEDocumentosPorConta = ({
 
                     {data.requer_ajuste_externo &&
                         <div className='col-12 mb-3'>
-                            {barraMensagemCustom.BarraMensagemSucessAzul("Acerto externo ao sistema.")}
+                            {barraMensagemCustom.BarraMensagemAcertoExterno("Acerto externo ao sistema.")}
                         </div>
                     }
                     {data.solicitacoes_de_ajuste_da_analise.map((ajuste, index) => (


### PR DESCRIPTION
Esse PR:
 
- [x] Alterar “Ir para página de acertos” para “Editar acertos solicitados” 
- [x] Alterar “Ver despesa a ajustar” para “Ver despesa”
- [x] Padronizar o termo acerto (onde houver "ajuste" substituir para "acerto") na funcionalidade de Ver Resumo.

História [AB#76332](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/76332)