### PR TITLE
fix(85660): Monitoramento de PCs: reversão de devoluções não pode apagar os arquivos, apenas alterar o status para devolvido

### DIFF
--- a/src/componentes/Globais/Cabecalho/ModalNotificaErroConcluirPC.js
+++ b/src/componentes/Globais/Cabecalho/ModalNotificaErroConcluirPC.js
@@ -13,7 +13,7 @@ export const ModalNotificaErroConcluirPC = (props) =>{
             primeiroBotaoCss="outline-success"
             segundoBotaoOnclick={props.irParaConcluirPc}
             segundoBotaoCss="success"
-            segundoBotaoTexto="Ir para Geração e Fechar"
+            segundoBotaoTexto="Ir para concluir"
         />
     )
 };

--- a/src/context/Notificacoes/index.js
+++ b/src/context/Notificacoes/index.js
@@ -128,7 +128,7 @@ export const NotificacaoContextProvider = ({children}) => {
                     handleClose={()=>setShow(false)}
                     irParaConcluirPc={irParaConcluirPc}
                     titulo="Atenção"
-                    texto={`<p>A geração da prestação de contas ${periodoErroConcluirPc} não foi finalizada corretamente, favor efetuar a geração novamente.`}
+                    texto={`<p>Houve um problema na conclusão do período/acerto ${periodoErroConcluirPc}. Favor concluir novamente.`}
                 />
             </section>
         </>


### PR DESCRIPTION
Esse PR:

- Altera texto modal erro ao concluir PC

História: [AB#85660](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85660)