### PR TITLE
feat(98017): Cria servico para manter ordenamento

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabelaConferenciaDeLancamentos.js
@@ -84,6 +84,8 @@ const TabelaConferenciaDeLancamentos = ({
     let filtrar_por_tipo_de_pagamento = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento
     let filtrar_por_informacoes = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao
     let filtrar_por_conferencia = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia
+    let ordenamento_tabela_lancamentos = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos
+    
 
         useEffect(() => {
         desmarcarTodos()
@@ -409,7 +411,7 @@ const TabelaConferenciaDeLancamentos = ({
                 await postLancamentosParaConferenciaMarcarComoCorreto(prestacaoDeContas.uuid, payload)
                 console.log("Marcados como correto com sucesso!")
                 desmarcarTodos()
-                await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual, false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia)
+                await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual, false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia, multiSortMeta)
             } catch (e) {
                 console.log("Erro ao marcar como correto ", e.response)
             }
@@ -438,7 +440,8 @@ const TabelaConferenciaDeLancamentos = ({
                 await postLancamentosParaConferenciaMarcarNaoConferido(prestacaoDeContas.uuid, payload)
                 console.log("Marcados como não conferido com sucesso!")
                 desmarcarTodos()
-                await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual, false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia)
+                await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual, false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia,
+                multiSortMeta)
             } catch (e) {
                 console.log("Erro ao marcar como não conferido ", e.response)
             }
@@ -480,8 +483,10 @@ const TabelaConferenciaDeLancamentos = ({
         filtrar_por_tipo_de_pagamento: dados_acompanhamento_de_pc_usuario_logado && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento ? dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento : "",
         filtrar_por_informacoes: dados_acompanhamento_de_pc_usuario_logado && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao ? dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao : [],
         filtrar_por_conferencia: dados_acompanhamento_de_pc_usuario_logado && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia ? dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia : [],
+        ordenamento_tabela_lancamentos: dados_acompanhamento_de_pc_usuario_logado && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos ? dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos : [],
     }
     const [stateFiltros, setStateFiltros] = useState(initialStateFiltros);
+    const [multiSortMeta, setMultiSortMeta] = useState(initialStateFiltros.ordenamento_tabela_lancamentos);
 
     const handleChangeFiltros = (name, value) => {
         setStateFiltros({
@@ -514,7 +519,7 @@ const TabelaConferenciaDeLancamentos = ({
 
     const handleSubmitFiltros = async () => {
         desmarcarTodos()
-        await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual,  false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia)
+        await carregaLancamentosParaConferencia(prestacaoDeContas, contaUuid, stateFiltros.filtrar_por_acao, stateFiltros.filtrar_por_lancamento, paginacao_atual,  false, stateFiltros.filtrar_por_data_inicio, stateFiltros.filtrar_por_data_fim, stateFiltros.filtrar_por_nome_fornecedor, stateFiltros.filtrar_por_numero_de_documento, stateFiltros.filtrar_por_tipo_de_documento, stateFiltros.filtrar_por_tipo_de_pagamento, stateFiltros.filtrar_por_informacoes, stateFiltros.filtrar_por_conferencia, multiSortMeta)
     };
 
     const limpaFiltros = async () => {
@@ -543,6 +548,7 @@ const TabelaConferenciaDeLancamentos = ({
                 filtrar_por_tipo_de_pagamento: filtrar_por_tipo_de_pagamento,
                 filtrar_por_conferencia: filtrar_por_conferencia,
                 filtrar_por_informacoes: filtrar_por_informacoes,
+                ordenamento_tabela_lancamentos: ordenamento_tabela_lancamentos,
                 paginacao_atual: event.rows * event.page,
             },
         }
@@ -591,6 +597,12 @@ const TabelaConferenciaDeLancamentos = ({
         }
     }
 
+    const onSort = (event) => {   
+        let copiaArrayDeOrdenamento = [...event.multiSortMeta]
+        setMultiSortMeta(copiaArrayDeOrdenamento);
+        meapcservice.setOrdenamentoTabelaLancamentos(visoesService.getUsuarioLogin(), copiaArrayDeOrdenamento)
+    };
+    
     return (
         <>
 
@@ -644,6 +656,8 @@ const TabelaConferenciaDeLancamentos = ({
                         // Usado para salvar no localStorage a página atual após os calculos ** ver função onPaginationClick
                         first={primeiroRegistroASerExibido}
                         onPage={onPaginationClick}
+                        multiSortMeta={multiSortMeta}
+                        onSort={onSort}
                     >
                         <Column
                             header={selecionarHeader()}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabsConferenciaDeLancamentos.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/TabsConferenciaDeLancamentos.js
@@ -19,6 +19,8 @@ export const TabsConferenciaDeLancamentos = ({contasAssociacao, toggleBtnEscolhe
     let filtrar_por_conferencia = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia
     let filtrar_por_informacoes = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao
 
+    let ordenamento_tabela_lancamentos = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos
+
     return (
         <>
             {loadingLancamentosParaConferencia ? (
@@ -38,7 +40,7 @@ export const TabsConferenciaDeLancamentos = ({contasAssociacao, toggleBtnEscolhe
                                         onClick={() => {
                                             toggleBtnEscolheConta(conta.uuid);
                                             setStateCheckBoxOrdenarPorImposto(false)
-                                            carregaLancamentosParaConferencia(prestacaoDeContas, conta.uuid, filtrar_por_acao, filtrar_por_lancamento, 0, false, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia)
+                                            carregaLancamentosParaConferencia(prestacaoDeContas, conta.uuid, filtrar_por_acao, filtrar_por_lancamento, 0, false, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia, ordenamento_tabela_lancamentos)
 
                                         }}
                                         className={`nav-link btn-escolhe-acao ${clickBtnEscolheConta === conta.uuid ? "btn-escolhe-acao-active" : ""}`}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/index.js
@@ -58,9 +58,10 @@ const ConferenciaDeLancamentos = ({prestacaoDeContas, onCarregaLancamentosParaCo
         let filtrar_por_tipo_de_pagamento = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento
         let filtrar_por_conferencia = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia
         let filtrar_por_informacao = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao
+        let ordenamento_tabela_lancamentos = dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos
 
         if (dados_acompanhamento_de_pc_usuario_logado && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.conta_uuid){
-            carregaLancamentosParaConferencia(prestacaoDeContas, dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, false, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_conferencia, filtrar_por_informacao)
+            carregaLancamentosParaConferencia(prestacaoDeContas, dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, false, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacao, filtrar_por_conferencia,  ordenamento_tabela_lancamentos)
             toggleBtnEscolheConta(dados_acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.conta_uuid)
         }else if (contasAssociacao.length > 0){
             carregaLancamentosParaConferencia(prestacaoDeContas, contasAssociacao[0].uuid)
@@ -77,7 +78,7 @@ const ConferenciaDeLancamentos = ({prestacaoDeContas, onCarregaLancamentosParaCo
         setClickBtnEscolheConta(conta_uuid);
     };
 
-    const salvaObjetoAcompanhamentoDePcPorUsuarioLocalStorage = (prestacao_de_contas, conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia) =>{
+    const salvaObjetoAcompanhamentoDePcPorUsuarioLocalStorage = (prestacao_de_contas, conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia, ordenamento_tabela_lancamentos) =>{
         let objetoAcompanhamentoDePcPorUsuario = {
             prestacao_de_conta_uuid: prestacaoDeContas.uuid,
             conferencia_de_lancamentos: {
@@ -93,14 +94,15 @@ const ConferenciaDeLancamentos = ({prestacaoDeContas, onCarregaLancamentosParaCo
                 filtrar_por_tipo_de_documento: filtrar_por_tipo_de_documento,
                 filtrar_por_tipo_de_pagamento: filtrar_por_tipo_de_pagamento,
                 filtrar_por_informacao: filtrar_por_informacoes,
-                filtrar_por_conferencia: filtrar_por_conferencia
+                filtrar_por_conferencia: filtrar_por_conferencia,
+                ordenamento_tabela_lancamentos: ordenamento_tabela_lancamentos
             },
         }
         meapcservice.setAcompanhamentoDePcPorUsuario(visoesService.getUsuarioLogin(), objetoAcompanhamentoDePcPorUsuario)
     }
 
-    const carregaLancamentosParaConferencia = async (prestacao_de_contas, conta_uuid, filtrar_por_acao=null, filtrar_por_lancamento=null, paginacao_atual, ordenar_por_imposto=null, filtrar_por_data_inicio=null, filtrar_por_data_fim=null, filtrar_por_nome_fornecedor=null, filtrar_por_numero_de_documento=null, filtrar_por_tipo_de_documento=null, filtrar_por_tipo_de_pagamento=null, filtrar_por_informacoes=[], filtrar_por_conferencia = []) =>{
-        salvaObjetoAcompanhamentoDePcPorUsuarioLocalStorage(prestacao_de_contas, conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia)
+    const carregaLancamentosParaConferencia = async (prestacao_de_contas, conta_uuid, filtrar_por_acao=null, filtrar_por_lancamento=null, paginacao_atual, ordenar_por_imposto=null, filtrar_por_data_inicio=null, filtrar_por_data_fim=null, filtrar_por_nome_fornecedor=null, filtrar_por_numero_de_documento=null, filtrar_por_tipo_de_documento=null, filtrar_por_tipo_de_pagamento=null, filtrar_por_informacoes=[], filtrar_por_conferencia = [], ordenamento_tabela_lancamentos=[]) =>{
+        salvaObjetoAcompanhamentoDePcPorUsuarioLocalStorage(prestacao_de_contas, conta_uuid, filtrar_por_acao, filtrar_por_lancamento, paginacao_atual, filtrar_por_data_inicio, filtrar_por_data_fim, filtrar_por_nome_fornecedor, filtrar_por_numero_de_documento, filtrar_por_tipo_de_documento, filtrar_por_tipo_de_pagamento, filtrar_por_informacoes, filtrar_por_conferencia, ordenamento_tabela_lancamentos)
 
         setContaUuid(conta_uuid)
         setLoadingLancamentosParaConferencia(true)

--- a/src/services/mantemEstadoAcompanhamentoDePc.service.js
+++ b/src/services/mantemEstadoAcompanhamentoDePc.service.js
@@ -21,7 +21,8 @@ const limpaAcompanhamentoDePcUsuarioLogado = (usuario) =>{
                 filtrar_por_tipo_de_documento: '',
                 filtrar_por_tipo_de_pagamento: '',
                 filtrar_por_conferencia: [],
-                filtrar_por_informacao: []
+                filtrar_por_informacao: [],
+                ordenamento_tabela_lancamentos: []
             },
         }
     };
@@ -36,6 +37,14 @@ const setAcompanhamentoDePcPorUsuario = (usuario, objeto) =>{
     };
     localStorage.setItem(ACOMPANHAMENTO_DE_PC, JSON.stringify(dados_acompanhamentos_de_pc_update));
 }
+
+const setOrdenamentoTabelaLancamentos = (usuario, ordenamento) => {
+    let acompanhamento_de_pc_usuario_logado = getAcompanhamentoDePcUsuarioLogado();
+    if (acompanhamento_de_pc_usuario_logado) {
+        acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos = ordenamento;
+        setAcompanhamentoDePcPorUsuario(usuario, acompanhamento_de_pc_usuario_logado);
+    }
+};
 
 const setAcompanhamentoDePc = async () =>{
     let todos_acompanhamentos_de_pc = getTodosAcompanhamentosDePc()
@@ -60,6 +69,7 @@ const setAcompanhamentoDePc = async () =>{
                filtrar_por_tipo_de_pagamento: acompanhamento_de_pc_usuario_logado && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento ? acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_tipo_de_pagamento : '',
                filtrar_por_informacoes: acompanhamento_de_pc_usuario_logado && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao ? acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_informacao : [],
                filtrar_por_conferencia: acompanhamento_de_pc_usuario_logado && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia ? acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.filtrar_por_conferencia : [],
+               ordenamento_tabela_lancamentos: acompanhamento_de_pc_usuario_logado && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos && acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos ? acompanhamento_de_pc_usuario_logado.conferencia_de_lancamentos.ordenamento_tabela_lancamentos : [],
             },
         }
     };
@@ -83,4 +93,5 @@ export const mantemEstadoAcompanhamentoDePc = {
     setAcompanhamentoDePcPorUsuario,
     getTodosAcompanhamentosDePc,
     getAcompanhamentoDePcUsuarioLogado,
+    setOrdenamentoTabelaLancamentos
 }


### PR DESCRIPTION
Esse PR:

- Adiciona serviço para manter estado de ordenamento da tabela de análise de lançamentos.
- Altera serviço de manter estados de filtros para incluir o ordenamento no mesmo objeto de acompanhamento de pc.

História: [AB#98017](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/98017)