### PR TITLE
feat(93756): Não permitir selecionar associação encerrada

### DIFF
--- a/src/assets/css/variaveis.scss
+++ b/src/assets/css/variaveis.scss
@@ -7,7 +7,7 @@ $mainColor: #00585E;
 $whiteColor: #ffffff;
 $hoverBackgroundColor: #2B7D83;
 $verdeClaro: #29d612;
-
+$corCinza: #9B9C9C;
 // Fontes
 
 @import url("https://fonts.googleapis.com/css?family=Roboto:300,400,700");

--- a/src/componentes/Globais/Tag/index.js
+++ b/src/componentes/Globais/Tag/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import './tag.scss';
+
+export const Tag = ({
+    label = '',
+    color = 'default'
+}) =>{
+
+    return(
+        <div className={`custom-tag custom-tag-${color}`}>
+            <span>{label}</span>
+        </div>
+    )
+};

--- a/src/componentes/Globais/Tag/tag.scss
+++ b/src/componentes/Globais/Tag/tag.scss
@@ -1,0 +1,15 @@
+@import 'src/assets/css/variaveis.scss';
+
+.custom-tag {
+    display: flex;
+    justify-content: center;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-radius: 5px;
+    align-items: center;
+}
+
+.custom-tag-default {
+    background-color: $corCinza;  
+    color: $corBranco;
+}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/AutoCompleteAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/AutoCompleteAssociacoes.js
@@ -2,6 +2,7 @@ import React, {useState, memo} from 'react';
 import {AutoComplete} from 'primereact/autocomplete';
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faSearch} from "@fortawesome/free-solid-svg-icons";
+import { Tag } from '../../../../Globais/Tag';
 
 const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComplete}) => {
     const [selectedAcao, setSelectedAcao] = useState(null);
@@ -21,6 +22,35 @@ const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComple
         }, 250);
     };
 
