### PR TITLE
feat(89378): Adiciona o campo observação no modal de associação

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -143,23 +143,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                     </div>
                                 </div>
                                 <div className='row'>
-                                    <div className='col'>
-                                        <label htmlFor="status_regularidade">Status de regularidade</label>
-                                        <select
-                                            value={props.values.status_regularidade}
-                                            onChange={props.handleChange}
-                                            name="status_regularidade"
-                                            id="status_regularidade"
-                                            className="form-control"
-                                        >
-                                            <option value=''>Selecione um status</option>
-                                            {tabelaAssociacoes && tabelaAssociacoes.status_regularidade && tabelaAssociacoes.status_regularidade.length > 0 && tabelaAssociacoes.status_regularidade.map((status) =>
-                                                <option key={status.id} value={status.id}>{status.nome}</option>
-                                            )}
-                                        </select>
-                                        {props.touched.status_regularidade && props.errors.status_regularidade && <span className="span_erro text-danger mt-1"> {props.errors.status_regularidade} </span>}
-                                    </div>
-                                    <div className='col'>
+                                    <div className='col-6'>
                                         <div className="form-group">
                                             <label htmlFor="processo_regularidade">Nº processo regularidade</label>
                                             <MaskedInput
@@ -174,6 +158,26 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                             {props.touched.processo_regularidade && props.errors.processo_regularidade && <span className="span_erro text-danger mt-1"> {props.errors.processo_regularidade} </span>}
                                         </div>
                                     </div>
+                                </div>
+                                <div className='row mb-0'>
+                                    <div className='col-12'>
+                                        <div className="form-group">
+                                            <label htmlFor="observacao">Observação</label>
+                                            <input
+                                                type="text"
+                                                value={props.values.observacao}
+                                                name="observacao"
+                                                id="observacao"
+                                                className="form-control"
+                                                onChange={props.handleChange}
+                                            />
+                                            <small class="form-text text-muted">Preencha este campo, se necessário, com informações relacionadas a unidade educacional.</small>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="row">
+                                    <div className="col">
+                                                                            </div>
                                 </div>
                                 <div className='row mt-3'>
                                     <div className='col'>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -3,6 +3,8 @@ import {ModalFormBodyText} from "../../../../Globais/ModalBootstrap";
 import {Formik} from "formik";
 import {YupSignupSchemaAssociacoes, exibeDataPT_BR} from "../../../../../utils/ValidacoesAdicionaisFormularios";
 import MaskedInput from "react-text-mask";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faExclamationCircle} from '@fortawesome/free-solid-svg-icons'
 
 const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitModalFormAssociacoes, listaDePeriodos, tabelaAssociacoes, carregaUnidadePeloCodigoEol, errosCodigoEol, onDeleteAssocicacaoTratamento}) => {
 
@@ -171,7 +173,13 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                                 className="form-control"
                                                 onChange={props.handleChange}
                                             />
-                                            <small class="form-text text-muted">Preencha este campo, se necessário, com informações relacionadas a unidade educacional.</small>
+                                                <small className="form-text text-muted">
+                                                    <FontAwesomeIcon
+                                                        style={{fontSize: '12px', marginRight:'4px'}}
+                                                        icon={faExclamationCircle}
+                                                    /> 
+                                                    <span>Preencha este campo, se necessário, com informações relacionadas a unidade educacional.</span>
+                                                </small>
                                         </div>
                                     </div>
                                 </div>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -91,6 +91,7 @@ export const Associacoes = () => {
         nome: '',
         uuid_unidade: '',
         codigo_eol_unidade: '',
+        observacao: '',
         tipo_unidade: '',
         nome_unidade: '',
         cnpj: '',
@@ -144,6 +145,7 @@ export const Associacoes = () => {
             nome: associacao_por_uuid.nome,
             uuid_unidade: associacao_por_uuid.unidade.uuid,
             codigo_eol_unidade: associacao_por_uuid.unidade.codigo_eol,
+            observacao: associacao_por_uuid.unidade.observacao,
             tipo_unidade: associacao_por_uuid.unidade.tipo_unidade,
             nome_unidade: associacao_por_uuid.unidade.nome,
             cnpj: associacao_por_uuid.cnpj,
@@ -211,7 +213,8 @@ export const Associacoes = () => {
                             logradouro: '',
                             bairro: '',
                             cep: ''
-                        }
+                        },
+                        observacao: values.observacao
                     };
                     try {
                         await postCriarAssociacao(payload);
@@ -233,7 +236,7 @@ export const Associacoes = () => {
                         status_regularidade: values.status_regularidade,
                         processo_regularidade: values.processo_regularidade,
                         unidade: values.uuid_unidade,
-
+                        observacao: values.observacao,
                     };
                     try {
                         await patchUpdateAssociacao(values.uuid, payload);

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -60,7 +60,6 @@ export const checkDuplicateInObject = (propertyName, inputArray) => {
 export const YupSignupSchemaAssociacoes  = yup.object().shape({
   nome: yup.string().required("Nome é obrigatório"),
   codigo_eol_unidade: yup.string().required("Código EOL da unidade é obrigatório"),
-  status_regularidade: yup.string().required("Status de regularidade é obrigatório"),
   cnpj: yup.string()
   .test('test-name', 'Digite um CNPJ Válido',
       function (value) {


### PR DESCRIPTION
Esse PR:

- Adiciona o campo observação na modal de criar e ditar associações com um help-text informativo.
- Remove o campo status de regularidade que não é mais utilizado na modal de criar/editar associação. Remove a sua verificação no frontend.
- Modifica o payload enviado para a API que altera as assoçiações/unidades.

História: [AB#89378](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/89378)