### PR TITLE
feat(95819): Implementar validação de cadastro em concluir acerto ou concluir período

### DIFF
--- a/src/componentes/Globais/ModalBootstrap/index.js
+++ b/src/componentes/Globais/ModalBootstrap/index.js
@@ -29,6 +29,22 @@ export const ModalBootstrap = (propriedades) => {
                     <div dangerouslySetInnerHTML={
                         {__html: propriedades.bodyText}
                     }/>
+                    {propriedades.bodyActions && propriedades.bodyActions.length ? (
+                        <div className="d-flex justify-content-center mt-3">
+                            {propriedades.bodyActions.map((_action, index) => {
+                                return (
+                                    <Button 
+                                        key={index}
+                                        variant='success' 
+                                        onClick={() => _action.callback()}
+                                        className="mx-3 btn-sm"
+                                    >
+                                        {_action.title}
+                                    </Button>                            
+                                )
+                            })}
+                        </div>
+                    ) : null }
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant={

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -1,4 +1,6 @@
 import React, {useCallback, useEffect, useState, useContext} from "react";
+import {Link, useLocation, useParams} from "react-router-dom";
+import moment from "moment";
 import {TopoComBotoes} from "./TopoComBotoes";
 import TabelaValoresPendentesPorAcao from "./TabelaValoresPendentesPorAcao";
 import {Justificativa} from "./Justivicativa";
@@ -25,17 +27,16 @@ import {ModalConfirmaSalvar} from "../../../../utils/Modais";
 import {ASSOCIACAO_UUID} from "../../../../services/auth.service";
 import {tabelaValoresPendentes} from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
 import DataSaldoBancario from "./DataSaldoBancario";
-import moment from "moment";
 import {trataNumericos} from "../../../../utils/ValidacoesAdicionaisFormularios";
 import TabelaTransacoes from "./TabelaTransacoes";
 import {getDespesasTabelas} from "../../../../services/escolas/Despesas.service";
 import {FiltrosTransacoes} from "./FiltrosTransacoes";
-import {Link, useLocation} from "react-router-dom";
 import { SidebarLeftService } from "../../../../services/SideBarLeft.service";
 import { SidebarContext } from "../../../../context/Sidebar";
 import { ModalLegendaInformacao } from "../../../Globais/ModalLegendaInformacao/ModalLegendaInformacao";
 
 export const DetalheDasPrestacoes = () => {
+    let {periodo_uuid, conta_uuid} = useParams();
     const contextSideBar = useContext(SidebarContext);
 
     // Alteracoes
@@ -92,7 +93,9 @@ export const DetalheDasPrestacoes = () => {
     );
 
     const getPeriodoConta = () => {
-        if (localStorage.getItem('periodoConta')) {
+        if(periodo_uuid){
+            setPeriodoConta({periodo: periodo_uuid, conta: conta_uuid ? conta_uuid : ""});
+        } else if (localStorage.getItem('periodoConta')) {
             const periodoConta = JSON.parse(localStorage.getItem('periodoConta'));
             setPeriodoConta(periodoConta)
         } else {

--- a/src/componentes/escolas/PrestacaoDeContas/ModalPendenciasCadastrais.js
+++ b/src/componentes/escolas/PrestacaoDeContas/ModalPendenciasCadastrais.js
@@ -1,0 +1,21 @@
+import React from "react";
+import {ModalBootstrap} from "../../Globais/ModalBootstrap";
+
+export const ModalPendenciasCadastrais = (props) =>{
+    return (
+        <ModalBootstrap
+            show={props.show}
+            size={props.size}
+            onHide={props.handleClose}
+            titulo={props.titulo}
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.handleClose}
+            primeiroBotaoTexto={props.primeiroBotaoTexto}
+            primeiroBotaoCss={props.primeiroBotaoCss}
+            segundoBotaoOnclick={props.segundoBotaoOnclick}
+            segundoBotaoCss={props.segundoBotaoCss}
+            segundoBotaoTexto={props.segundoBotaoTexto}
+            bodyActions={props.bodyActions}
+        />
+    )
+};

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -175,7 +175,7 @@ const routesConfig = [
     },
     {
         exact: true,
-        path: "/detalhe-das-prestacoes/",
+        path: "/detalhe-das-prestacoes/:periodo_uuid?/:conta_uuid?/",
         component: DetalhedasPrestacoesPage,
         permissoes: ['access_prestacao_contas'],
     },


### PR DESCRIPTION
Esse PR:

- Valida pendências de cadastro em concluir acerto/concluir período.
- Dá opção ao usuário de navegar para as páginas das pendências.
- Seleciona período/conta específica na conciliação, caso tenha pendência em apenas uma conta.

História AB#95819