### PR TITLE
feat(91755): Adiciona verificação data documento e pagamento

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -15,7 +15,8 @@ import {
     getMotivosPagamentoAntecipado,
     marcarLancamentoAtualizado,
     marcarLancamentoExcluido,
-    marcarGastoIncluido
+    marcarGastoIncluido,
+    getValidarDataDaDespesa
 } from "../../../../services/escolas/Despesas.service";
 import {useParams, useLocation} from 'react-router-dom';
 import {DespesaContext} from "../../../../context/Despesa";
@@ -1013,8 +1014,20 @@ export const CadastroForm = ({verbo_http}) => {
     }
 
     const onCalendarCloseDataPagamento = async (values, setFieldValue) => {
+        try {
+            const {data_transacao, associacao} = values
+
+            if (data_transacao) {
+                await getValidarDataDaDespesa(associacao, data_transacao.toISOString().substring(0, 10))
+            }
+                       
+        } catch (error) {
+            setFieldValue("data_transacao", null)
+            setFormErrors(prevState => ({...prevState, data_transacao: error.response.data.mensagem}))
+        }
+
         for(let despesa_imposto = 0; despesa_imposto <= values.despesas_impostos.length -1; despesa_imposto ++){
-                                                    
+
             let erro = await validacoesPersonalizadas(values, setFieldValue, "despesa_imposto", despesa_imposto)
             
             setFormErrorsImposto(prevState => ({...prevState, [despesa_imposto] : erro}))
@@ -1028,6 +1041,19 @@ export const CadastroForm = ({verbo_http}) => {
             [index]: erro
         })
         liberaBtnSalvar(values);
+    }
+
+    const onCalendarCloseDataDoDocumento = async(values, setFieldValue) => {
+        try {
+            const {data_documento, associacao} = values
+
+            await getValidarDataDaDespesa(associacao, data_documento.toISOString().substring(0, 10))
+            setFormErrors(prevState => ({...prevState, data_documento: ''}))
+                       
+        } catch (error) {
+            setFieldValue("data_documento", null)
+            setFormErrors(prevState => ({...prevState, data_documento: error.response.data.mensagem}))
+        }
     }
 
     return (
@@ -1116,6 +1142,7 @@ export const CadastroForm = ({verbo_http}) => {
                         onCalendarCloseDataPagamentoImposto={onCalendarCloseDataPagamentoImposto}
                         parametroLocation={parametroLocation}
                         bloqueiaCamposDespesa={bloqueiaCamposDespesa}
+                        onCalendarCloseDataDoDocumento={onCalendarCloseDataDoDocumento}
                     />
             </>
             }

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -105,7 +105,8 @@ export const CadastroFormFormik = ({
                                        onCalendarCloseDataPagamento,
                                        onCalendarCloseDataPagamentoImposto,
                                        parametroLocation,
-                                       bloqueiaCamposDespesa
+                                       bloqueiaCamposDespesa,
+                                       onCalendarCloseDataDoDocumento
                                    }) => {
 
     // Corrigi Cálculo validação dos valores
@@ -229,6 +230,10 @@ export const CadastroFormFormik = ({
                                             id="data_documento"
                                             value={values.data_documento !== null ? values.data_documento : ""}
                                             onChange={setFieldValue}
+                                            onCalendarClose={async () => {
+                                                onCalendarCloseDataDoDocumento(values, setFieldValue, "data_documento")
+                                                setFieldValue('')
+                                            }}
                                             className={
                                                 !eh_despesa_com_comprovacao_fiscal(props.values)
                                                     ? "form-control"
@@ -240,7 +245,9 @@ export const CadastroFormFormik = ({
                                         />
                                         {props.errors.data_documento && <span
                                             className="span_erro text-danger mt-1"> {props.errors.data_documento}</span>}
-                                    </div>
+                                        {formErrors.data_documento && <span
+                                            className="span_erro text-danger mt-1"> {formErrors.data_documento}</span>}
+                                    </div>     
 
                                     <div className="col-12 col-md-6 mt-4">
                                         <label htmlFor="numero_documento">Número do documento</label>

--- a/src/services/escolas/Despesas.service.js
+++ b/src/services/escolas/Despesas.service.js
@@ -116,3 +116,7 @@ export const marcarLancamentoExcluido = async (uuid_analise_lancamento) => {
 export const marcarGastoIncluido = async (payload) => {
     return (await api.post(`/api/analises-documento-prestacao-conta/marcar-como-gasto-incluido/`, payload, authHeader)).data
 };
+
+export const getValidarDataDaDespesa = async (associacao_uuid, data_da_depesa) => {
+    return (await api.get(`/api/despesas/validar-data-da-despesa?associacao_uuid=${associacao_uuid}&data=${data_da_depesa}`, authHeader)).data
+}


### PR DESCRIPTION
Esse PR:

- Adiciona a chamada para API de verificação dos campos de data do pagamento e data do documento
- Adiciona a verificação para que as datas selecionadas não sejam maiores que a data de encerramento da associação.

História: [AB#91755](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/91755)

