### PR TITLE
feat(96256): Atualização de versão - NodeJS 13.14.0 --> 14.21.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # just to create `build` directory
-FROM node:13.14-alpine as builder
+FROM node:14.21-alpine as builder
 WORKDIR /app
 
 COPY . ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ptrf",
-      "version": "7.0.1",
+      "version": "8.3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.27",
         "@fortawesome/free-solid-svg-icons": "^5.12.1",
@@ -26,7 +26,7 @@
         "http-status-codes": "^1.4.0",
         "jwt-decode": "^2.2.0",
         "moment": "^2.24.0",
-        "node-sass": "^4.13.1",
+        "node-sass": "^4.14.1",
         "numero-por-extenso": "^1.0.8",
         "ordinal-pt-br": "^1.0.0",
         "primeicons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "http-status-codes": "^1.4.0",
     "jwt-decode": "^2.2.0",
     "moment": "^2.24.0",
-    "node-sass": "^4.13.1",
+    "node-sass": "^4.14.1",
     "numero-por-extenso": "^1.0.8",
     "ordinal-pt-br": "^1.0.0",
     "primeicons": "^2.0.0",


### PR DESCRIPTION
Esse PR:

- Atualiza a versão do NodeJS de 13.14.0 para 14.21.3
- Atualiza a versão do Node-Sass de 4.13.1 para 4.14.1

História: [AB#96256](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/96256)