### PR TITLE
feat(93201): Associações - Torna o campo período inicial obrigatório.

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/ModalFormAssociacoes.js
@@ -181,7 +181,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                 <div className='row'>
                                     <div className='col-6'>
                                     <label htmlFor="periodo_inicial">
-                                        Período inicial
+                                        Período inicial*
                                     </label>
                                        <div
                                            data-tip={
@@ -212,6 +212,7 @@ const ModalFormAssociacoes = ({show, stateFormModal, handleClose, handleSubmitMo
                                             /> 
                                             <span>O período inicial informado é uma referência e indica que o período a ser habilitado para a associação será o período posterior ao período informado.</span>
                                         </small>
+                                        {props.touched.periodo_inicial && props.errors.periodo_inicial && <span className="span_erro text-danger mt-1"> {props.errors.periodo_inicial} </span>}
                                     </div>
                                     <div className="col-6">
                                         <div className="form-group">

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -60,6 +60,11 @@ export const checkDuplicateInObject = (propertyName, inputArray) => {
 export const YupSignupSchemaAssociacoes  = yup.object().shape({
   nome: yup.string().required("Nome é obrigatório"),
   codigo_eol_unidade: yup.string().required("Código EOL da unidade é obrigatório"),
+  periodo_inicial: yup.string().test('test-name', 'Período inicial é obrigatório',
+      function (value) {
+        return !(value === undefined || value === null || value === "");
+
+      }),
   cnpj: yup.string()
   .test('test-name', 'Digite um CNPJ Válido',
       function (value) {


### PR DESCRIPTION
Esse PR:
- Torna o campo período inicial obrigatória no cadastro de associações

Atende: [AB#93201](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/93201)