### PR TITLE
feat(85901): Inclui tratamento de categorias de conciliação

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/FormularioAcertos.js
@@ -25,17 +25,14 @@ export const FormularioAcertos = ({solicitacoes_acerto, listaTiposDeAcertoLancam
     const {setIsValorParcialValido} = useContext(ValidarParcialTesouro)
 
     const categoriaNaoPodeRepetir = (categoria) => {
-        if(categoria.id === 'DEVOLUCAO'){
-            return true;
-        }
-        else if(categoria.id === 'EXCLUSAO_LANCAMENTO'){
-            return true;
-        }
-        else if(categoria.id === 'SOLICITACAO_ESCLARECIMENTO'){
-            return true;
-        }
-
-        return false;
+        const categoriasQueNaoPodemRepetir = [
+            'DEVOLUCAO',
+            'EXCLUSAO_LANCAMENTO',
+            'SOLICITACAO_ESCLARECIMENTO',
+            'CONCILIACAO_LANCAMENTO',
+            'DESCONCILIACAO_LANCAMENTO'
+        ];
+        return categoriasQueNaoPodemRepetir.includes(categoria.id);
     }
 
     const categoriaNaoTemItensParaExibir = (categoria) => {

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
@@ -50,6 +50,11 @@ export const DetalharAcertos = () => {
         let mounted = true;
 
         const carregaTiposDeAcertoLancamentos = async () => {
+            const categoriasQueSoAceitamGatos = [
+                'DEVOLUCAO',
+                'CONCILIACAO_LANCAMENTO',
+                'DESCONCILIACAO_LANCAMENTO'
+            ];
             if (mounted){
                 setLoading(true)
                 let tipos_de_acerto_lancamentos_agrupado = await getTiposDeAcertoLancamentosAgrupadoCategoria()
@@ -57,7 +62,7 @@ export const DetalharAcertos = () => {
                 
                 let tem_gasto = verificaSeTemLancamentosDoTipoGasto()
                 if (!tem_gasto) {
-                    tipos_de_acerto_lancamentos_agrupado = tipos_de_acerto_lancamentos_agrupado.filter(elemento => elemento.id !== 'DEVOLUCAO')
+                    tipos_de_acerto_lancamentos_agrupado = tipos_de_acerto_lancamentos_agrupado.filter(elemento => !categoriasQueSoAceitamGatos.includes(elemento.id))
                 }
 
                 setListaTiposDeAcertoLancamentosAgrupado(tipos_de_acerto_lancamentos_agrupado)


### PR DESCRIPTION
Esse PR:
- Altera a análise de lançamentos de PC para considerar as categorias de acerto de conciliação
- Bloqueia a repetição de solicitações repetidas nessas categorias
- Bloqueia a exibição dessas categorias em lançamentos de tipo crédito
- Trata a exibição das categorias conforme situação de conciliação da despesa

História: [AB#85901](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/85901)
