### PR TITLE
Merge fix 93028 em homolog r2

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -415,7 +415,9 @@ export const CadastroForm = ({verbo_http}) => {
         return mensagens;
     }
 
-
+    const desabilitaBtnSalvar = () => {
+        setBtnSubmitDisable(true)
+    }
 
     const onSubmit = async (values, setFieldValue) => {
         // Inclusão de validações personalizadas para reduzir o numero de requisições a API Campo: cpf_cnpj_fornecedor
@@ -965,6 +967,7 @@ export const CadastroForm = ({verbo_http}) => {
         if (Object.entries(errors).length === 0) {
             await verificaSaldoInsuficienteConta(values, errors, setFieldValue)
         }
+        setBtnSubmitDisable(false)
     }
 
     const serviceSubmitModais = async (values, setFieldValue, errors, msg) =>{
@@ -1105,6 +1108,7 @@ export const CadastroForm = ({verbo_http}) => {
                         setShowDelete={setShowDelete}
                         setShowTextoModalDelete={setShowTextoModalDelete}
                         btnSubmitDisable={btnSubmitDisable}
+                        desabilitaBtnSalvar={desabilitaBtnSalvar}
                         saldosInsuficientesDaAcao={saldosInsuficientesDaAcao}
                         setShow={setShow}
                         saldosInsuficientesDaConta={saldosInsuficientesDaConta}

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -65,6 +65,7 @@ export const CadastroFormFormik = ({
                                        setShowDelete,
                                        setShowTextoModalDelete,
                                        btnSubmitDisable,
+                                       desabilitaBtnSalvar,
                                        saldosInsuficientesDaAcao,
                                        saldosInsuficientesDaConta,
                                        mensagensAceitaCusteioCapital,
@@ -842,7 +843,8 @@ export const CadastroFormFormik = ({
                                             }
                                             type="button"
                                             onClick={async (e) => {
-                                                serviceIniciaEncadeamentoDosModais(values, errors, setFieldValue, {resetForm})
+                                                desabilitaBtnSalvar();
+                                                serviceIniciaEncadeamentoDosModais(values, errors, setFieldValue, {resetForm});
                                             }}
                                             className="btn btn-success mt-2"
                                         >


### PR DESCRIPTION
Esse PR:

- Desabilita o botão salvar antes do processo de ativação do serviço de encadeamento de modais no cadastro de despesas, assim impossibilitando o registro da mesma despesa mais de uma vez na ação de salvar.

História: [AB#93028](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93028)