### PR TITLE
fix(79016): Corrige validação de valores despesa

### DIFF
--- a/src/componentes/escolas/Despesas/metodosAuxiliares.js
+++ b/src/componentes/escolas/Despesas/metodosAuxiliares.js
@@ -207,7 +207,7 @@ const getErroValorOriginalRateios = (values) =>{
         values.despesas_impostos.map((despesa_imposto) => {
             if(despesa_imposto.rateios.length > 0){
                 despesa_imposto.rateios.map((rateio) => {
-                    valor_imposto = valor_imposto + trataNumericos(rateio.valor_rateio);
+                    valor_imposto = valor_imposto + trataNumericos(rateio.valor_original);
                 });
             }
         });


### PR DESCRIPTION
A validação de valores originais da despesa estavam considerando o campo de valor realizado do imposto, quando deveria usar o valor original.

Corrige [AB#79016](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/79016)