### PR TITLE
fix(90066): Corrige data em conferência lançamento

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
@@ -538,7 +538,15 @@ const TabelaConferenciaDeLancamentos = ({
 
     const retornaToolTipCredito = (rowData) => {
         if (rowData.documento_mestre && rowData.documento_mestre.rateio_estornado && rowData.documento_mestre.rateio_estornado.uuid) {
-            let data_rateio = dataTemplate(null, null, rowData.documento_mestre.rateio_estornado.data_documento)
+            let data_rateio = ""
+
+            if(rowData.documento_mestre.rateio_estornado.data_documento){
+                data_rateio = dataTemplate(null, null, rowData.documento_mestre.rateio_estornado.data_documento)
+            }
+            else if(rowData.documento_mestre.rateio_estornado.data_transacao){
+                data_rateio = dataTemplate(null, null, rowData.documento_mestre.rateio_estornado.data_transacao)
+            }
+            
             let texto_tooltip = `Esse estorno está vinculado <br/> à despesa do dia ${data_rateio}.`
             return (
                 <>


### PR DESCRIPTION
Agora a tooltip de estorno utiliza a data de transação, caso não encontre a data de documento