+    const itemTemplate = (item) => {
+        if(item.encerrada) {
+            return (
+                <div className='d-flex' style={{opacity: 0.6}}>
+                    <span className='mr-3'>{item.unidade.nome_com_tipo}</span>
+                    <Tag label='Associação encerrada'/>
+                </div>
+            )
+        } else {
+            return item.unidade.nome_com_tipo;
+        }
+    };
+    
+    const handleChange = (e) => {
+        if(e.value.encerrada){
+            setSelectedAcao(null)
+        } else {
+            setSelectedAcao(e.value)
+        }
+    };
+
+    const handleSelect = (e) => {
+        if(e.value.encerrada){
+            recebeAcaoAutoComplete(null)
+        } else {
+            recebeAcaoAutoComplete(e.value)
+        }        
+    };
+
     return (
         <div className="d-flex bd-highlight">
             <div className="flex-grow-1 bd-highlight">
@@ -31,10 +61,11 @@ const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComple
                     suggestions={filteredAcoes}
                     completeMethod={searchAcao}
                     field="unidade.nome_com_tipo"
-                    onChange={(e) => setSelectedAcao(e.value)}
+                    onChange={handleChange}
                     inputClassName="form-control"
-                    onSelect={(e) => recebeAcaoAutoComplete(e.value)}
+                    onSelect={handleSelect}
                     style={{width: "100%", borderLeft:'none'}}
+                    itemTemplate={itemTemplate}
                 />
             </div>
             <div className="bd-highlight ml-0 py-1 px-3 ml-n3 border-top border-right border-bottom">

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/Filtros.js
@@ -1,11 +1,13 @@
 import React from "react";
+import { Select } from 'antd';
+const { Option } = Select;
 
-export const Filtros = ({stateFiltros, handleChangeFiltros, handleSubmitFiltros, limpaFiltros, listaTiposDeAcao}) =>{
+export const Filtros = ({stateFiltros, handleChangeFiltros, handleSubmitFiltros, limpaFiltros, listaTiposDeAcao, handleOnChangeMultipleSelectStatus, tabelaAssociacoes}) =>{
     return(
         <>
             <form>
                 <div className="form-row">
-                    <div className="form-group col-md-6">
+                    <div className="form-group col-md-3">
                         <label htmlFor="filtrar_por_nome_cod_eol">Filtrar por nome ou código EOL</label>
                         <input
                             value={stateFiltros.filtrar_por_nome_cod_eol}
@@ -45,6 +47,24 @@ export const Filtros = ({stateFiltros, handleChangeFiltros, handleSubmitFiltros,
                             <option value='INATIVA'>Inativa</option>
                         </select>
                     </div>
+                    <div className="form-group col-md-3">
+                        <label htmlFor="filtro_informacoes">Filtrar por informações</label>
+                        <Select
+                            mode="multiple"
+                            allowClear
+                            style={{ width: '100%' }}
+                            placeholder="Selecione as informações"
+                            name="filtro_informacoes"
+                            id="filtro_informacoes"
+                            value={stateFiltros.filtro_informacoes}
+                            onChange={handleOnChangeMultipleSelectStatus}
+                            className='multiselect-lista-valores-reprogramados'
+                        >
+                            {tabelaAssociacoes.filtro_informacoes && tabelaAssociacoes.filtro_informacoes.length > 0 && tabelaAssociacoes.filtro_informacoes.map(item => (
+                                <Option key={item.id} value={item.id}>{item.nome}</Option>
+                            ))}
+                        </Select>
+                    </div>                    
                 </div>
                 <div className="d-flex  justify-content-end mt-n2">
                     <button onClick={()=>limpaFiltros()} type="button" className="btn btn btn-outline-success mt-2 mr-2">Limpar</button>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/TabelaAcoesDasAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/TabelaAcoesDasAssociacoes.js
@@ -1,35 +1,60 @@
 import React from "react";
 import {DataTable} from 'primereact/datatable'
 import {Column} from 'primereact/column'
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faInfoCircle} from "@fortawesome/free-solid-svg-icons";
+import useTagInformacaoAssociacaoEncerradaTemplate from "../../../../../hooks/Globais/TagsInformacoesAssociacoes/useTagInformacaoAssociacaoEncerradaTemplate";
 
-
-export const TabelaAcoesDasAssociacoes = ({todasAsAcoes, rowsPerPage, statusTemplate, dataTemplate, acoesTemplate}) => {
+export const TabelaAcoesDasAssociacoes = ({todasAsAcoes, rowsPerPage, statusTemplate, dataTemplate, acoesTemplate, setShowModalLegendaInformacao}) => {
+    const tagInformacaoAssociacaoEncerrada = useTagInformacaoAssociacaoEncerradaTemplate();
 
     return(
-        <DataTable
-            value={todasAsAcoes}
-            paginator={todasAsAcoes.length > rowsPerPage}
-            paginatorTemplate="PrevPageLink PageLinks NextPageLink"
-            rows={rowsPerPage}
-        >
-            <Column field="associacao.unidade.codigo_eol" header="EOL"/>
-            <Column field="associacao.unidade.nome_com_tipo" header="Unidade Educacional"/>
-            <Column field="acao.nome" header="Ação"/>
-            <Column
-                field="acao.nome"
-                header="Status"
-                body={statusTemplate}
-            />
-            <Column
-                field="criado_em"
-                header="Criado em"
-                body={dataTemplate}
-            />
-            <Column
-                field="status"
-                header="Ações"
-                body={acoesTemplate}
-            />
-        </DataTable>
+        <>
+            <div className="d-flex justify-content-end">
+                <button
+                    onClick={()=> setShowModalLegendaInformacao(true)}
+                    className="btn btn-link link-green"
+                    style={{padding: '0px', textDecoration: 'none'}}
+                >
+                    <FontAwesomeIcon
+                        style={{fontSize: '18px', marginRight: "4px", paddingTop: "2px"}}
+                        icon={faInfoCircle}
+                    />
+                    <span>Legenda informação</span>
+                </button>
+            </div>
+            <DataTable
+                value={todasAsAcoes}
+                paginator={todasAsAcoes.length > rowsPerPage}
+                paginatorTemplate="PrevPageLink PageLinks NextPageLink"
+                rows={rowsPerPage}
+            >
+                <Column field="associacao.unidade.codigo_eol" header="EOL"/>
+                <Column field="associacao.unidade.nome_com_tipo" header="Unidade Educacional"/>
+                <Column
+                    field="informacao"
+                    header="Informações"
+                    style={{width: '15%'}}
+                    className="align-middle text-center"
+                    body={tagInformacaoAssociacaoEncerrada}
+                />            
+                <Column field="acao.nome" header="Ação"/>
+                <Column
+                    field="acao.nome"
+                    header="Status"
+                    body={statusTemplate}
+                />
+                <Column
+                    field="criado_em"
+                    header="Criado em"
+                    body={dataTemplate}
+                />
+                <Column
+                    field="status"
+                    header="Ações"
+                    body={acoesTemplate}
+                />
+            </DataTable>
+        </>
     )
 };

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
@@ -22,6 +22,7 @@ import Loading from "../../../../../utils/Loading";
 import {ModalFormAcoesDaAssociacao} from "./ModalFormAcoesDasAssociacoes";
 import {ModalConfirmDeleteAcaoAssociacao} from "./ModalConfirmDeleteAcaoAssociacao";
 import {ModalInfoQtdeRateiosReceitasAcao} from "./ModalInfoQtdeRateiosReceitasAcao";
+import { ModalLegendaInformacaoAssociacao } from "../../../../Globais/LegendaInformaçãoAssociacao/ModalLegendaInformacaoAssociacao";
 
 export const AcoesDasAssociacoes = () => {
 
@@ -36,6 +37,7 @@ export const AcoesDasAssociacoes = () => {
     const [stateFiltros, setStateFiltros] = useState(initialStateFiltros);
     const [listaTiposDeAcao, setListaTiposDeAcao] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [showModalLegendaInformacao, setShowModalLegendaInformacao] = useState(false);
 
     const carregaTodasAsAcoes = useCallback(async () => {
         setLoading(true);
@@ -251,7 +253,17 @@ export const AcoesDasAssociacoes = () => {
                             statusTemplate={statusTemplate}
                             dataTemplate={dataTemplate}
                             acoesTemplate={acoesTemplate}
+                            setShowModalLegendaInformacao={setShowModalLegendaInformacao}
                         />
+                        <section>
+                            <ModalLegendaInformacaoAssociacao
+                                show={showModalLegendaInformacao}
+                                primeiroBotaoOnclick={() => setShowModalLegendaInformacao(false)}
+                                titulo="Legenda Informação"
+                                primeiroBotaoTexto="Fechar"
+                                primeiroBotaoCss="outline-success"                            
+                            />
+                        </section>
                     </>
                 }
                 <section>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
@@ -23,6 +23,7 @@ import {ModalFormAcoesDaAssociacao} from "./ModalFormAcoesDasAssociacoes";
 import {ModalConfirmDeleteAcaoAssociacao} from "./ModalConfirmDeleteAcaoAssociacao";
 import {ModalInfoQtdeRateiosReceitasAcao} from "./ModalInfoQtdeRateiosReceitasAcao";
 import { ModalLegendaInformacaoAssociacao } from "../../../../Globais/LegendaInformaçãoAssociacao/ModalLegendaInformacaoAssociacao";
+import { getTabelaAssociacoes } from "../../../../../services/dres/Associacoes.service";
 
 export const AcoesDasAssociacoes = () => {
 
@@ -30,6 +31,7 @@ export const AcoesDasAssociacoes = () => {
         filtrar_por_nome_cod_eol: "",
         filtrar_por_acao: "",
         filtrar_por_status: "",
+        filtro_informacoes: []
     };
 
     const [todasAsAcoes, setTodasAsAcoes] = useState([]);
@@ -38,6 +40,7 @@ export const AcoesDasAssociacoes = () => {
     const [listaTiposDeAcao, setListaTiposDeAcao] = useState([]);
     const [loading, setLoading] = useState(true);
     const [showModalLegendaInformacao, setShowModalLegendaInformacao] = useState(false);
+    const [tabelaAssociacoes, setTabelaAssociacoes] = useState({});
 
     const carregaTodasAsAcoes = useCallback(async () => {
         setLoading(true);
@@ -46,6 +49,9 @@ export const AcoesDasAssociacoes = () => {
 
         let todas_associacoes = await getAssociacoes();
         setTodasAsAcoesAutoComplete(todas_associacoes);
+
+        let tabela_associacoes = await getTabelaAssociacoes();
+        setTabelaAssociacoes(tabela_associacoes);
 
         setLoading(false);
     }, []);
@@ -75,7 +81,10 @@ export const AcoesDasAssociacoes = () => {
     };
     const handleSubmitFiltros = async () => {
         setLoading(true);
-        let acoes_filtradas = await getFiltros(stateFiltros.filtrar_por_nome_cod_eol, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_status);
+        let acoes_filtradas = await getFiltros(stateFiltros.filtrar_por_nome_cod_eol, 
+                                               stateFiltros.filtrar_por_acao, 
+                                               stateFiltros.filtrar_por_status, 
+                                               stateFiltros.filtro_informacoes);
         setTodasAsAcoes(acoes_filtradas);
         setLoading(false)
     };
@@ -154,7 +163,11 @@ export const AcoesDasAssociacoes = () => {
         });
     };
     const handleEditarAcoes = (rowData) => {
-        setReadOnly(false);
+        if(rowData.data_de_encerramento_associacao) {
+            setReadOnly(true);
+        } else {
+            setReadOnly(false);
+        }
         setStateFormModal({
             associacao: rowData.associacao.uuid,
             acao: rowData.acao.uuid,
@@ -214,6 +227,15 @@ export const AcoesDasAssociacoes = () => {
         }
     };
 
+    const handleOnChangeMultipleSelectStatus =  async (value) => {
+        let name = "filtro_informacoes"
+
+        setStateFiltros({
+            ...stateFiltros,
+            [name]: value
+        });
+    };
+
     return (
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Ações das Associações</h1>
@@ -245,6 +267,8 @@ export const AcoesDasAssociacoes = () => {
                             handleSubmitFiltros={handleSubmitFiltros}
                             limpaFiltros={limpaFiltros}
                             listaTiposDeAcao={listaTiposDeAcao}
+                            handleOnChangeMultipleSelectStatus={handleOnChangeMultipleSelectStatus}
+                            tabelaAssociacoes={tabelaAssociacoes}
                         />
                         <p>Exibindo <span className='total-acoes'>{totalDeAcoes}</span> ações de associações</p>
                         <TabelaAcoesDasAssociacoes

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -201,8 +201,8 @@ export const getTabelaCategoriaDocumentos = async () => {
     return (await api.get(`api/tipos-acerto-documento/tabelas/`, authHeader)).data
 };
 
-export const getFiltros = async (nome='', acao__uuid, status) => {
-    return (await api.get(`/api/acoes-associacoes/?nome=${nome}${acao__uuid ? '&acao__uuid='+acao__uuid : ''}${status ? '&status='+status : ''}`, authHeader)).data
+export const getFiltros = async (nome='', acao__uuid, status, filtro_informacoes) => {
+    return (await api.get(`/api/acoes-associacoes/?nome=${nome}${acao__uuid ? '&acao__uuid='+acao__uuid : ''}${status ? '&status='+status : ''}${filtro_informacoes ? `&filtro_informacoes=${filtro_informacoes}` : ''}`, authHeader)).data
 };
 
 export const postAddAcaoAssociacao = async (payload) => {


### PR DESCRIPTION
Esse PR:

- Adiciona coluna com informação e modal com legenda de etiqueta
- Adiciona sinalização de associação encerrada na pesquisa e bloqueia seleção
- Implementa filtro por informações

História: [AB#93756](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93756)