### PR TITLE
fix(78638): Corrige exibição data devolução tesouro

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
@@ -147,7 +147,7 @@ export const DetalharAcertos = () => {
                                     devolucao_tesouro: acerto.devolucao_ao_tesouro && acerto.devolucao_ao_tesouro.uuid ? {
                                         uuid: acerto.devolucao_ao_tesouro.uuid,
                                         tipo: acerto.devolucao_ao_tesouro.tipo && acerto.devolucao_ao_tesouro.tipo.uuid ? acerto.devolucao_ao_tesouro.tipo.uuid : acerto.devolucao_ao_tesouro.tipo,
-                                        data: acerto.devolucao_ao_tesouro.data ? dataTemplate(acerto.devolucao_ao_tesouro.data) : null,
+                                        data: acerto.devolucao_ao_tesouro.data ? dataTemplate(null, null, acerto.devolucao_ao_tesouro.data) : null,
                                         devolucao_total: acerto.devolucao_ao_tesouro.devolucao_total,
                                         valor: acerto.devolucao_ao_tesouro.valor ? Number(acerto.devolucao_ao_tesouro.valor).toLocaleString('pt-BR', {
                                             style: 'currency',


### PR DESCRIPTION
Corrige a exibição da data de devolução ao tesouro nos detalhes de uma solicitação de acerto do tipo devolução.

Quando a UE já havia informado a data, ela não era exibida devido a um erro na chamada da função de formatação.

Corrige AB#78638