### PR TITLE
feat(83473): Não permitir marcar como justificado

### DIFF
--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDocumentos/index.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDocumentos/index.js
@@ -184,10 +184,17 @@ const AcertosDocumentos = ({analiseAtualUuid, prestacaoDeContas, prestacaoDeCont
     const justificarNaoRealizacaoDocumentos = async (textoConfirmadoJustificado) => {
         try {
             let selecionados = getSolicitacoesSelecionadas();
-            await postJustificarNaoRealizacaoDocumentoPrestacaoConta({
+            let response = await postJustificarNaoRealizacaoDocumentoPrestacaoConta({
                 "uuids_solicitacoes_acertos_documentos": selecionados.map(doc => doc.uuid),
                 "justificativa": textoConfirmadoJustificado
             })
+
+            if (response && !response.todas_as_solicitacoes_marcadas_como_justificado){
+                // Reaproveitando o modal CheckNaoPermitido
+                setTituloModalCheckNaoPermitido('Não é possível marcar a solicitação como justificada')
+                setTextoModalCheckNaoPermitido(`<p>${response.mensagem}</p>`)
+                setShowModalCheckNaoPermitido(true)
+            }
             await carregaAcertosDocumentos()
         }catch (e) {
             console.log("Erro ao justificarNaoRealizacaoDocumentos")
@@ -394,7 +401,7 @@ const AcertosDocumentos = ({analiseAtualUuid, prestacaoDeContas, prestacaoDeCont
                                                         onChange={(event) => handleChangeTextareaEsclarecimentoDocumento(event, acerto.uuid)}
                                                         className="form-control"
                                                         placeholder="Digite aqui o esclarecimento"
-                                                        disabled={![['change_analise_dre']].some(visoesService.getPermissoes) || visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'DRE' || prestacaoDeContas.status !== 'DEVOLVIDA' || !analisePermiteEdicao}
+                                                        disabled={![['change_analise_dre']].some(visoesService.getPermissoes) || visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'DRE' || prestacaoDeContas.status !== 'DEVOLVIDA' || !analisePermiteEdicao || acerto.status_realizacao === "JUSTIFICADO"}
                                                     />
                                                 </div>
                                             }

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/index.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/index.js
@@ -254,10 +254,16 @@ const AcertosLancamentos = ({
     const justificarNaoRealizacao = async (textoConfirmadoJustificado) => {
         setLoadingLancamentos(true)
         let selecionados = getSolicitacoesSelecionadas();
-        await postJustificarNaoRealizacaoLancamentoPrestacaoConta({
+        let response = await postJustificarNaoRealizacaoLancamentoPrestacaoConta({
             "uuids_solicitacoes_acertos_lancamentos": selecionados.map(lanc => lanc.uuid),
             "justificativa": textoConfirmadoJustificado
-        })
+        });
+        if (response && !response.todas_as_solicitacoes_marcadas_como_justificado){
+            // Reaproveitando o modal CheckNaoPermitido
+            setTituloModalCheckNaoPermitido('Não é possível marcar a solicitação como justificada')
+            setTextoModalCheckNaoPermitido(`<p>${response.mensagem}</p>`)
+            setShowModalCheckNaoPermitido(true)
+        }
         await carregaAcertosLancamentos(contaSelecionada)
         setLoadingLancamentos(false)
     }
@@ -539,7 +545,7 @@ const AcertosLancamentos = ({
                                                                 onChange={(event) => handleChangeTextareaEsclarecimentoLancamento(event, acerto.uuid)}
                                                                 className="form-control"
                                                                 placeholder="Digite aqui o esclarecimento"
-                                                                disabled={![['change_analise_dre']].some(visoesService.getPermissoes) || visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'DRE' || prestacaoDeContas.status !== 'DEVOLVIDA' || !analisePermiteEdicao}
+                                                                disabled={![['change_analise_dre']].some(visoesService.getPermissoes) || visoesService.getItemUsuarioLogado('visao_selecionada.nome') === 'DRE' || prestacaoDeContas.status !== 'DEVOLVIDA' || !analisePermiteEdicao || acerto.status_realizacao === "JUSTIFICADO"}
                                                             />
                                                         </div>
                                                     </div>


### PR DESCRIPTION
feat(83473): Não permitir marcar como justificado

Esse PR:

- Adiciona regra para desabilitar caixa de esclarecimento quando o status for justificado
- Adiciona modal informando que não foi possivel justificar o acerto

História: [AB#83473](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/83473)