### PR TITLE
Hotfix/1.33.4 (#1351)

### DIFF
--- a/hotfixes.md
+++ b/hotfixes.md
@@ -1,3 +1,6 @@
+### 1.33.4 - 16/11/2022 - Hotfix - Soluções de bugs urgentes durante a sprint 53
+* (78755) O sistema não salva o cadastro de um Membro da Associação (Conselheiro do Conselho Fiscal)
+
 ### 1.33.3 - 22/09/2022 - Hotfix - Soluções de bugs urgentes durante a sprint 50
 * (74773) Resolve problema de visualização de devolução ao tesouro de despesa sem tipo definido
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "1.33.3",
+  "version": "1.33.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/src/componentes/escolas/Associacao/Membros/CadastroDeMembrosDaAssociacao/index.js
+++ b/src/componentes/escolas/Associacao/Membros/CadastroDeMembrosDaAssociacao/index.js
@@ -361,7 +361,7 @@ const CadastroDeMembrosDaAssociacao = () => {
     const onSubmitEditarMembro = async () => {
         let enviar_formulario = true
         let erros = {};
-        const regex_email = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+        const regex_email = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
         let values = {...formRef.current.values}
 


### PR DESCRIPTION
* docs(1.33.4): Hotfix

Corrige 78755

* fix(78755): Corrige validação e-mail membro associação (#1350)

O regex de validação de e-mail de membro de associação não estava validando o caso de um ponto após o e-mail (ex: teste@teste.com.) Esse e-mail era considerado válido.

O regex foi alterado para considerar essa situação.