### PR TITLE
feat(83915): Editar Retificação - Incluir PCs na Retificação - Parte 2

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
@@ -37,6 +37,7 @@ const RetificacaoRelatorioConsolidado = () => {
     const [ehEdicaoRetificacao, setEhEdicaoRetificacao] = useState(null);
     const [tabelaAssociacoes, setTabelaAssociacoes] = useState({});
     const [pcsRetificaveis, setPcsRetificaveis] = useState(false);
+    const [todasAsPcsRetificaveis, setTodasAsPcsRetificaveis] = useState(false);
     const [pcsEmRetificacao, setPcsEmRetificacao] = useState(false);
     const [quantidadeSelecionada, setQuantidadeSelecionada] = useState(0);
     const [quantidadeSelecionadaEmRetificacao, setQuantidadeSelecionadaEmRetificacao] = useState(0);
@@ -63,7 +64,7 @@ const RetificacaoRelatorioConsolidado = () => {
             setRelatorioConsolidado(consolidado);
             setLoading(false);
         }
-
+        
     }, [relatorio_consolidado_uuid])
 
     useEffect(() => {
@@ -100,6 +101,7 @@ const RetificacaoRelatorioConsolidado = () => {
                 });
 
             setPcsRetificaveis(pcs)
+            setTodasAsPcsRetificaveis(pcs)
             setLoadingPcsRetificaveis(false);
         }
 
@@ -747,7 +749,7 @@ const RetificacaoRelatorioConsolidado = () => {
                                 </>
                             }
 
-                            {pcsRetificaveis.length > 0 &&
+                            {todasAsPcsRetificaveis.length > 0 &&
                                 <>
                                     <TituloTabela
                                     titulo={"Unidades com PCs não retificadas"}


### PR DESCRIPTION
Esse PR:

- Adiciona um estado totalizando as PCs retificáveis
- Adiciona a verificação de visibilidade do bloco de PCs retificáveis

História: [AB#83915](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/83915)