### PR TITLE
fix(96131): Corrige validação de despesas não reconhecidas

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -332,7 +332,7 @@ export const CadastroFormFormik = ({
                                                 name="documento_transacao"
                                                 id="documento_transacao"
                                                 type="text"
-                                                className={`${aux.documentoTransacaoObrigatorio(values.tipo_transacao, despesasTabelas) && !values.documento_transacao && verbo_http === "PUT" ? 'is_invalid' : ""} ${!values.documento_transacao && "despesa_incompleta"} form-control`}
+                                                className={`${aux.documentoTransacaoObrigatorio(values.tipo_transacao, despesasTabelas) && !values.documento_transacao && verbo_http === "PUT" ? 'is_invalid' : ""} ${aux.documentoTransacaoObrigatorio(values.tipo_transacao, despesasTabelas) && !values.documento_transacao && "despesa_incompleta"} form-control`}
                                                 placeholder="Digite o número do documento"
                                                 disabled={readOnlyCampos || ![['add_despesa'], ['change_despesa']].some(visoesService.getPermissoes)}
                                             />


### PR DESCRIPTION
Esse PR corrige a validação de despesas não reconhecidas.

A validação de campos obrigatórios na despesa não estava levando em consideração que documentos de transação não são obrigatórios em despesas não reconhecidas pela associação.

Corrige [AB#96131](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/96131)