### PR TITLE
feat(80272): Gera relatório consolidado automaticamente - Parte 3

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/index.js
@@ -50,6 +50,7 @@ const RelatorioConsolidado = () => {
 
     const [trilhaStatus, setTrilhaStatus] = useState(false);
     const [loading, setLoading] = useState(false);
+    const [loadingRelatorioConsolidado, setLoadingRelatorioConsolidado] = useState(false);
     const [disableGerar, setDisableGerar] = useState(true);
 
     const carregaPeriodos = useCallback(async () => {
@@ -164,14 +165,14 @@ const RelatorioConsolidado = () => {
 
     useEffect(() => {
         if (statusProcessamentoRelatorioConsolidadoDePublicacoesParciais && statusProcessamentoRelatorioConsolidadoDePublicacoesParciais === "EM_PROCESSAMENTO") {
-            setLoading(true)
+            setLoadingRelatorioConsolidado(true)
             const timer = setInterval(() => {
                 retornaStatusProcessamentoRelatorioConsolidadoDePublicacoesParciais();
-            }, 5000);
+            }, 6000);
             // clearing interval
             return () => clearInterval(timer);
         } else {
-            setLoading(false);
+            setLoadingRelatorioConsolidado(false);
         }
     }, [statusProcessamentoRelatorioConsolidadoDePublicacoesParciais, retornaStatusProcessamentoRelatorioConsolidadoDePublicacoesParciais]);
 
@@ -282,10 +283,9 @@ const RelatorioConsolidado = () => {
             } else {
                 let publicar = await postPublicarConsolidadoDre(payload);
                 setStatusProcessamentoConsolidadoDre(publicar.status);
+                setStatusProcessamentoRelatorioConsolidadoDePublicacoesParciais('EM_PROCESSAMENTO');
+                await carregaConsolidadosDreJaPublicadosProximaPublicacao()
             }
-            verificarStatusRelatorioConsolidado()
-
-            await carregaConsolidadosDreJaPublicadosProximaPublicacao()
         } catch (e) {
             console.log("Erro ao publicar Consolidado Dre ", e)
         }
@@ -306,24 +306,11 @@ const RelatorioConsolidado = () => {
             } else {
                 let publicar = await postPublicarConsolidadoDre(payload);
                 setStatusProcessamentoConsolidadoDre(publicar.status);
+                setStatusProcessamentoRelatorioConsolidadoDePublicacoesParciais('EM_PROCESSAMENTO');
+                await carregaConsolidadosDreJaPublicadosProximaPublicacao()
             }
-            verificarStatusRelatorioConsolidado()
-
-            await carregaConsolidadosDreJaPublicadosProximaPublicacao()
         } catch (e) {
             console.log("Erro ao publicar Consolidado Dre ", e)
-        }
-    }
-
-    const verificarStatusRelatorioConsolidado = async () => {
-        try {
-            let statusRelatorioConsolidado = await getStatusRelatorioConsolidadoDePublicacoesParciais(dre_uuid, periodoEscolhido)
-
-            if(statusRelatorioConsolidado && statusRelatorioConsolidado.status) {
-                setStatusProcessamentoRelatorioConsolidadoDePublicacoesParciais(statusRelatorioConsolidado.status);
-            }
-        } catch (e) {
-            console.log("Erro ao verificar status do Relatório Consolidado ", e)
         }
     }
 
@@ -398,7 +385,7 @@ const RelatorioConsolidado = () => {
                                     retornaCorCirculoTrilhaStatus={retornaCorCirculoTrilhaStatus}
                                     eh_circulo_duplo={eh_circulo_duplo}
                                 />
-                                {loading ? (
+                                {loading || loadingRelatorioConsolidado ? (
                                         <div className="mt-5">
                                             <Loading
                                                 corGrafico="black"


### PR DESCRIPTION
Esse PR:

- Adiciona um estado específico para o carregamento do relatório consolidado
- Modifica o estado do relatório consolidado automaticamente ao gerar um consolidado
- Remove função não mais utilizada de verificação de status do relatório consolidado

História: [AB#80272](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/80272)