### PR TITLE
feat(94327): Refatora tags conciliacao bancaria

### DIFF
--- a/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
+++ b/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {Column} from "primereact/column";
 import {DataTable} from "primereact/datatable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -6,7 +6,6 @@ import {faKey, faInfoCircle} from "@fortawesome/free-solid-svg-icons";
 import { TagInformacao } from "../TagInformacao";
 
 export const ListaDeUnidades = ({listaUnidades, rowsPerPage, acaoAoEscolherUnidade, textoAcaoEscolher, setShowModalLegendaInformacao}) => {
-    const [unidadesComTag, setUnidadesComTag] = useState([]);
 
     const unidadeEscolarTemplate = (rowData) => {
         return (
@@ -49,41 +48,6 @@ export const ListaDeUnidades = ({listaUnidades, rowsPerPage, acaoAoEscolherUnida
         )
     };
 
-    const adicionaTagsNasUnidades = (unidadesSemTags) => {
-        let tagsTabelaUnidade = ["Encerrada"]
-
-        if(unidadesSemTags.length > 0) {
-            let assComTag = unidadesSemTags.map((ass) => {
-                ass.informacoes = []
-
-                tagsTabelaUnidade.forEach(tag => {
-                    if(tag === "Encerrada" && ass.data_de_encerramento_associacao && ass.tooltip_associacao_encerrada) {
-                        ass.informacoes.push({
-                            tag_id: 7,
-                            tag_nome: "Associação encerrada",
-                            tag_hint: ass.tooltip_associacao_encerrada
-                        })
-                    }
-                    
-                });
-
-                return ass;
-            })
-
-            return assComTag;
-        }
-        return []
-    }
-
-    useEffect(() => {
-        let unidadesTags = adicionaTagsNasUnidades(listaUnidades);
-        setUnidadesComTag(unidadesTags)
-    }, [listaUnidades])
-
-    useEffect(() => {
-
-    }, [listaUnidades])
-
     return (
         <>
         <div className="d-flex justify-content-end">
@@ -101,9 +65,9 @@ export const ListaDeUnidades = ({listaUnidades, rowsPerPage, acaoAoEscolherUnida
         </div>
 
         <DataTable
-            value={unidadesComTag}
+            value={listaUnidades}
             className="mt-3"
-            paginator={unidadesComTag.length > rowsPerPage}
+            paginator={listaUnidades.length > rowsPerPage}
             rows={rowsPerPage}
             paginatorTemplate="PrevPageLink PageLinks NextPageLink"
             autoLayout={true}

--- a/src/componentes/Globais/EscolheUnidade/index.js
+++ b/src/componentes/Globais/EscolheUnidade/index.js
@@ -5,7 +5,7 @@ import Loading from "../../../utils/Loading";
 import {FiltroDeUnidades} from "./FiltroDeUnidades";
 import Img404 from "../../../assets/img/img-404.svg";
 import {MsgImgCentralizada} from "../Mensagens/MsgImgCentralizada";
-import { ModalLegendaInformacaoAssociacao } from "../../Globais/ModalLegendaInformacao/ModalLegendaInformacaoAssociacao";
+import { ModalLegendaInformacao } from "../../Globais/ModalLegendaInformacao/ModalLegendaInformacao";
 
 export const EscolheUnidade = (props) =>{
 
@@ -43,6 +43,7 @@ export const EscolheUnidade = (props) =>{
             setLoading(true)
             try {
                 let listaUnidades = await getUnidades(dre_uuid, stateFiltros.nome_ou_codigo);
+                console.log(listaUnidades)
                 setListaUnidades(listaUnidades);
             }catch (e) {
                 console.log("Erro ao carregar lista de unidades.", e)
@@ -96,12 +97,13 @@ export const EscolheUnidade = (props) =>{
             }
 
             <section>
-                <ModalLegendaInformacaoAssociacao
+                <ModalLegendaInformacao
                     show={showModalLegendaInformacao}
                     primeiroBotaoOnclick={() => setShowModalLegendaInformacao(false)}
                     titulo="Legenda Informação"
                     primeiroBotaoTexto="Fechar"
                     primeiroBotaoCss="outline-success"
+                    entidadeDasTags="associacao"
                 />
             </section>
 

--- a/src/componentes/Globais/ModalLegendaInformacao/ModalLegendaInformacao.js
+++ b/src/componentes/Globais/ModalLegendaInformacao/ModalLegendaInformacao.js
@@ -1,5 +1,6 @@
 import React, {Fragment, useCallback, useEffect, useState} from "react";
 import { getTagInformacao } from "../../../services/escolas/Despesas.service";
+import { getTagInformacaoAssociacao } from "../../../services/escolas/Associacao.service"
 import {Button, Modal} from "react-bootstrap";
 import Loading from "../../../utils/Loading";
 import { TagInformacao } from "../TagInformacao"
@@ -11,14 +12,23 @@ export const ModalLegendaInformacao = (propriedades) => {
     const handleTagInformacao = useCallback(async () => {
         setLoading(true)
         try {
-            const response = await getTagInformacao()
-            setListaTagInformacao(response)
+            let tagsInformacao = []
+
+            if(propriedades.entidadeDasTags === "associacao") {
+               tagsInformacao = await getTagInformacaoAssociacao()
+               console.log("TAGS INFORMACAO", tagsInformacao)
+            } else {
+               tagsInformacao = await getTagInformacao()
+            }
+
+
+            setListaTagInformacao(tagsInformacao)
         } catch (e) {
             console.error('Erro ao carregar tag informação', e)
         }
         setLoading(false)
 
-    }, [])
+    }, [propriedades.entidadeDasTags])
 
     useEffect(() => {
         handleTagInformacao()
@@ -44,9 +54,9 @@ export const ModalLegendaInformacao = (propriedades) => {
                 <Modal.Body> {
                     loading ? (
                         <Loading corGrafico="black" corFonte="dark" marginTop="0" marginBottom="0"/>
-                    ) : listaTagInformacao?.length > 0 ? listaTagInformacao.map((tag) => {
+                    ) : listaTagInformacao?.length > 0 ? listaTagInformacao.map((tag, index) => {
                         tag.texto = tag.nome
-                        return (TagInformacao(tag, "modal-legenda-informacao"))
+                        return <React.Fragment key={index}>{(TagInformacao(tag, "modal-legenda-informacao"))}</React.Fragment>
                     }) : <span>Nenhuma informação encontrada</span>
                 } </Modal.Body>
                 <Modal.Footer>

--- a/src/componentes/Globais/TagInformacao/index.js
+++ b/src/componentes/Globais/TagInformacao/index.js
@@ -11,7 +11,8 @@ const types = {
     6: 'tag-red-white',
     7: 'tag-neutral-3',
     8: 'tag-light-purple',
-    9: 'tag-verde'
+    9: 'tag-blue',
+    10: 'tag-blue-white',
 }
 
 

--- a/src/componentes/Globais/TagInformacao/tagInformacaoTemplate.scss
+++ b/src/componentes/Globais/TagInformacao/tagInformacaoTemplate.scss
@@ -70,3 +70,14 @@
     color: #fff;
     background-color: #5F55A1;
 }
+
+.tag-blue {
+    color: #fff;
+    background-color: #1130AF;
+}
+
+.tag-blue-white {
+    border: 2px solid #1130AF;
+    color: #1130AF;
+    background: inherit;
+}

--- a/src/componentes/dres/Associacoes/TabelaAssociacoes.js
+++ b/src/componentes/dres/Associacoes/TabelaAssociacoes.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {Column} from "primereact/column";
 import {DataTable} from "primereact/datatable";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
@@ -6,40 +6,6 @@ import {faInfoCircle} from "@fortawesome/free-solid-svg-icons";
 import { TagInformacao } from "../../Globais/TagInformacao";
 
 export const TabelaAssociacoes = ({associacoes, rowsPerPage, unidadeEscolarTemplate, acoesTemplate, setShowModalLegendaInformacao}) =>{
-    const [associacaoComTag, setAssociacaoComTag] = useState([]);
-
-    const adicionaTagsNasAssociacoes = (associacoesSemTags) => {
-        let tagsTabelaAssociacao = ["Encerrada"]
-
-        if(associacoesSemTags.length > 0) {
-            let assComTag = associacoesSemTags.map((ass) => {
-                ass.informacoes = []
-
-                tagsTabelaAssociacao.forEach(tag => {
-                    if(tag === "Encerrada" && ass.data_de_encerramento && ass.tooltip_data_encerramento) {
-                        ass.informacoes.push({
-                            tag_id: 7,
-                            tag_nome: "Associação encerrada",
-                            tag_hint: ass.tooltip_data_encerramento
-                        })
-                    }
-                    
-                });
-
-                return ass;
-            })
-
-            return assComTag;
-        }
-        return []
-    }
-
-    useEffect(() => {
-        let associacoesTags = adicionaTagsNasAssociacoes(associacoes);
-        setAssociacaoComTag(associacoesTags)
-    }, [associacoes])
-
-
   return(
     <>
         <div className="d-flex justify-content-end">
@@ -57,9 +23,9 @@ export const TabelaAssociacoes = ({associacoes, rowsPerPage, unidadeEscolarTempl
         </div>
 
         <DataTable
-            value={associacaoComTag}
+            value={associacoes}
             className="mt-3 container-tabela-associacoes"
-            paginator={associacaoComTag.length > rowsPerPage}
+            paginator={associacoes.length > rowsPerPage}
             rows={rowsPerPage}
             paginatorTemplate="PrevPageLink PageLinks NextPageLink"
             autoLayout={true}

--- a/src/componentes/dres/Associacoes/index.js
+++ b/src/componentes/dres/Associacoes/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Redirect} from "react-router-dom";
 import {getTabelaAssociacoes, getAssociacoesPorUnidade, filtrosAssociacoes, getAssociacao, getContasAssociacao} from "../../../services/dres/Associacoes.service";
-import { ModalLegendaInformacaoAssociacao } from "../../Globais/ModalLegendaInformacao/ModalLegendaInformacaoAssociacao";
+import { ModalLegendaInformacao } from "../../Globais/ModalLegendaInformacao/ModalLegendaInformacao";
 import "./associacoes.scss"
 import {TabelaAssociacoes} from "./TabelaAssociacoes";
 import {FiltrosAssociacoes} from "./FiltrosAssociacoes";
@@ -175,12 +175,13 @@ export const Associacoes = () =>{
                     />
 
                     <section>
-                        <ModalLegendaInformacaoAssociacao
+                        <ModalLegendaInformacao
                             show={showModalLegendaInformacao}
                             primeiroBotaoOnclick={() => setShowModalLegendaInformacao(false)}
                             titulo="Legenda Informação"
                             primeiroBotaoTexto="Fechar"
                             primeiroBotaoCss="outline-success"
+                            entidadeDasTags="associacao"
                         />
                     </section>
                 </>

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
@@ -36,7 +36,7 @@ import {
     limparDetalharAcertos
 } from "../../../../../store/reducers/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/actions";
 import {visoesService} from "../../../../../services/visoes.service";
-import {ModalLegendaInformacao} from "../../../../Globais/ModalLegendaInformacao/ModalLegendaInformacaoDespesa"
+import {ModalLegendaInformacao} from "../../../../Globais/ModalLegendaInformacao/ModalLegendaInformacao"
 import {ModalLegendaConferenciaLancamentos} from "./Modais/ModalLegendaConferenciaLancamentos"
 import { TagInformacao } from "../../../../Globais/TagInformacao/index";
 

--- a/src/componentes/escolas/Despesas/ListaDeDespesas/LegendaInformacao.js
+++ b/src/componentes/escolas/Despesas/ListaDeDespesas/LegendaInformacao.js
@@ -3,7 +3,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faInfoCircle} from "@fortawesome/free-solid-svg-icons";
 import {
     ModalLegendaInformacao
-} from "../../../Globais/ModalLegendaInformacao/ModalLegendaInformacaoDespesa"
+} from "../../../Globais/ModalLegendaInformacao/ModalLegendaInformacao"
 
 export const LegendaInformacao = ({showModalLegendaInformacao, setShowModalLegendaInformacao}) => {
     return (

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/TabelaAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/TabelaAssociacoes.js
@@ -1,46 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {DataTable} from 'primereact/datatable'
 import {Column} from 'primereact/column'
 import { TagInformacao } from "../../../../Globais/TagInformacao";
 
 export const TabelaAssociacoes = ({listaDeAssociacoes, rowsPerPage, acoesTemplate}) => {
-    const [associacaoComTag, setAssociacaoComTag] = useState([]);
-
-    const adicionaTagsNasAssociacoes = (associacoesSemTags) => {
-        let tagsTabelaAssociacao = ["Encerrada"]
-
-        if(associacoesSemTags.length > 0) {
-            let assComTag = associacoesSemTags.map((ass) => {
-                ass.informacoes = []
-
-                tagsTabelaAssociacao.forEach(tag => {
-                    if(tag === "Encerrada" && ass.data_de_encerramento && ass.tooltip_data_encerramento) {
-                        ass.informacoes.push({
-                            tag_id: 7,
-                            tag_nome: "Associação encerrada",
-                            tag_hint: ass.tooltip_data_encerramento
-                        })
-                    }
-                    
-                });
-
-                return ass;
-            })
-
-            return assComTag;
-        }
-        return []
-    }
-
-    useEffect(() => {
-        let associacoesTags = adicionaTagsNasAssociacoes(listaDeAssociacoes);
-        setAssociacaoComTag(associacoesTags)
-    }, [listaDeAssociacoes])
-
     return(
         <DataTable
-            value={associacaoComTag}
-            paginator={associacaoComTag.length > rowsPerPage}
+            value={listaDeAssociacoes}
+            paginator={listaDeAssociacoes.length > rowsPerPage}
             paginatorTemplate="PrevPageLink PageLinks NextPageLink"
             rows={rowsPerPage}
         >

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -25,7 +25,7 @@ import {BtnAddAssociacoes} from "./BtnAddAssociacoes";
 import {ModalConfirmDeleteAssociacao} from "./ModalConfirmDeleteAssociacao";
 import {ModalInfoExclusaoNaoPermitida} from "./ModalInfoExclusaoNaoPermitida";
 import { ModalConfirmUpdateObservacao } from "./ModalConfirmUpdateObservacao";
-import { ModalLegendaInformacaoAssociacao } from "../../../../Globais/ModalLegendaInformacao/ModalLegendaInformacaoAssociacao";
+import { ModalLegendaInformacao } from "../../../../Globais/ModalLegendaInformacao/ModalLegendaInformacao";
 import Loading from "../../../../../utils/Loading";
 
 export const Associacoes = () => {
@@ -461,12 +461,13 @@ export const Associacoes = () => {
                     </section>
 
                     <section>
-                        <ModalLegendaInformacaoAssociacao
+                        <ModalLegendaInformacao
                             show={showModalLegendaInformacao}
                             primeiroBotaoOnclick={() => setShowModalLegendaInformacao(false)}
                             titulo="Legenda Informação"
                             primeiroBotaoTexto="Fechar"
                             primeiroBotaoCss="outline-success"
+                            entidadeDasTags="associacao"
                         />
                     </section>
                 </div>

--- a/src/services/escolas/Associacao.service.js
+++ b/src/services/escolas/Associacao.service.js
@@ -148,3 +148,7 @@ export const getUsuarioPeloUsername = async (username) => {
 export const getDataPreenchimentoPreviaAta = async (uuidPeriodo) => {
     return (await api.get(`/api/associacoes/${localStorage.getItem(ASSOCIACAO_UUID)}/previa-ata/?periodo_uuid=${uuidPeriodo}`, authHeader)).data
 };
+
+export const getTagInformacaoAssociacao = async () => {
+    return (await api.get(`api/associacoes/tags-informacoes/`, authHeader)).data
+}


### PR DESCRIPTION
Esse PR:

- Adiciona tags conciliação.
- Altera a apresentação das tags de associações e despesas.
- Adiciona endpoint de resgate de tags de associações.

História: [AB#94327](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/94327)