### PR TITLE
feat(91682): Adiciona mensagem de erro campo encerrar associação

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -187,7 +187,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                                 style={{fontSize: '12px', marginRight:'4px'}}
                                                 icon={faExclamationCircle}
                                             /> 
-                                            <span>{values.retorna_se_pode_editar_periodo_inicial ? values.retorna_se_pode_editar_periodo_inicial.help_text : ''}</span>
+                                            <span>O período inicial informado é uma referência e indica que o período a ser habilitado para a associação será o período posterior ao período informado.</span>
                                         </small>
                                     </div>
                                     <div className="col-6">
@@ -215,7 +215,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                                     style={{fontSize: '12px', marginRight:'4px'}}
                                                     icon={faExclamationCircle}
                                                 /> 
-                                                <span>{values.data_de_encerramento_help_text ? values.data_de_encerramento_help_text : ''}</span>
+                                                <span>A associação deixará de ser exibida nos períodos posteriores à data de encerramento informada.</span>
                                             </small>
                                         </div>
                                     </div>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -159,7 +159,6 @@ export const Associacoes = () => {
             id: associacao_por_uuid.id,
             operacao: 'edit',
             data_de_encerramento: associacao_por_uuid.data_de_encerramento.data,
-            data_de_encerramento_help_text: associacao_por_uuid.data_de_encerramento.help_text,
             retorna_se_pode_editar_periodo_inicial: associacao_por_uuid.retorna_se_pode_editar_periodo_inicial
         });
         setShowModalForm(true)
@@ -196,7 +195,6 @@ export const Associacoes = () => {
         }else {
             let payload;
             if (!errosCodigoEol){
-                setLoading(true);
                 if (values.operacao === 'create'){
                     payload = {
                         nome: values.nome,
@@ -232,9 +230,7 @@ export const Associacoes = () => {
                     }catch (e) {
                         console.log('Erro ao criar associação ', e.response.data)
                     }
-                    setLoading(false);
                 }else {
-                    setLoading(true);
                     payload = {
                         nome: values.nome,
                         cnpj: values.cnpj,
@@ -256,9 +252,11 @@ export const Associacoes = () => {
                         setShowModalForm(false);
                         await carregaTodasAsAssociacoes();
                     }catch (e) {
+                        if(e.response.data && e.response.data.erro === 'data_invalida') {
+                            setErrors({ data_de_encerramento: e.response.data.mensagem.replace('data_fim_realizacao_despesas', 'a data do fim da realização das despesas') });
+                        } 
                         console.log('Erro ao editar associação ', e.response.data)
                     }
-                    setLoading(false);
                 }
             }
         }


### PR DESCRIPTION
Esse PR:

- Recebe o novo objeto de erro enviado pelo backend e apresenta ao usuário.
- Fixa mensagens de informação que não estavam presentes no momento de criação da associação.
- Remove loadings no momento de criar e atualizar as associações.

História: [AB#91682](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91682)