### PR TITLE
feat(91682): Adiciona data de encerramento de associação

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -2,11 +2,21 @@ import React, {memo} from "react";
 import {ModalFormBodyText} from "../../../../Globais/ModalBootstrap";
 import {Formik} from "formik";
 import {YupSignupSchemaAssociacoes, exibeDataPT_BR} from "../../../../../utils/ValidacoesAdicionaisFormularios";
+import {DatePickerField} from "../../../../Globais/DatePickerField";
 import MaskedInput from "react-text-mask";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faExclamationCircle} from '@fortawesome/free-solid-svg-icons'
+import { visoesService } from "../../../../../services/visoes.service";
+import ReactTooltip from "react-tooltip";
 
 const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitModalFormAssociacoes, listaDePeriodos, tabelaAssociacoes, carregaUnidadePeloCodigoEol, errosCodigoEol, onDeleteAssocicacaoTratamento}) => {
+
+    const converteDataLocalParaUTC = (dateString) => {
+        const dataObj = new Date(dateString);
+        const offsetMs = dataObj.getTimezoneOffset() * 60 * 1000;
+        const utcDataObj = new Date(dataObj.getTime() + offsetMs);
+        return utcDataObj;
+    }
 
     const bodyTextarea = () => {
         return (
@@ -23,6 +33,13 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                             values,
                             setFieldValue,
                         } = props;
+
+                        let data_fim_periodo = null
+                        if(values.periodo_inicial) {
+                            let periodo = listaDePeriodos.find(periodo => periodo.uuid === values.periodo_inicial)
+                            data_fim_periodo = periodo ? periodo.data_fim_realizacao_despesas : null;
+                        }
+
                         return(
                             <form onSubmit={props.handleSubmit}>
                                 <div className='row'>
@@ -98,19 +115,19 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                         </div>
                                     </div>
                                     <div className='col'>
-                                        <label htmlFor="periodo_inicial">Período inicial</label>
-                                        <select
-                                            value={props.values.periodo_inicial && props.values.periodo_inicial ? props.values.periodo_inicial : ""}
-                                            onChange={props.handleChange}
-                                            name="periodo_inicial"
-                                            id="periodo_inicial"
-                                            className="form-control"
-                                        >
-                                            <option value=''>Selecione um período</option>
-                                            {listaDePeriodos && listaDePeriodos.map((periodo) =>
-                                                <option key={periodo.uuid} value={periodo.uuid}>{`${periodo.referencia} - ${periodo.data_inicio_realizacao_despesas ? exibeDataPT_BR(periodo.data_inicio_realizacao_despesas) : "-"} até ${periodo.data_fim_realizacao_despesas ? exibeDataPT_BR(periodo.data_fim_realizacao_despesas) : "-"}`}</option>
-                                            )}
-                                        </select>
+                                        <div className="form-group">
+                                            <label htmlFor="processo_regularidade">Nº processo regularidade</label>
+                                            <MaskedInput
+                                                mask={[/\d/, /\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, '-', /\d/]}
+                                                type="text"
+                                                value={props.values.processo_regularidade}
+                                                name="processo_regularidade"
+                                                id="processo_regularidade"
+                                                className="form-control"
+                                                onChange={props.handleChange}
+                                            />
+                                            {props.touched.processo_regularidade && props.errors.processo_regularidade && <span className="span_erro text-danger mt-1"> {props.errors.processo_regularidade} </span>}
+                                        </div>
                                     </div>
                                 </div>
                                 <div className='row'>
@@ -146,22 +163,64 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                 </div>
                                 <div className='row'>
                                     <div className='col-6'>
+                                    <label htmlFor="periodo_inicial">
+                                        Período inicial
+                                    </label>
+                                       <div data-tip={values.retorna_se_pode_editar_periodo_inicial ? values.retorna_se_pode_editar_periodo_inicial.mensagem_pode_editar_periodo_inicial : ''} data-html={true} style={{display:'inline'}} data-for={`tooltip-id-${values.uuid}`}>
+                                       <select
+                                            value={values.periodo_inicial && values.periodo_inicial ? values.periodo_inicial : ""}
+                                            onChange={props.handleChange}
+                                            name="periodo_inicial"
+                                            id="periodo_inicial"
+                                            className="form-control"
+                                            disabled={values.retorna_se_pode_editar_periodo_inicial ? !values.retorna_se_pode_editar_periodo_inicial.pode_editar_periodo_inicial : ''}
+                                        >
+                                            <option value=''>Selecione um período</option>
+                                            {listaDePeriodos && listaDePeriodos.map((periodo) =>
+                                                <option key={periodo.uuid} value={periodo.uuid}>{`${periodo.referencia} - ${periodo.data_inicio_realizacao_despesas ? exibeDataPT_BR(periodo.data_inicio_realizacao_despesas) : "-"} até ${periodo.data_fim_realizacao_despesas ? exibeDataPT_BR(periodo.data_fim_realizacao_despesas) : "-"}`}</option>
+                                            )}
+                                        </select>
+                                        <ReactTooltip id={`tooltip-id-${values.uuid}`} html={true}/>
+                                       </div>
+                                        <small className="form-text text-muted">
+                                            <FontAwesomeIcon
+                                                style={{fontSize: '12px', marginRight:'4px'}}
+                                                icon={faExclamationCircle}
+                                            /> 
+                                            <span>{values.retorna_se_pode_editar_periodo_inicial ? values.retorna_se_pode_editar_periodo_inicial.help_text : ''}</span>
+                                        </small>
+                                    </div>
+                                    <div className="col-6">
                                         <div className="form-group">
-                                            <label htmlFor="processo_regularidade">Nº processo regularidade</label>
-                                            <MaskedInput
-                                                mask={[/\d/, /\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, '-', /\d/]}
-                                                type="text"
-                                                value={props.values.processo_regularidade}
-                                                name="processo_regularidade"
-                                                id="processo_regularidade"
+                                            <label htmlFor="data_de_encerramento">
+                                                Data de encerramento
+                                            </label>
+                                            <DatePickerField
+                                                name="data_de_encerramento"
+                                                id="data_de_encerramento"
+                                                value={values.data_de_encerramento !== null ? values.data_de_encerramento : ""}
+                                                onChange={visoesService.getPermissoes(['change_encerrar_associacoes']) ? (name, val) => {
+                                                    setFieldValue(name, val ? val.toISOString().substr(0, 10) : null)
+                                                    }: null}
+                                                disabled={!visoesService.getPermissoes(['change_encerrar_associacoes'])}
                                                 className="form-control"
-                                                onChange={props.handleChange}
+                                                minDate={converteDataLocalParaUTC(data_fim_periodo)}
+                                                maxDate={new Date()}
                                             />
-                                            {props.touched.processo_regularidade && props.errors.processo_regularidade && <span className="span_erro text-danger mt-1"> {props.errors.processo_regularidade} </span>}
+                                            {props.errors.data_de_encerramento && <span
+                                                className="span_erro text-danger mt-1"> {props.errors.data_de_encerramento}
+                                            </span>}
+                                            <small className="form-text text-muted">
+                                                <FontAwesomeIcon
+                                                    style={{fontSize: '12px', marginRight:'4px'}}
+                                                    icon={faExclamationCircle}
+                                                /> 
+                                                <span>{values.data_de_encerramento_help_text ? values.data_de_encerramento_help_text : ''}</span>
+                                            </small>
                                         </div>
                                     </div>
                                 </div>
-                                <div className='row mb-0'>
+                                <div className='row mb-0 pt-2'>
                                     <div className='col-12'>
                                         <div className="form-group">
                                             <label htmlFor="observacao">Observação</label>
@@ -182,10 +241,6 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                                 </small>
                                         </div>
                                     </div>
-                                </div>
-                                <div className="row">
-                                    <div className="col">
-                                                                            </div>
                                 </div>
                                 <div className='row mt-3'>
                                     <div className='col'>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -14,6 +14,7 @@ import {
     deleteAssociacao,
     getAcoesAssociacao,
     getContasAssociacao,
+    validarDataDeEncerramento
 } from "../../../../../services/sme/Parametrizacoes.service";
 import {TabelaAssociacoes} from "./TabelaAssociacoes";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -157,6 +158,9 @@ export const Associacoes = () => {
             uuid: associacao_por_uuid.uuid,
             id: associacao_por_uuid.id,
             operacao: 'edit',
+            data_de_encerramento: associacao_por_uuid.data_de_encerramento.data,
+            data_de_encerramento_help_text: associacao_por_uuid.data_de_encerramento.help_text,
+            retorna_se_pode_editar_periodo_inicial: associacao_por_uuid.retorna_se_pode_editar_periodo_inicial
         });
         setShowModalForm(true)
     }, [stateFormModal]);
