### PR TITLE
Feature/74210 visualizar relatorio consolidado

### DIFF
--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BarraDeStatus/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BarraDeStatus/index.js
@@ -1,6 +1,9 @@
 import React from "react";
+import useDataTemplate from "../../../../../hooks/Globais/useDataTemplate";
 
-export const BarraDeStatus = ({statusRelatorio}) =>{
+export const BarraDeStatus = ({statusRelatorio, relatorioConsolidado}) => {
+    const dataTemplate = useDataTemplate()
+    
     const BarraStyle = {
         paddingLeft: "16px",
         paddingRight: "16px",
@@ -8,14 +11,14 @@ export const BarraDeStatus = ({statusRelatorio}) =>{
     };
 
     const BarraCor = {
-        1: {backgroundColor: '#D06D12'},
-        2: {backgroundColor: '#297805'}
+        1: {backgroundColor: '#297805'},
+        2: {backgroundColor: '#D06D12'}
     };
 
     return(
         <div className="row" style={BarraStyle}>
             <div className={`col-12`} style={BarraCor[statusRelatorio.cor_idx]}>
-                <p className="titulo-status pt-1 pb-1 mb-0">{statusRelatorio.status_txt ? statusRelatorio.status_txt : ""}</p>
+                <p className="titulo-status pt-1 pb-1 mb-0">{statusRelatorio.status_txt ? statusRelatorio.status_txt + dataTemplate(null, null, relatorioConsolidado.data_publicacao) : ""}</p>
             </div>
         </div>
     );

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BarraDeStatus/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BarraDeStatus/index.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+export const BarraDeStatus = ({statusRelatorio}) =>{
+    const BarraStyle = {
+        paddingLeft: "16px",
+        paddingRight: "16px",
+        paddingTop: "16px",
+    };
+
+    const BarraCor = {
+        1: {backgroundColor: '#D06D12'},
+        2: {backgroundColor: '#297805'}
+    };
+
+    return(
+        <div className="row" style={BarraStyle}>
+            <div className={`col-12`} style={BarraCor[statusRelatorio.cor_idx]}>
+                <p className="titulo-status pt-1 pb-1 mb-0">{statusRelatorio.status_txt ? statusRelatorio.status_txt : ""}</p>
+            </div>
+        </div>
+    );
+};

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/ConferenciaDeDocumentos/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/ConferenciaDeDocumentos/index.js
@@ -28,8 +28,6 @@ const ConferenciaDeDocumentos = ({relatorioConsolidado, getConsolidadoDREUuid, s
         getConsolidadoDREUuid()
 
     }, [params, getConsolidadoDREUuid, uuid_analise_atual])
-        console.log("🚀 ~ file: index.js:33 ~ carregaListaDeDocumentosRelatorio ~ uuid_analise_atual", uuid_analise_atual)
-        console.log("🚀 ~ file: index.js:33 ~ carregaListaDeDocumentosRelatorio ~ uuid_analise_atual", uuid_analise_atual)
 
     useEffect(() => {
         carregaListaDeDocumentosRelatorio()

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/ConferenciaDeDocumentos/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/ConferenciaDeDocumentos/index.js
@@ -12,7 +12,7 @@ const ConferenciaDeDocumentos = ({relatorioConsolidado, getConsolidadoDREUuid, s
     const [loadingDocumentosRelatorio, setLoadingDocumentosRelatorio] = useState(true)
 
     const editavel = relatorioConsolidado.status_sme === 'EM_ANALISE' ? true : false
-    const uuid_analise_atual = relatorioConsolidado && relatorioConsolidado.analise_atual && relatorioConsolidado.analise_atual.uuid ? relatorioConsolidado.analise_atual.uuid : null
+    const uuid_analise_atual = relatorioConsolidado && relatorioConsolidado.analise_atual && relatorioConsolidado.analise_atual.uuid ? relatorioConsolidado.analise_atual.uuid : relatorioConsolidado?.analises_do_consolidado_dre[relatorioConsolidado?.analises_do_consolidado_dre.length - 1]?.uuid
 
     const carregaListaDeDocumentosRelatorio = useCallback(async () => {
         setLoadingDocumentosRelatorio(true)
@@ -28,6 +28,8 @@ const ConferenciaDeDocumentos = ({relatorioConsolidado, getConsolidadoDREUuid, s
         getConsolidadoDREUuid()
 
     }, [params, getConsolidadoDREUuid, uuid_analise_atual])
+        console.log("🚀 ~ file: index.js:33 ~ carregaListaDeDocumentosRelatorio ~ uuid_analise_atual", uuid_analise_atual)
+        console.log("🚀 ~ file: index.js:33 ~ carregaListaDeDocumentosRelatorio ~ uuid_analise_atual", uuid_analise_atual)
 
     useEffect(() => {
         carregaListaDeDocumentosRelatorio()

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/DevolucaoParaAcertos/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/DevolucaoParaAcertos/index.js
@@ -19,6 +19,18 @@ const DevolucaoParaAcertos = ({relatorioConsolidado, refreshConsolidado, disable
         setDataLimite(value)
     }
 
+
+    const verificaAnaliseAtual = () => {
+        if (!relatorioConsolidado || !relatorioConsolidado.analises_do_consolidado_dre) {
+            return null;
+        }
+        if (relatorioConsolidado.status_sme !== 'ANALISADO') {
+            return relatorioConsolidado.analise_atual?.uuid;
+        } else {
+            return relatorioConsolidado.analises_do_consolidado_dre[relatorioConsolidado.analises_do_consolidado_dre.length - 1]?.uuid;
+        }
+    }
+
     const devolverParaAcertos = useCallback(async () =>{
         setLoading(true);
         setBotaoDevolverParaAcertoDisabled(true)
@@ -52,7 +64,7 @@ const DevolucaoParaAcertos = ({relatorioConsolidado, refreshConsolidado, disable
                     <Link
                         onClick={ (event) => {return disableBtnVerResumo() ? event.preventDefault(): event}}
                         to={{
-                            pathname: `/analise-relatorio-consolidado-dre-detalhe-acertos-resumo/${relatorioConsolidado?.analise_atual?.uuid}`,
+                            pathname: `/analise-relatorio-consolidado-dre-detalhe-acertos-resumo/${verificaAnaliseAtual()}`,
                         }}
                         className="btn btn-outline-success mr-2"
                         disabled={disableBtnVerResumo()}

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
@@ -18,6 +18,7 @@ import Loading from "../../../../utils/Loading";
 
 import "./../../../dres/PrestacaoDeContas/prestacao-de-contas.scss"
 import DevolucaoParaAcertos from "./DevolucaoParaAcertos";
+import { BarraDeStatus } from '../../AcompanhamentoPcsSme/BarraDeStatus'
 
 export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
     const params = useParams()
@@ -34,6 +35,7 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
     const [selectedResponsavel, setSelectedResponsavel] = useState(null);
     const [habilitaVerResumoComentariosNotificados, setHabilitaVerResumoComentariosNotificados] = useState(false);
     const [habilitaVerResumoAcertoEmDocumento, setHabilitaVerResumoAcertoEmDocumento] = useState(false);
+    const [statusRelatorio, setStatusRelatorio] = useState({'cor_idx': 1, 'status_txt': ''});
 
     const getConsolidadoDREUuid = useCallback(async () => {
         let {consolidado_dre_uuid} = params
@@ -258,6 +260,7 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
             :
                 <>
                     <div className="page-content-inner">
+                        <BarraDeStatus statusRelatorio={statusRelatorio} />
                         <Cabecalho relatorioConsolidado={relatorioConsolidado}/>
                         <BotoesAvancarRetroceder
                             relatorioConsolidado={relatorioConsolidado}

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
@@ -18,7 +18,7 @@ import Loading from "../../../../utils/Loading";
 
 import "./../../../dres/PrestacaoDeContas/prestacao-de-contas.scss"
 import DevolucaoParaAcertos from "./DevolucaoParaAcertos";
-import { BarraDeStatus } from '../../AcompanhamentoPcsSme/BarraDeStatus'
+import { BarraDeStatus } from './BarraDeStatus'
 
 export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
     const params = useParams()
@@ -35,7 +35,7 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
     const [selectedResponsavel, setSelectedResponsavel] = useState(null);
     const [habilitaVerResumoComentariosNotificados, setHabilitaVerResumoComentariosNotificados] = useState(false);
     const [habilitaVerResumoAcertoEmDocumento, setHabilitaVerResumoAcertoEmDocumento] = useState(false);
-    const [statusRelatorio, setStatusRelatorio] = useState({'cor_idx': 1, 'status_txt': ''});
+    const [statusRelatorio, setStatusRelatorio] = useState({'cor_idx': 1, 'status_txt': 'Análise de prestação de contas concluída em '});
 
     const getConsolidadoDREUuid = useCallback(async () => {
         let {consolidado_dre_uuid} = params
@@ -229,7 +229,7 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
     }
 
     const disableBtnVerResumo = () => {
-        let disabled = true
+        let disabled = false
         if(habilitaVerResumoAcertoEmDocumento){
             disabled = false;
         }
@@ -260,7 +260,11 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
             :
                 <>
                     <div className="page-content-inner">
-                        <BarraDeStatus statusRelatorio={statusRelatorio} />
+                        {relatorioConsolidado.status_sme === "ANALISADO" ?
+                        <BarraDeStatus
+                            statusRelatorio={statusRelatorio}
+                            relatorioConsolidado={relatorioConsolidado}
+                        /> : null }
                         <Cabecalho relatorioConsolidado={relatorioConsolidado}/>
                         <BotoesAvancarRetroceder
                             relatorioConsolidado={relatorioConsolidado}

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/TopoComBotoes/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/TopoComBotoes/index.js
@@ -19,6 +19,17 @@ export const TopoComBotoes = ({relatorioConsolidado, dataLimiteDevolucao, tabAtu
         document.location.reload()
     }, [dataLimiteDevolucao, relatorioConsolidado, setLoading])
 
+    const obterUuid = () => {
+        if (relatorioConsolidado?.analise_atual) {
+            return relatorioConsolidado.analise_atual.consolidado_dre;
+        } else if (relatorioConsolidado?.analises_do_consolidado_dre) {
+            return relatorioConsolidado.analises_do_consolidado_dre[relatorioConsolidado.analises_do_consolidado_dre.length - 1]?.consolidado_dre;
+        } else {
+            return null;
+        }
+    }
+    
+
     let history = useHistory();
 
     return (
@@ -29,9 +40,7 @@ export const TopoComBotoes = ({relatorioConsolidado, dataLimiteDevolucao, tabAtu
                 </h2>
                 <div className="container-botoes">
                     <Button variant="outline-success"
-                        onClick={
-                            () => history.push('/analise-relatorio-consolidado-dre-detalhe/'+ relatorioConsolidado.analise_atual.consolidado_dre + '/')
-                    }>
+                        onClick={() => history.push(`/analise-relatorio-consolidado-dre-detalhe/${obterUuid()}/`)}>
                         Voltar
                     </Button>
                     {tabAtual === 'conferencia-atual' &&              


### PR DESCRIPTION
- [x] Exibi o cabeçalho padrão do relatório e a barra de status indicando "4 - Concluída"
- [x] Exibi os campos "Responsável pela análise" e "Início da análise" preenchidos e como somente leitura
- [x] Oferece a opção "Voltar" para que o usuário possa retornar à tela anterior e visualizar todos os relatórios com todos os status
- [x] Oferece a opção "Analisar" e permitir que o usuário altere o status do relatório para "Em análise" e retorne à tela de detalhamento do relatório como "Em análise"


Historía#AB74210