### PR TITLE
feat(96759): Acompanhamento de pc exibir ata apresentação

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ArquivosDeReferencia/ArquivosDeReferenciaVisualizacaoDownload.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ArquivosDeReferencia/ArquivosDeReferenciaVisualizacaoDownload.js
@@ -59,9 +59,23 @@ const ArquivosDeReferenciaVisualizacaoDownload = ({prestacaoDeContas, infoAta}) 
         )
     }, [handleClickDownloadArquivoDeReferencia, handleClickVisualizarArquivoDeReferencia])
 
+    const getArquivosApresentadosEmTodasAsContas = useCallback(() => {
+        if (arquivos_referencia && arquivos_referencia.length > 0 && infoAta) {
+            let arquivos_apresentados_em_todas_as_contas = arquivos_referencia.filter(element => element.arquivo_apresentado_em_todas_as_contas)
+
+            return arquivos_apresentados_em_todas_as_contas;
+        }
+
+        return [];
+    }, [arquivos_referencia, infoAta])
+
     const getArquivosReferenciaPorConta = useCallback(() => {
+        let arquivos_apresentados_em_todas_as_contas = getArquivosApresentadosEmTodasAsContas();
+
         if (arquivos_referencia && arquivos_referencia.length > 0 && infoAta && infoAta.conta_associacao && infoAta.conta_associacao.uuid) {
             let arquivos = arquivos_referencia.filter(element => element.conta_uuid === infoAta.conta_associacao.uuid)
+
+            arquivos = arquivos.concat(arquivos_apresentados_em_todas_as_contas);
             setArquivoReferenciaPorConta(arquivos)
         }
     }, [arquivos_referencia, infoAta])

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/index.js
@@ -131,15 +131,14 @@ export const VisualizacaoDaAta = () => {
         setListaPresentes(lista_presentes);
     }
 
-    const aprensentaWatermarkPrevia = (dados_da_ata) => {
-        if(dados_da_ata && ((dados_da_ata.tipo_ata !== 'RETIFICACAO' && !dados_da_ata.prestacao_conta) || (dados_da_ata.tipo_ata === 'RETIFICACAO' && prestacaoDeContasDetalhe && prestacaoDeContasDetalhe.status && prestacaoDeContasDetalhe.status === 'DEVOLVIDA'))) {
+    const aprensentaWatermarkPrevia = (dados_da_ata, prestacaoDetalhes) => {
+        if(dados_da_ata && ((dados_da_ata.tipo_ata !== 'RETIFICACAO' && !dados_da_ata.prestacao_conta) || (dados_da_ata.tipo_ata === 'RETIFICACAO' && prestacaoDetalhes && prestacaoDetalhes.status && prestacaoDetalhes.status === 'DEVOLVIDA'))) {
             setWatermarkPrevia(true)
         }
     }
 
     const getDadosAta = async () => {
         let dados_ata = await getAtas(uuid_ata);
-        aprensentaWatermarkPrevia(dados_ata)
         let doc_pc = periodo_prestacao_de_contas.data_inicial ? await getPeriodoFechado(periodo_prestacao_de_contas.data_inicial) : null;
 
         let prestacao = null
@@ -148,6 +147,8 @@ export const VisualizacaoDaAta = () => {
         } else if (periodoUuid) {
             prestacao = await getPreviaPrestacaoDeContasDetalhe(periodoUuid);
         }
+
+        aprensentaWatermarkPrevia(dados_ata, prestacao)
 
         setPrestacaoDeContasDetalhe(prestacao);
         let data_da_reuniao = dados_ata.data_reuniao ? dados_ata.data_reuniao : "";

--- a/src/services/dres/PrestacaoDeContas.service.js
+++ b/src/services/dres/PrestacaoDeContas.service.js
@@ -143,6 +143,8 @@ export const getVisualizarArquivoDeReferencia = async (nome_do_arquivo, uuid, ti
         url = `/api/relacao-bens/${uuid}/pdf`
     }else if(tipo === "EB"){
         url = `/api/conciliacoes/${uuid}/extrato-bancario`
+    } else if(tipo === "AP" || tipo === "APR"){
+        url = `api/atas-associacao/download-arquivo-ata/?ata-uuid=${uuid}`
     }
 
     return (await api
@@ -175,6 +177,8 @@ export const getDownloadArquivoDeReferencia = async (nome_do_arquivo, uuid, tipo
         url = `/api/relacao-bens/${uuid}/pdf`
     }else if(tipo === "EB"){
         url = `/api/conciliacoes/${uuid}/extrato-bancario`
+    }else if(tipo === "AP" || tipo === "APR"){
+        url = `api/atas-associacao/download-arquivo-ata/?ata-uuid=${uuid}`
     }
 
     return (await api


### PR DESCRIPTION
Esse PR:

- Adiciona na listagem dos materiais de referência, do acompanhamento de pcs, a ata de apresentação da pc e a ata da retificação da apresentação da pc.
- Refatora a apresentação da marca dagua segundo os dados recebidos da ata.

História: [AB#96759](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/96759) 