@@ -214,9 +218,13 @@ export const Associacoes = () => {
                             bairro: '',
                             cep: ''
                         },
-                        observacao: values.observacao
+                        observacao: values.observacao,
+                        data_de_encerramento: values.data_de_encerramento
                     };
                     try {
+                        if(values.data_de_encerramento) {
+                            await validarDataDeEncerramento(values.uuid, values.data_de_encerramento, values.periodo_inicial)
+                        }
                         await postCriarAssociacao(payload);
                         console.log('Associação criada com sucesso.');
                         setShowModalForm(false);
@@ -237,8 +245,12 @@ export const Associacoes = () => {
                         processo_regularidade: values.processo_regularidade,
                         unidade: values.uuid_unidade,
                         observacao: values.observacao,
+                        data_de_encerramento: values.data_de_encerramento
                     };
                     try {
+                        if(values.data_de_encerramento) {
+                            await validarDataDeEncerramento(values.uuid, values.data_de_encerramento, values.periodo_inicial)
+                        }
                         await patchUpdateAssociacao(values.uuid, payload);
                         console.log('Associação editada com sucesso.');
                         setShowModalForm(false);

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -142,6 +142,9 @@ export const getAcoesAssociacao = async (associacao_uuid) => {
 export const getContasAssociacao = async (associacao_uuid) => {
     return (await api.get(`api/associacoes/${associacao_uuid}/contas/`, authHeader)).data
 };
+export const validarDataDeEncerramento = async (associacao_uuid, data_de_encerramento, periodo_inicial) => {
+    return (await api.get(`api/associacoes/${associacao_uuid}/validar-data-de-encerramento/?data_de_encerramento=${data_de_encerramento}&periodo_inicial=${periodo_inicial}`, authHeader)).data
+};
 
 
 


### PR DESCRIPTION
Esse PR:

- Adiciona o DateField de data de encerramento de associação.
- Adiciona a inativação da seleção de período inicial conforme resposta do backend.
- Adiciona tooltip com informativo de bloqueio do campo.
- Adiciona chamada prévia à edição e criação de associação para verificar a validade da data de encerramento.

História: [AB#91682](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91682)