### PR TITLE
fix(90108): Adiciona identificar único na tooltip e sua referência

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/IconeEditarRetificacao.js
+++ b/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/IconeEditarRetificacao.js
@@ -20,7 +20,7 @@ const IconeEditarRetificacao = ({consolidadoDre}) => {
     return (
         <>
             {consolidadoDre && consolidadoDre?.ja_publicado && consolidadoDre?.data_publicacao && consolidadoDre?.eh_retificacao && 
-                <div data-tip={retornaMsgToolTip()} data-html={true} style={{display:'inline'}}>
+                    <div data-tip={retornaMsgToolTip()} data-html={true} style={{display:'inline'}} data-for={`tooltip-id-${consolidadoDre.uuid}`}>
                     <button
                         onClick={(e) => console.log(e)}
                         className="btn btn-link pt-1 pb-1 pl-2 pr-0"
@@ -30,7 +30,7 @@ const IconeEditarRetificacao = ({consolidadoDre}) => {
                             style={{marginRight: "0", color: '#00585E', fontSize: '18px'}}
                             icon={faEdit}
                         />
-                        <ReactTooltip html={true}/>
+                        <ReactTooltip id={`tooltip-id-${consolidadoDre.uuid}`} html={true}/>
 
                     </button>
                 </div>


### PR DESCRIPTION
Esse PR:

- Adiciona identificar único na tooltip e sua referência, evitando a duplam renderização devido a loops na página.

História: [AB#90108](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/90108)