### PR TITLE
feat(77677): Nao permitir incluir itens repetidos

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/FormularioAcertos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/FormularioAcertos.js
@@ -5,6 +5,65 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faTimesCircle, faExclamationCircle, faCheckCircle} from "@fortawesome/free-solid-svg-icons";
 
 const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, tiposDeAcertoDocumentosAgrupados, handleChangeTipoDeAcertoDocumento, textoCategoria, corTextoCategoria, adicionaTextoECorCategoriaVazio, removeTextoECorCategoriaTipoDeAcertoJaCadastrado, ehSolicitacaoCopiada}) =>{
+
+    const categoriaNaoPodeRepetir = (categoria) => {
+        if(categoria.id === 'SOLICITACAO_ESCLARECIMENTO'){
+            return true;
+        }
+
+        return false;
+    }
+
+    const itemDaCategoriaPodeRepetir = (categoria) => {
+        if(categoria.id === 'INCLUSAO_CREDITO'){
+            return true;
+        }
+        else if(categoria.id === 'INCLUSAO_GASTO'){
+            return true;
+        }
+
+        return false;
+    }
+
+    const categoriaNaoTemItensParaExibir = (categoria) => {
+        let itens_a_exibir = categoria.tipos_acerto_documento.filter((item) => (item.deve_exibir === true));
+
+        if(itens_a_exibir.length === 0){
+            return true;
+        }
+
+        return false;
+    }
+
+    const opcoesSelect = (acertos) => {
+        for(let index_categoria=0; index_categoria <= tiposDeAcertoDocumentosAgrupados.length -1; index_categoria ++){
+            let categoria = tiposDeAcertoDocumentosAgrupados[index_categoria]
+            categoria.deve_exibir_categoria = true;
+
+            for(let index_tipo_acerto=0; index_tipo_acerto <= categoria.tipos_acerto_documento.length -1; index_tipo_acerto++){
+                let acerto = categoria.tipos_acerto_documento[index_tipo_acerto];
+                let uuid = acerto.uuid
+                acerto.deve_exibir = true
+
+                let ja_selecionado = acertos.filter((item) => (item.tipo_acerto === uuid))
+
+                if(ja_selecionado.length > 0){
+
+                    if(!itemDaCategoriaPodeRepetir(categoria)){
+                        acerto.deve_exibir = false
+                    }
+
+                    if(categoriaNaoPodeRepetir(categoria) || categoriaNaoTemItensParaExibir(categoria)){
+                        categoria.deve_exibir_categoria = false;
+                    }  
+                }
+            }
+        }
+
+        return tiposDeAcertoDocumentosAgrupados
+    }
+
+
     return(
         <div className='mt-3'>
             <Formik
@@ -28,7 +87,7 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                     name="solicitacoes_acerto"
                                     render={({remove, push}) => (
                                         <>
-                                            {values.solicitacoes_acerto && values.solicitacoes_acerto.length > 0 && values.solicitacoes_acerto.map((acerto, index) => {
+                                            {values.solicitacoes_acerto && values.solicitacoes_acerto.length > 0 && values.solicitacoes_acerto.map((acerto, index, acertos) => {
                                                 return (
                                                     <div key={index}>
                                                         <div
@@ -70,10 +129,10 @@ const FormularioAcertos = ({solicitacoes_acerto, onSubmitFormAcertos, formRef, t
                                                                     disabled={acerto.uuid ? true : false}
                                                                 >
                                                                     <option key='' value="">Selecione a especificação do acerto</option>
-                                                                    {tiposDeAcertoDocumentosAgrupados && tiposDeAcertoDocumentosAgrupados.length > 0 && tiposDeAcertoDocumentosAgrupados.map(item => (
-                                                                        <optgroup key={item.id} label={item.nome}>
+                                                                    {tiposDeAcertoDocumentosAgrupados && tiposDeAcertoDocumentosAgrupados.length > 0 && opcoesSelect(acertos).map(item => (
+                                                                        <optgroup key={item.id} label={item.nome} className={!item.deve_exibir_categoria ? 'esconde-categoria' : ''}>
                                                                             {item.tipos_acerto_documento && item.tipos_acerto_documento.length > 0 && item.tipos_acerto_documento.map(tipo_acerto => (
-                                                                                <option key={tipo_acerto.uuid} value={tipo_acerto.uuid} data-categoria={item.id}>{tipo_acerto.nome}</option>
+                                                                                <option className={!tipo_acerto.deve_exibir ? 'esconde-tipo-acerto' : ''} key={tipo_acerto.uuid} value={tipo_acerto.uuid} data-categoria={item.id}>{tipo_acerto.nome}</option>
                                                                             ))}
                                                                         </optgroup>
                                                                     ))}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertos.js
@@ -11,6 +11,56 @@ export const FormularioAcertos = ({solicitacoes_acerto, listaTiposDeAcertoLancam
 
     const uuidDevolucaoTesouro = listaTiposDeAcertoLancamentosAgrupado.find(item => item.id === "DEVOLUCAO")?.tipos_acerto_lancamento[0].uuid
 
+
+    const categoriaNaoPodeRepetir = (categoria) => {
+        if(categoria.id === 'DEVOLUCAO'){
+            return true;
+        }
+        else if(categoria.id === 'EXCLUSAO_LANCAMENTO'){
+            return true;
+        }
+        else if(categoria.id === 'SOLICITACAO_ESCLARECIMENTO'){
+            return true;
+        }
+
+        return false;
+    }
+
+    const categoriaNaoTemItensParaExibir = (categoria) => {
+        let itens_a_exibir = categoria.tipos_acerto_lancamento.filter((item) => (item.deve_exibir === true));
+
+        if(itens_a_exibir.length === 0){
+            return true;
+        }
+
+        return false;
+    }
+
+    const opcoesSelect = (acertos) => {
+        for(let index_categoria=0; index_categoria <= listaTiposDeAcertoLancamentosAgrupado.length -1; index_categoria ++){
+            let categoria = listaTiposDeAcertoLancamentosAgrupado[index_categoria]
+            categoria.deve_exibir_categoria = true;
+
+            for(let index_tipo_acerto=0; index_tipo_acerto <= categoria.tipos_acerto_lancamento.length -1; index_tipo_acerto++){
+                let acerto = categoria.tipos_acerto_lancamento[index_tipo_acerto];
+                let uuid = acerto.uuid
+                acerto.deve_exibir = true
+
+                let ja_selecionado = acertos.filter((item) => (item.tipo_acerto === uuid))
+
+                if(ja_selecionado.length > 0){
+                    acerto.deve_exibir = false
+
+                    if(categoriaNaoPodeRepetir(categoria) || categoriaNaoTemItensParaExibir(categoria)){
+                        categoria.deve_exibir_categoria = false;
+                    } 
+                }
+            }
+        }
+
+        return listaTiposDeAcertoLancamentosAgrupado
+    }
+
     return (
         <div className='mt-3'>
             <Formik
@@ -35,13 +85,6 @@ export const FormularioAcertos = ({solicitacoes_acerto, listaTiposDeAcertoLancam
                                 render={({remove, push}) => (
                                     <>
                                         {values.solicitacoes_acerto && values.solicitacoes_acerto.length > 0 && values.solicitacoes_acerto.map((acerto, index, acertos) => {
-                                            const indexDevolucaoTesouro = acertos.findIndex(acerto => acerto.tipo_acerto === uuidDevolucaoTesouro)
-                                            let acertosSemDevolucao = (item) => item
-
-                                            if (indexDevolucaoTesouro !== -1) {
-                                                acertosSemDevolucao = indexDevolucaoTesouro !== index ? (item) => item.filter((option) => option.id !== "DEVOLUCAO") : (item) => item
-                                            }
-
                                             return (
                                                 <div key={index}>
                                                     <div
@@ -85,11 +128,11 @@ export const FormularioAcertos = ({solicitacoes_acerto, listaTiposDeAcertoLancam
                                                             >
                                                                 <option key='' value="">Selecione a especificação do acerto</option>
                                                                 
-                                                                {listaTiposDeAcertoLancamentosAgrupado && listaTiposDeAcertoLancamentosAgrupado.length > 0 && acertosSemDevolucao(listaTiposDeAcertoLancamentosAgrupado).map(item => {
+                                                                {listaTiposDeAcertoLancamentosAgrupado && listaTiposDeAcertoLancamentosAgrupado.length > 0 && opcoesSelect(acertos).map(item => {
                                                                     return (
-                                                                        <optgroup key={item.id} label={item.nome}>
+                                                                        <optgroup key={item.id} label={item.nome} className={!item.deve_exibir_categoria ? 'esconde-categoria' : ''}>
                                                                             {item.tipos_acerto_lancamento && item.tipos_acerto_lancamento.length > 0 && item.tipos_acerto_lancamento.map(tipo_acerto => (
-                                                                                <option key={tipo_acerto.uuid} value={tipo_acerto.uuid} data-categoria={item.id} data-objeto={JSON.stringify({ ...tipo_acerto })}>{tipo_acerto.nome}</option>
+                                                                                <option className={!tipo_acerto.deve_exibir ? 'esconde-tipo-acerto' : ''} key={tipo_acerto.uuid} value={tipo_acerto.uuid} data-categoria={item.id} data-objeto={JSON.stringify({ ...tipo_acerto })}>{tipo_acerto.nome}</option>
                                                                             ))}
                                                                         </optgroup>
                                                                     );

--- a/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
+++ b/src/componentes/dres/PrestacaoDeContas/prestacao-de-contas.scss
@@ -562,3 +562,11 @@
   color: #297805;
   font-weight: bold;
 }
+
+.esconde-categoria{
+  display: none !important;
+}
+
+.esconde-tipo-acerto{
+  display: none !important;
+}


### PR DESCRIPTION
feat(77677): Nao permitir incluir itens repetidos

Esse PR:

[x] Não permite seleção repetida de tipos de acerto (exceto para as categorias inclusão de crédito e gasto)
[x] Não permite seleção repetida das categorias (exclusão de lancto e esclarecimento)

História: [AB#77677](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/77677)