### PR TITLE
feat(84792): Incluir orientação para o usuário na opção de Concluir

### DIFF
--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BotoesAvancarRetroceder/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/BotoesAvancarRetroceder/index.js
@@ -1,8 +1,9 @@
 import React from "react";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faAngleDoubleLeft, faAngleDoubleRight} from "@fortawesome/free-solid-svg-icons";
+import ReactTooltip from "react-tooltip";
 
-export const BotoesAvancarRetroceder = ({relatorioConsolidado, metodoAvancar, metodoRetroceder, disabledBtnAvancar, disabledBtnRetroceder}) =>{
+export const BotoesAvancarRetroceder = ({relatorioConsolidado, metodoAvancar, metodoRetroceder, disabledBtnAvancar, disabledBtnRetroceder, tooltipAvançar=null}) =>{
     return(
         <>
             {Object.entries(relatorioConsolidado).length > 0 &&
@@ -30,11 +31,13 @@ export const BotoesAvancarRetroceder = ({relatorioConsolidado, metodoAvancar, me
                                 disabled={!relatorioConsolidado.botoes_avancar_e_retroceder.habilita_botao_avancar || disabledBtnAvancar }
                                 className="btn btn-success ml-2"
                             >
-                                {relatorioConsolidado.botoes_avancar_e_retroceder.texto_botao_avancar}
-                                <FontAwesomeIcon
-                                    style={{marginLeft: "5px", color: '#fff'}}
-                                    icon={faAngleDoubleRight}
-                                />
+                                <span data-tip={tooltipAvançar}>{relatorioConsolidado.botoes_avancar_e_retroceder.texto_botao_avancar} 
+                                    <FontAwesomeIcon
+                                        style={{marginLeft: "5px", color: '#fff'}}
+                                        icon={faAngleDoubleRight}
+                                    />    
+                                </span>
+                                {tooltipAvançar && <ReactTooltip place="left"/>}
                             </button>
                         </div>
                     }

--- a/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
+++ b/src/componentes/sme/AcompanhamentoRelatoriosConsolidadosSME/AcompanhamentoDeRelatorioConsolidadoSMEDetalhe/index.js
@@ -244,6 +244,22 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
         return disabled
     }
 
+    const adicionaTooltipBtnAvancar = () => {
+        if(!relatorioConsolidado.botoes_avancar_e_retroceder.habilita_botao_avancar && relatorioConsolidado.status_sme === "EM_ANALISE") {
+            return 'Para concluir a análise da publicação é necessário realizar a conferência de todos os documentos.'
+        }
+
+        if(!selectedResponsavel && relatorioConsolidado.status_sme === "EM_ANALISE") {
+            return 'Para concluir a análise da publicação é necessário selecionar o responsável.'
+        }
+
+        if(!selectedResponsavel && relatorioConsolidado.status_sme === "PUBLICADO") {
+            return 'Para iniciar a análise da publicação é necessário selecionar o responsável.'
+        }
+
+        return null;
+    }
+
     return(
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Acompanhamento da documentação da DRE</h1>
@@ -272,6 +288,7 @@ export const AcompanhamentoDeRelatorioConsolidadoSMEDetalhe = () => {
                             metodoRetroceder={handleRetroceder}
                             disabledBtnAvancar={disabledBtnAvancar}
                             disabledBtnRetroceder={disabledBtnRetroceder}
+                            tooltipAvançar={adicionaTooltipBtnAvancar()}
                         />
                         <TrilhaDeStatus relatorioConsolidado={relatorioConsolidado}/>
                         <ResponsavelAnalise


### PR DESCRIPTION
Esse PR:

- adiciona função seletiva para a mensagem do botão de avançar o acompanhamento do relatorio
- adiciona prop que repassa a mensagem para o componente BotoesAvancarRetroceder

História: [AB#84792](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/84792)