### PR TITLE
feat(80219): Altera texto ata da retificação de consolidado

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "1.33.5",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,22 +1,44 @@
 import React from "react";
 
-export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia}) => {
-    
-    return(
+export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia, ehRetificacao, motivoRetificacao}) => {
+
+    const getTexto = (ehRetificacao) => {
+        const baseLegal = "conforme incisos III e IV do art. 34 da Portaria SME nº 6.634/2021"
+
+        const textoBase = `${retornaDadosAtaFormatado("data_reuniao")}, às ${retornaDadosAtaFormatado("hora_reuniao")},
+         reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de Educação 
+         ${retornaDadosAtaFormatado("nome_dre")}, instituída pela Portaria DRE-${retornaDadosAtaFormatado("nome_dre")} 
+         nº ${retornaDadosAtaFormatado("numero_portaria")} de ${retornaDadosAtaFormatado("data_portaria")},`
+
+        const textoObjetivo = `para análise das prestações de contas ${ehRetificacao ? "RETIFICADAS" : ""} 
+        dos recursos transferidos pelo programa de Transferência de Recursos Financeiros - PTRF, 
+        período de ${retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a 
+        ${retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")}, 
+        ${ehRetificacao ? "em virtude dos seguintes motivos:" : `${baseLegal} e deliberou:`}`
+
+        const motivosRetificacao = ehRetificacao ? motivoRetificacao : ""
+
+        const deliberacaoRetificacao = ehRetificacao ? `Após análise, ${baseLegal}, a Comissão deliberou:` : ""
+
+        return <>
+            <p className="texto-dinamico-superior">{textoBase} {textoObjetivo}</p>
+            <p className="texto-dinamico-superior">{motivosRetificacao}</p>
+            <p className="texto-dinamico-superior">{deliberacaoRetificacao}</p>
+        </>
+    }
+    return (
         <>
             <p className="titulo-texto-dinamico-superior mb-2">{retornaTituloCorpoAta()} {retornaDadosAtaFormatado("numero_ata")}</p>
             {ehPrevia() &&
                 <p className="texto-atencao">
-                    Atenção! Essa é apenas uma prévia da ata. As informações aqui exibidas podem mudar até a publicação do relatório consolidado. A ata final só poderá ser criada após a publicação.
+                    Atenção! Essa é uma versão prévia da ata. As informações aqui exibidas podem ser alteradas até a
+                    publicação do consolidado das PCs. A ata final só poderá ser gerada após a publicação do
+                    consolidado.
                 </p>
             }
-            
-            <p className="texto-dinamico-superior">
-                {retornaDadosAtaFormatado("data_reuniao")}, às {retornaDadosAtaFormatado("hora_reuniao")}, reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de Educação {retornaDadosAtaFormatado("nome_dre")},
-                instituída pela Portaria DRE-{retornaDadosAtaFormatado("nome_dre")} nº {retornaDadosAtaFormatado("numero_portaria")} de {retornaDadosAtaFormatado("data_portaria")}, para análise das prestações de contas dos recursos transferidos pelo
-                Programa de Transferência de Recursos Financeiros - PTRF, período de {retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a {retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")},
-                conforme inciso III e IV do art. 34 da Portaria SME nº 6.634/2021 e deliberou:
-            </p>
+
+            {getTexto(ehRetificacao)}
+
         </>
     )
 }

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
@@ -184,13 +184,7 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
     }
 
     const ehPrevia = () => {
-        if(!consolidadoDre.uuid){
-            return true;
-        }
-        else if(consolidadoDre.uuid && consolidadoDre.versao === "PREVIA"){
-            return true;
-        }
-        return false;
+        return dadosAta && dadosAta.versao === "PREVIA";
     }
 
     const handleClickFecharAtaParecerTecnico = () => {
@@ -240,6 +234,8 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
                                 retornaDadosAtaFormatado={retornaDadosAtaFormatado}
                                 retornaTituloCorpoAta={retornaTituloCorpoAta}
                                 ehPrevia={ehPrevia}
+                                ehRetificacao={dadosAta.eh_retificacao}
+                                motivoRetificacao={dadosAta.motivo_retificacao}
                             />
                         }
 


### PR DESCRIPTION
Esse PR altera a exibição em tela da ata de um consolidado DRE :
- O texto da ata é alterado para os casos que tratar-se de uma retificação de consolidado DRE.
- A condição para exibição do alerta de prévia também foi revisto.

[AB#80219](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/80219)