### PR TITLE
fix(89842): Exibe info de pcs não apresentadas

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/ListaPrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/ListaPrestacaoDeContas/index.js
@@ -196,19 +196,20 @@ export const ListaPrestacaoDeContas = () => {
     };
 
     const gravaPcNaoApresentada = (rowData) =>{
+        console.log('rowData', rowData)
         let obj_prestacao = {
             associacao: {
                 uuid: rowData.associacao_uuid,
                 nome: rowData.unidade_nome,
-                cnpj: '',
+                cnpj: rowData.associacao.cnpj,
                 unidade: {
-                    codigo_eol:'',
+                    codigo_eol:rowData.associacao.unidade.codigo_eol,
                 },
                 presidente_associacao:{
-                    nome:'',
+                    nome:rowData.associacao.presidente_associacao.nome,
                 },
                 presidente_conselho_fiscal:{
-                    nome:'',
+                    nome:rowData.associacao.presidente_conselho_fiscal.nome,
                 }
             },
             periodo_uuid: rowData.periodo_uuid,


### PR DESCRIPTION
Esse PR:
- Altera o cabeçalho de pc para exibir informações da associação mesmo quando não apresentada.

Corrige AB#89842