### PR TITLE
feat(93201): Altera os hints de período inicial apenas leitura e passa a exibir "*" em campos obrigatórios

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -49,11 +49,15 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                         }
 
                         return(
-                            <form onSubmit={props.handleSubmit}>
+                            <>
+                                <div style={{textAlign: "right"}}>
+                                    <span>* Preenchimento obrigatório</span>
+                                </div>
+                                <form onSubmit={props.handleSubmit}>
                                 <div className='row'>
                                     <div className='col'>
                                         <div className="form-group">
-                                            <label htmlFor="nome">Nome</label>
+                                            <label htmlFor="nome">Nome*</label>
                                             <input
                                                 type="text"
                                                 value={props.values.nome}
@@ -70,7 +74,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                 <div className='row'>
                                     <div className='col'>
                                         <div className="form-group">
-                                            <label htmlFor="codigo_eol_unidade">Código EOL</label>
+                                            <label htmlFor="codigo_eol_unidade">Código EOL*</label>
                                             <input
                                                 type="text"
                                                 value={props.values.codigo_eol_unidade}
@@ -284,6 +288,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                     </div>
                                 </div>
                             </form>
+                            </>
                         );
                     }}
                 </Formik>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -183,14 +183,20 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                     <label htmlFor="periodo_inicial">
                                         Período inicial
                                     </label>
-                                       <div data-tip={values.retorna_se_pode_editar_periodo_inicial ? values.retorna_se_pode_editar_periodo_inicial.mensagem_pode_editar_periodo_inicial : ''} data-html={true} style={{display:'inline'}} data-for={`tooltip-id-${values.uuid}`}>
+                                       <div
+                                           data-tip={
+                                            values.pode_editar_periodo_inicial && !values.pode_editar_periodo_inicial?.pode_editar_periodo_inicial
+                                                ? values.pode_editar_periodo_inicial?.mensagem_pode_editar_periodo_inicial?.reduce((hint, text) => (hint + `${text}<br/>`), '<p>') + '</p>'
+                                                : ''
+                                           } data-html={true} style={{display:'inline'}} data-for={`tooltip-id-${values.uuid}`}
+                                       >
                                        <select
                                             value={values.periodo_inicial && values.periodo_inicial ? values.periodo_inicial : ""}
                                             onChange={props.handleChange}
                                             name="periodo_inicial"
                                             id="periodo_inicial"
                                             className="form-control"
-                                            disabled={values.retorna_se_pode_editar_periodo_inicial ? !values.retorna_se_pode_editar_periodo_inicial.pode_editar_periodo_inicial : '' || !podeEditarDadosAssociacao(props.values)}
+                                            disabled={values.pode_editar_periodo_inicial ? !values.pode_editar_periodo_inicial.pode_editar_periodo_inicial : '' || !podeEditarDadosAssociacao(props.values)}
                                         >
                                             <option value=''>Selecione um período</option>
                                             {listaDePeriodos && listaDePeriodos.map((periodo) =>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -178,7 +178,7 @@ export const Associacoes = () => {
             id: associacao_por_uuid.id,
             operacao: 'edit',
             data_de_encerramento: associacao_por_uuid.data_de_encerramento.data,
-            retorna_se_pode_editar_periodo_inicial: associacao_por_uuid.retorna_se_pode_editar_periodo_inicial,
+            pode_editar_periodo_inicial: associacao_por_uuid.pode_editar_periodo_inicial,
             pode_editar_dados_associacao_encerrada: associacao_por_uuid.data_de_encerramento.pode_editar_dados_associacao_encerrada ? associacao_por_uuid.data_de_encerramento.pode_editar_dados_associacao_encerrada : false
         });
         setShowModalForm(true)


### PR DESCRIPTION
Esse PR:
- Altera a apresentação do hint do campo período inicial quando apenas leitura que passa a ter múltiplas linhas
- Passa a exibir "*" em campos obrigatórios

Atende [AB#93201](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93201)