### PR TITLE
fix(78755): Corrige validação e-mail membro associação

### DIFF
--- a/src/componentes/escolas/Associacao/Membros/CadastroDeMembrosDaAssociacao/index.js
+++ b/src/componentes/escolas/Associacao/Membros/CadastroDeMembrosDaAssociacao/index.js
@@ -361,7 +361,7 @@ const CadastroDeMembrosDaAssociacao = () => {
     const onSubmitEditarMembro = async () => {
         let enviar_formulario = true
         let erros = {};
-        const regex_email = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+        const regex_email = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
         let values = {...formRef.current.values}
 


### PR DESCRIPTION
O regex de validação de e-mail de membro de associação não estava validando o caso de um ponto após o e-mail (ex: teste@teste.com.) Esse e-mail era considerado válido.

O regex foi alterado para considerar essa situação.