### PR TITLE
feat(83020): Não permitir que a PC retificada retorne para o status de Não Recebida

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -115,7 +115,7 @@ export const GetComportamentoPorStatus = (
                         metodoAvancar={analisarPrestacaoDeContas}
                         metodoRetroceder={() => setShowNaoRecebida(true)}
                         disabledBtnAvancar={!TEMPERMISSAO}
-                        disabledBtnRetroceder={!TEMPERMISSAO}
+                        disabledBtnRetroceder={bloqueiaBtnRetroceder() || !TEMPERMISSAO}
                     />
                     <TrilhaDeStatus
                         prestacaoDeContas={prestacaoDeContas}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
@@ -1022,7 +1022,7 @@ export const DetalhePrestacaoDeContas = () =>{
     }
 
     const bloqueiaBtnRetroceder = () => {
-        if(prestacaoDeContas && prestacaoDeContas.status === "EM_ANALISE" && pcEmRetificacao()){
+        if((prestacaoDeContas && (prestacaoDeContas.status === "EM_ANALISE" || prestacaoDeContas.status === "RECEBIDA") && pcEmRetificacao())){
             return true;
         }
         


### PR DESCRIPTION
Esse PR:

- Bloqueia o botão de retroceder o recebimento de um PC em retificação
- Modifica a função que gerência o bloqueio do botão retroceder PCs adicionando a condição para verificar PC recebida

História: [AB#83020](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/83020)