### PR TITLE
fix(78552): Corrige função de comparação de objetos

### DIFF
--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -814,32 +814,27 @@ export const gerarUuid = () => {
 
 export const comparaObjetos = (objetoA, objetoB) =>{
 
-  //Busca as chaves do objetoA e objetoB
-  //utilizando o "let" o escopo da variável é limitado para o bloco.
-  //Object.keys retornará um array com todas as chaves do objeto.
+  if (objetoA === null  || objetoB === null ){
+    // null é um 'object', mas não é possível se obter keys de um null. Tratamento precisa ser distinto.
+    return objetoA === objetoB
+  }
+
   let aChaves = Object.keys(objetoA),
       bChaves = Object.keys(objetoB);
 
-  //Compara os tamanhos, se forem diferentes retorna falso pois
-  //o numero de propriedades é diferente, logo os objetos são diferentes
   if (aChaves.length !== bChaves.length) {
     return false;
   }
 
-  //Verifico se existe algum elemento com valor diferente nos objetos.
-  //o array.some executa uma função(passada por parâmetro) para cada valor
-  //do array. Essa função deve executar um teste, se para algum dos valores
-  //o teste é verdadeiro, a execução é interrompida e true é retornado.
-  //Do contrário, se o teste nunca for verdadeiro ele retornará false
-  //após executar o teste para todos valores do array.
-  //Estou basicamente verficando se existe diferença entre dois valores do objeto.
-
   let saoDiferentes = aChaves.some((chave) => {
-    return objetoA[chave] !== objetoB[chave];
+    if (typeof objetoA[chave] == "object" && typeof objetoB[chave] == "object" ){
+      return !comparaObjetos(objetoA[chave] , objetoB[chave] )
+    }
+    else {
+      return objetoA[chave] !== objetoB[chave];
+    }
   });
 
-  //como saoDiferentes contém true caso os objetos sejam diferentes eu
-  //simplesmente nego esse valor para retornar que os objetos são iguais (ou não).
   return !saoDiferentes;
 }
 


### PR DESCRIPTION
A função falhava quando os objetos comparados tinham outros objetos como propriedades.Em uma comparação simples, obj1 === obj2 são considerados diferentes mesmos que iguais em conteúdo.

A função foi alterada para verificar se uma propriedade era um 'object' e, nesse caso, usar a si própria recursivamente para comparar um objeto com o outro.