### PR TITLE
fix(78550): Corrige validação valor parcial dev tesouro

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertosDevolucaoAoTesouro.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertosDevolucaoAoTesouro.js
@@ -74,9 +74,13 @@ export const FormularioAcertosDevolucaoAoTesouro = ({formikProps, acerto, index,
                     id={`devolucao_tesouro[${index}.devolucao_total]`}
                     onChange={(e) => {
                         const valorTesouro = e.target.value === 'true' ? valorDocumento : acerto.devolucao_tesouro.valor;
-                        acerto.devolucao_tesouro.valor =  e.target.value === 'true' ? valorDocumento : acerto.devolucao_tesouro.valor
+                        acerto.devolucao_tesouro.valor = e.target.value === 'true' ? valorDocumento : acerto.devolucao_tesouro.valor
                         formikProps.handleChange(e);
-                        verificaParcialError(valorTesouro.toString())
+                        //verificaParcialError espera um valor formatado no formato R$40,00.
+                        verificaParcialError(valorTesouro.toLocaleString('pt-br', {
+                            style: 'currency',
+                            currency: 'BRL'
+                        }).replace(/\s/g, ''))
                         setIsTotal(e.target.value === 'true')
                     }}
                     className='form-control'


### PR DESCRIPTION
Corrige a validação de valores parciais de devolução ao tesouro.

Quando o usuário selecionava "Valor total" e depois "valor parcial" a validação não recusava um valor igual ao total do documento.

Corrige [AB#78550](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/78550)