### PR TITLE
feat(97899): Inclui acerto comprovante

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
@@ -1,33 +1,68 @@
-import React from "react";
+import React, {useState, useCallback} from "react";
 import {DatePickerField} from "../../../Globais/DatePickerField";
 import {trataNumericos} from "../../../../utils/ValidacoesAdicionaisFormularios";
 import CurrencyInput from "react-currency-input";
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
-import {faExclamationCircle, faCheck, faTrash} from '@fortawesome/free-solid-svg-icons'
+import {faExclamationCircle, faCheck, faTrash, faDownload, faEye} from '@fortawesome/free-solid-svg-icons'
 import ReactTooltip from "react-tooltip";
 import moment from "moment";
+import ModalVisualizarArquivoDeReferencia from "./ModalVisualizarArquivoDeReferencia";
+import { getDownloadArquivoDeReferencia } from "../../../../services/dres/PrestacaoDeContas.service";
+import {Form} from 'react-bootstrap';
 
 
 export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao, handleChangeAnalisesDeContaDaPrestacao, getObjetoIndexAnalise, editavel, prestacaoDeContas, adicaoAjusteSaldo, setAdicaoAjusteSaldo, onClickAdicionarAcertoSaldo, onClickDescartarAcerto, formErrosAjusteSaldo, validaAjustesSaldo, handleOnKeyDownAjusteSaldo, onClickSalvarAcertoSaldo, ajusteSaldoSalvoComSucesso, onClickDeletarAcertoSaldo}) => {
     let index = getObjetoIndexAnalise().analise_index;
     const tooltip_1 = 'A diferença entre o saldo bancário e o saldo reprogramado <br/> pode ocorrer em virtude de cheques não compensados, <br/> despesas/créditos não lançados ou lançados com erro ou <br/> estornos ainda não realizados.'
 
+    const [showModalVisualizarArquivoDeRerefencia, setShowModalVisualizarArquivoDeRerefencia] = useState(false)
+    const [uuidArquivoReferencia, setUuidArquivoReferencia] = useState('')
+    const [tipoArquivoReferencia, setTipoArquivoReferencia] = useState('')
+    const [nomeArquivoReferencia, setNomeArquivoReferencia] = useState('')
+
+    const handleClickDownloadArquivoDeReferencia = useCallback(async (rowData) => {
+        let nome_do_arquivo = `${rowData.nome}`
+        try {
+            await getDownloadArquivoDeReferencia(nome_do_arquivo, rowData.uuid, rowData.tipo);
+            console.log("Download efetuado com sucesso");
+        } catch (e) {
+            console.log("Erro ao efetuar o download ", e.response);
+        }
+    }, [])
+
+    const handleClickVisualizarArquivoDeReferencia = useCallback((extrato_bancario) => {
+        setUuidArquivoReferencia(extrato_bancario.uuid)
+        setTipoArquivoReferencia(extrato_bancario.tipo)
+        setNomeArquivoReferencia(extrato_bancario.nome)
+        setShowModalVisualizarArquivoDeRerefencia(true)
+    }, [])
+
+    const handleCloseModalVisualizarArquivoDeRerefencia = useCallback(() => {
+        setShowModalVisualizarArquivoDeRerefencia(false)
+    }, []);
+
     const informacoes_conciliacao_ue = () => {
         let info = null;
+        let extrato_bancario = [];
 
         if(infoAta && infoAta.conta_associacao){
             let conta_associacao = infoAta.conta_associacao.uuid;
             info = prestacaoDeContas.informacoes_conciliacao_ue.find(element => element.conta_uuid === conta_associacao);
+
+            let arquivos_referencia = prestacaoDeContas.arquivos_referencia.filter(element => element.conta_uuid === infoAta.conta_associacao.uuid);
+            extrato_bancario = arquivos_referencia.filter(element => element.tipo === "EB")
         }
 
         let dados = {
             saldo_extrato: '-',
-            data_extrato: '-'
+            data_extrato: '-',
+            extrato_bancario: null,
         }
 
         if (info){
             dados.saldo_extrato = info.saldo_extrato ? info.saldo_extrato : '-';
-            dados.data_extrato = info.data_extrato ? moment(info.data_extrato).format('DD/MM/YYYY') : '-'
+            dados.data_extrato = info.data_extrato ? moment(info.data_extrato).format('DD/MM/YYYY') : '-';
+            dados.extrato_bancario = extrato_bancario.length > 0 ? extrato_bancario[0] : null;
         }
 
         return dados;
@@ -101,7 +136,7 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
         let permite = true;
 
         if(index > -1){
-            if(!analisesDeContaDaPrestacao[index].saldo_extrato && !analisesDeContaDaPrestacao[index].data_extrato){
+            if(!analisesDeContaDaPrestacao[index].saldo_extrato && !analisesDeContaDaPrestacao[index].data_extrato && !analisesDeContaDaPrestacao[index].solicitar_envio_do_comprovante_do_saldo_da_conta){
                 permite = false;
             }
 
@@ -182,7 +217,31 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
                                     </p>
 
                                 </div>
+                                
                             </div>
+                            
+                            {informacoes_conciliacao_ue().extrato_bancario &&
+                                <div className="row container-extrato-bancario ml-0 mr-0">
+                                    <div className="col-12 mt-3">
+                                        <div className="d-flex align-items-center justify-content-start pb-3">
+                                            <span className="pr-2">{informacoes_conciliacao_ue().extrato_bancario.nome}</span>
+                                            <button onClick={() => handleClickVisualizarArquivoDeReferencia(informacoes_conciliacao_ue().extrato_bancario)} className="btn-editar-membro" type="button">
+                                                <FontAwesomeIcon
+                                                    style={{fontSize: '20px', marginRight: "0", marginTop: '2px', color: "#00585E"}}
+                                                    icon={faEye}
+                                                />
+                                            </button>
+                                            <span> | </span>
+                                            <button onClick={() => handleClickDownloadArquivoDeReferencia(informacoes_conciliacao_ue().extrato_bancario)} className="btn-editar-membro" type="button">
+                                                <FontAwesomeIcon
+                                                    style={{fontSize: '20px', marginRight: "0", color: "#00585E"}}
+                                                    icon={faDownload}
+                                                />
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div> 
+                            }
 
                             {(adicaoAjusteSaldo || (index >-1 && analisesDeContaDaPrestacao[index] && analisesDeContaDaPrestacao[index].uuid)) &&
                                 <div id="correcao_extrato_bancario">
@@ -280,8 +339,46 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
                                                 }
                                             </div>
                                         </div>
-
+    
                                     </div>
+
+                                    <div className="row container-extrato-bancario ml-0 mr-0">
+                                        <div className="col-12">
+                                            <Form.Check
+                                                type="checkbox"
+                                                checked={analisesDeContaDaPrestacao[index].solicitar_envio_do_comprovante_do_saldo_da_conta}
+                                                label={"Solicitar o envio do comprovante de saldo da conta"}
+                                                key={index}
+                                                onChange={(e) => {
+                                                    handleChangeAnalisesDeContaDaPrestacao(e.target.name, e.target.checked)
+                                                }}
+                                                name="solicitar_envio_do_comprovante_do_saldo_da_conta"
+                                                disabled={!editavel || !adicaoAjusteSaldo}
+                                            />
+                                        </div>
+                                    </div>
+
+                                    {analisesDeContaDaPrestacao[index].solicitar_envio_do_comprovante_do_saldo_da_conta &&
+                                        <div className="row container-extrato-bancario ml-0 mr-0">
+                                            <div className="col-12 mt-2 pb-2">
+                                                <span><strong>Obervação</strong></span>
+
+                                                <textarea
+                                                    value={analisesDeContaDaPrestacao[index].observacao_solicitar_envio_do_comprovante_do_saldo_da_conta}
+                                                    onChange={(e) => {
+                                                        handleChangeAnalisesDeContaDaPrestacao(e.target.name, e.target.value)
+                                                    }}
+                                                    className="form-control mt-2"
+                                                    rows="3"
+                                                    id="observacao_solicitar_envio_do_comprovante_do_saldo_da_conta"
+                                                    name="observacao_solicitar_envio_do_comprovante_do_saldo_da_conta"
+                                                    placeholder="Descrição da observação"
+                                                    disabled={!editavel || !adicaoAjusteSaldo}
+                                                >
+                                                </textarea>
+                                            </div>
+                                        </div>
+                                    }
                                 </div>
                             }
 
@@ -358,6 +455,16 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
                     </div>
                 </form>
             </>
+
+            <section>
+                <ModalVisualizarArquivoDeReferencia
+                    show={showModalVisualizarArquivoDeRerefencia}
+                    handleClose={handleCloseModalVisualizarArquivoDeRerefencia}
+                    uuidArquivoReferencia={uuidArquivoReferencia}
+                    nomeArquivoReferencia={nomeArquivoReferencia}
+                    tipoArquivoReferencia={tipoArquivoReferencia}
+                />
+            </section>
         </>
     )
 };

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ArquivosDeReferencia/ArquivosDeReferenciaVisualizacaoDownload.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ArquivosDeReferencia/ArquivosDeReferenciaVisualizacaoDownload.js
@@ -74,6 +74,7 @@ const ArquivosDeReferenciaVisualizacaoDownload = ({prestacaoDeContas, infoAta}) 
 
         if (arquivos_referencia && arquivos_referencia.length > 0 && infoAta && infoAta.conta_associacao && infoAta.conta_associacao.uuid) {
             let arquivos = arquivos_referencia.filter(element => element.conta_uuid === infoAta.conta_associacao.uuid)
+            arquivos = arquivos.filter(element => element.tipo !== "EB")
 
             arquivos = arquivos.concat(arquivos_apresentados_em_todas_as_contas);
             setArquivoReferenciaPorConta(arquivos)

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/DevolucaoParaAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/DevolucaoParaAcertos/index.js
@@ -80,8 +80,6 @@ const DevolucaoParaAcertos = ({
             if (mounted) {
                 if (infoAta && infoAta.contas && infoAta.contas.length > 0) {    
                     return await infoAta.contas.map(async (conta) => {
-                        let analise_prestacao_contas_ajustes = await getAnaliseAjustesSaldoPorConta(conta.conta_associacao.uuid, prestacaoDeContas.uuid, analise_atual_uuid);
-                        setAnalisesDeContaDaPrestacao([...analise_prestacao_contas_ajustes])
                         let lancamentos_ajustes = await getLancamentosAjustes(analise_atual_uuid, conta.conta_associacao.uuid)
                         setLancamentosAjustes([...lancamentos_ajustes])
                         let documentos_ajustes = await getDocumentosAjustes(analise_atual_uuid, conta.conta_associacao.uuid)

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
@@ -210,6 +210,9 @@ export const DetalhePrestacaoDeContas = () =>{
                             conta_associacao: conta.conta_associacao.uuid,
                             data_extrato: conta.data_extrato,
                             saldo_extrato: conta.saldo_extrato !== null ? valorTemplate(conta.saldo_extrato) : null,
+                            solicitar_envio_do_comprovante_do_saldo_da_conta: conta.solicitar_envio_do_comprovante_do_saldo_da_conta,
+                            observacao_solicitar_envio_do_comprovante_do_saldo_da_conta: conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta ? conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta : "",
+                            
                         })
                     });
                 setAnalisesDeContaDaPrestacao(arrayAnalises);
@@ -381,6 +384,8 @@ export const DetalhePrestacaoDeContas = () =>{
                 conta_associacao: conta.uuid,
                 data_extrato: '',
                 saldo_extrato: null,
+                solicitar_envio_do_comprovante_do_saldo_da_conta: false,
+                observacao_solicitar_envio_do_comprovante_do_saldo_da_conta: ""
             })
 
             setAnalisesDeContaDaPrestacao(lista)
@@ -401,18 +406,22 @@ export const DetalhePrestacaoDeContas = () =>{
             uuid: analise.uuid,
             conta_associacao: analise.conta_associacao.uuid,
             data_extrato: analise.data_extrato,
-            saldo_extrato: analise.saldo_extrato !== null ? valorTemplate(analise.saldo_extrato) : null
+            saldo_extrato: analise.saldo_extrato !== null ? valorTemplate(analise.saldo_extrato) : null,
+            solicitar_envio_do_comprovante_do_saldo_da_conta: analise.solicitar_envio_do_comprovante_do_saldo_da_conta,
+            observacao_solicitar_envio_do_comprovante_do_saldo_da_conta: analise.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta !== null ? analise.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta : "",
         })
 
         setAnalisesDeContaDaPrestacao(()=>[
             ...arrayAnalise
-        ])  
+        ])     
     }
 
     const onClickSalvarAcertoSaldo = async (conta, analise_de_conta, index) => {
         let uuid_analise;
         let data_extrato = null;
         let saldo_extato = null;
+        let solicitar_envio_do_comprovante_do_saldo_da_conta = null;
+        let observacao_solicitar_envio_do_comprovante_do_saldo_da_conta = null;
 
         if(prestacaoDeContas && prestacaoDeContas.analise_atual && prestacaoDeContas.analise_atual.uuid){
             uuid_analise = prestacaoDeContas.analise_atual.uuid
@@ -430,6 +439,19 @@ export const DetalhePrestacaoDeContas = () =>{
             if(analise_de_conta.saldo_extrato){
                 saldo_extato = trataNumericos(analise_de_conta.saldo_extrato)
             }
+
+            if(analise_de_conta.solicitar_envio_do_comprovante_do_saldo_da_conta !== null){
+                solicitar_envio_do_comprovante_do_saldo_da_conta = analise_de_conta.solicitar_envio_do_comprovante_do_saldo_da_conta
+            }
+
+            if(analise_de_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta){
+                if(solicitar_envio_do_comprovante_do_saldo_da_conta === false){
+                    observacao_solicitar_envio_do_comprovante_do_saldo_da_conta = null;
+                }
+                else{
+                    observacao_solicitar_envio_do_comprovante_do_saldo_da_conta = analise_de_conta.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta;
+                }
+            }
         }
 
         let payload = {
@@ -437,7 +459,9 @@ export const DetalhePrestacaoDeContas = () =>{
             conta_associacao: conta.uuid,
             prestacao_conta: prestacaoDeContas.uuid,
             data_extrato: data_extrato,
-            saldo_extrato: saldo_extato
+            saldo_extrato: saldo_extato,
+            solicitar_envio_do_comprovante_do_saldo_da_conta: solicitar_envio_do_comprovante_do_saldo_da_conta,
+            observacao_solicitar_envio_do_comprovante_do_saldo_da_conta: observacao_solicitar_envio_do_comprovante_do_saldo_da_conta,
         }
 
         try {
@@ -594,23 +618,22 @@ export const DetalhePrestacaoDeContas = () =>{
                 uuid_analise = ultima_analise.uuid
             }
 
-            let analise_teste = await getAnaliseAjustesSaldoPorConta(info_ata_por_conta.conta_associacao.uuid, prestacaoDeContas.uuid, uuid_analise);
-            analise_teste = analise_teste[0]
+            let analise_encontrada = await getAnaliseAjustesSaldoPorConta(info_ata_por_conta.conta_associacao.uuid, prestacaoDeContas.uuid, uuid_analise);
+            analise_encontrada = analise_encontrada[0]
 
-
-            if(analise_teste){
+            if(analise_encontrada){
                 setAnalisesDeContaDaPrestacao(analise=>[
                     ...analise,
                     {
-                        uuid: analise_teste.uuid,
-                        conta_associacao: analise_teste.conta_associacao.uuid,
-                        data_extrato: analise_teste.data_extrato,
-                        saldo_extrato: analise_teste.saldo_extrato !== null ? valorTemplate(analise_teste.saldo_extrato) : null
+                        uuid: analise_encontrada.uuid,
+                        conta_associacao: analise_encontrada.conta_associacao.uuid,
+                        data_extrato: analise_encontrada.data_extrato,
+                        saldo_extrato: analise_encontrada.saldo_extrato !== null ? valorTemplate(analise_encontrada.saldo_extrato) : null,
+                        solicitar_envio_do_comprovante_do_saldo_da_conta: analise_encontrada.solicitar_envio_do_comprovante_do_saldo_da_conta,
+                        observacao_solicitar_envio_do_comprovante_do_saldo_da_conta: analise_encontrada.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta ? analise_encontrada.observacao_solicitar_envio_do_comprovante_do_saldo_da_conta : "",
                     }
                 ])
             }
-
-            
         }
 
     };


### PR DESCRIPTION
feat(97899): Inclui acerto comprovante

Esse PR:

- Remove extrato bancário da lista de documentos
- Adiciona extrato bancário ao acerto da conta
- Adiciona opção de solicitar um novo extrato bancario 
- Adiciona campo observação
- Altera condições para bloqueio do botão salvar ao criar acerto
- Refatora função que calcula se há acertos da conta para habilitar botão ver resumo

História: [AB#97899](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/97899)