### PR TITLE
feat(91752): Créditos da escola: Não permitir cadastrar/alterar crédito com data posterior ao encerramento da associação

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
+++ b/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
@@ -22,6 +22,7 @@ export const ReceitaFormFormik = ({
                                       getAvisoTipoReceita,
                                       setShowCadastrarSaida,
                                       tabelas,
+                                      periodosValidosAssociacaoencerrada,
                                       receita,
                                       verificaSeExibeDetalhamento,
                                       temOpcoesDetalhesTipoReceita,
@@ -205,9 +206,8 @@ export const ReceitaFormFormik = ({
                                             {receita.referencia_devolucao
                                                 ? null
                                                 : <option value="">Selecione um período</option>}
-                                            {tabelas.periodos !== undefined && tabelas.periodos.length > 0 ? (tabelas.periodos.map((item, key) => (
-                                                <option key={key}
-                                                        value={item.uuid}>{item.referencia_por_extenso}</option>
+                                            {periodosValidosAssociacaoencerrada && periodosValidosAssociacaoencerrada.length > 0 ? (periodosValidosAssociacaoencerrada.map((item, key) => (
+                                                <option key={key} value={item.uuid}>{item.referencia_por_extenso}</option>
                                             ))) : null}
                                         </select>
                                         {props.touched.referencia_devolucao && props.errors.referencia_devolucao &&
@@ -398,7 +398,7 @@ export const ReceitaFormFormik = ({
                                 {!ehOperacaoExclusaoReaberturaSeletiva() &&
                                     <button
                                         onClick={(e) => servicoDeVerificacoes(e, values, errors)}
-                                        disabled={readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                        disabled={formDateErrors || readOnlyBtnAcao || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
                                         type="submit"
                                         className="btn btn-success mt-2"
                                     >

--- a/src/services/escolas/Receitas.service.js
+++ b/src/services/escolas/Receitas.service.js
@@ -26,15 +26,8 @@ export const getTabelasReceitaReceita = async (associacao=null) => {
 };
 
 
-export const criarReceita = async payload => {
-    return api
-        .post(`api/receitas/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, payload, authHeader)
-        .then(response => {
-            return response;
-        })
-        .catch(error => {
-            return error.response;
-        });
+export const criarReceita = async (payload) => {
+    return (await api.post(`api/receitas/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, payload, authHeader))
 };
 
 export const getReceita = async (uuid, associacao=null) => {
@@ -50,15 +43,9 @@ export const getReceita = async (uuid, associacao=null) => {
         });
 };
 
+
 export const atualizaReceita = async (uuid, payload) => {
-    return api
-        .put(`api/receitas/${uuid}/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, payload, authHeader)
-        .then(response => {
-            return response;
-        })
-        .catch(error => {
-            return error.response;
-        });
+    return (await api.put(`api/receitas/${uuid}/?associacao_uuid=${localStorage.getItem(ASSOCIACAO_UUID)}`, payload, authHeader))
 };
 
 export const deletarReceita = async uuid => {
@@ -107,4 +94,12 @@ export const marcarLancamentoAtualizado = async (uuid_analise_lancamento) => {
 
 export const marcarCreditoIncluido = async (payload) => {
     return (await api.post(`/api/analises-documento-prestacao-conta/marcar-como-credito-incluido/`, payload, authHeader)).data
+};
+
+export const getValidarDataDaReceita = async (associacao_uuid, data_da_receita) => {
+    return (await api.get(`/api/receitas/validar-data-da-receita-associacao-encerrada/?associacao_uuid=${associacao_uuid}&data_da_receita=${data_da_receita}`, authHeader)).data
+};
+
+export const getPeriodosValidosAssociacaoEncerrada = async (associacao_uuid) => {
+    return (await api.get(`/api/receitas/periodos-validos-associacao-encerrada/?associacao_uuid=${associacao_uuid}`, authHeader)).data
 };


### PR DESCRIPTION
Esse PR:

- Implementa Validações data de encerramento em Receitas.
- Refatora Módulo de Receitas

História: [AB#91752](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91752)