### PR TITLE
feat(82945): Não exibir blocos de comentários e acertos

### DIFF
--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/ComentariosNotificados/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/ComentariosNotificados/index.js
@@ -1,26 +1,41 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import './styles.scss'
 import useDataTemplate from "../../../../../hooks/Globais/useDataTemplate";
 
 export const ComentariosNotificados = ({comentarios}) => {
     const dataTemplate = useDataTemplate()
 
-    return (
-        <>
-            <h5 className="mb-4 mt-5"><strong>Comentários Notificados</strong></h5>
+    const [comentariosNotificados, setComentariosNotificados] = useState([])
 
-            {comentarios.length ? '' : <p> Exibindo <strong>0</strong> comentários</p>}
-            {comentarios.map((value, index) => {
-                if (value.notificado) {
-                    return (
-                        <Fragment key={index}>
-                        <span className='mb-2'><strong>Data da notificação : </strong>{dataTemplate(null, null, value.notificado_em)}</span>
-                        <input className="form-control form-control-md mb-2" type="text"  defaultValue={value.comentario}/>
-                        </Fragment>
-                    )
-                }
-            })}
-            
-        </>
+    useEffect(() => {
+        let comentariosNotificadosFiltrados = comentarios.reduce(function(notificados, comentario){
+              if(comentario.notificado) {
+                return [...notificados, comentario];
+              }
+              return [...notificados];
+        }, []);
+
+        setComentariosNotificados(comentariosNotificadosFiltrados)
+    },[comentarios])
+
+    return (
+            comentariosNotificados.length > 0 ?
+                (
+                <>
+                    <h5 className="mb-4 mt-5"><strong>Comentários Notificados</strong></h5>
+
+                    {comentarios.map((value, index) => {
+                        if (value.notificado) {
+                            return (
+                                <Fragment key={index}>
+                                <span className='mb-2'><strong>Data da notificação : </strong>{dataTemplate(null, null, value.notificado_em)}</span>
+                                <input className="form-control form-control-md mb-2" type="text"  defaultValue={value.comentario}/>
+                                </Fragment>
+                            )
+                        }
+                    })}
+                    
+                </>
+                ) : <></>
         )
 }

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/TabelaConferenciaDeDocumentosRelatorios/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEResumoAcertos/TabelaConferenciaDeDocumentosRelatorios/index.js
@@ -33,39 +33,40 @@ export const TabelaConferenciaDeDocumentosRelatorios = ({ relatorioConsolidado, 
     }
 
     return (
-        <>
-            <h5 className="mb-4 mt-4"><strong>Acertos nos documentos</strong></h5>
-            {listaDocumentoHistorico?.length || listaDeDocumentosRelatorio?.length ? <DataTable
-                value={tabAtual === 'historico' ? listaDocumentoHistorico : listaDeDocumentosRelatorio}
-                paginator={
-                    0 > rowsPerPage
-                }
-                rows={rowsPerPage}
-                expandedRows={expandedRowsDocumentos}
-                onRowToggle={(e) => setExpandedRowsDocumentos(e.data)}
-                rowExpansionTemplate={rowExpansionTemplateDocumentos}
-                paginatorTemplate="PrevPageLink PageLinks NextPageLink"
-                stripedRows
-                className=""
-                autoLayout={true}>
+         listaDocumentoHistorico && listaDeDocumentosRelatorio && (listaDocumentoHistorico?.length || listaDeDocumentosRelatorio?.length) ?
+            (
+                <>
+                <h5 className="mb-4 mt-4"><strong>Acertos nos documentos</strong></h5>
+                <DataTable
+                    value={tabAtual === 'historico' ? listaDocumentoHistorico : listaDeDocumentosRelatorio}
+                    paginator={
+                        0 > rowsPerPage
+                    }
+                    rows={rowsPerPage}
+                    expandedRows={expandedRowsDocumentos}
+                    onRowToggle={(e) => setExpandedRowsDocumentos(e.data)}
+                    rowExpansionTemplate={rowExpansionTemplateDocumentos}
+                    paginatorTemplate="PrevPageLink PageLinks NextPageLink"
+                    stripedRows
+                    className=""
+                    autoLayout={true}>
 
-                <Column header={'Nome do Documento'}
-                    field='nome'
-                    className="align-middle text-left borda-coluna"
-                    style={
-                        {
-                            borderLeft: 'none',
-                            width: '200px'
-                        }
-                    } />
-                    <Column 
-                    header=''
-                    expander
-                    style={{width: '4%'}}
-                /> 
-            </DataTable>: 
-                <p>Exibindo <strong>0</strong> documentos</p>
-                }
-        </>
+                    <Column header={'Nome do Documento'}
+                        field='nome'
+                        className="align-middle text-left borda-coluna"
+                        style={
+                            {
+                                borderLeft: 'none',
+                                width: '200px'
+                            }
+                        } />
+                        <Column 
+                        header=''
+                        expander
+                        style={{width: '4%'}}
+                    /> 
+                </DataTable>
+                </>
+            ) : <></>
     )
 }


### PR DESCRIPTION
Esse PR:

- Modifica a visualização do bloco de comentários notificados, baseado em um novo estado
- Modifica a visualização do bloco de acertos

História: [AB#82945](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/82945)