### PR TITLE
fix(100511): Desfazer analise de pc em retificação

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/BotoesAvancarRetroceder.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/BotoesAvancarRetroceder.js
@@ -22,8 +22,8 @@ export const BotoesAvancarRetroceder = ({prestacaoDeContas, textoBtnAvancar, tex
                                     style={{marginRight: "5px", color: '#fff'}}
                                     icon={faAngleDoubleLeft}
                                 />
-                                <span data-tip={tooltipRetroceder}>{textoBtnRetroceder}</span>
-                                {tooltipRetroceder && <ReactTooltip place="right"/>}
+                                <span data-tip={tooltipRetroceder} data-for={`tooltip-id-${prestacaoDeContas.uuid}`}>{textoBtnRetroceder}</span>
+                                {tooltipRetroceder && <ReactTooltip  place="right" id={`tooltip-id-${prestacaoDeContas.uuid}`} html={true}/>}
                             </button>
                             </>
                         }

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -553,8 +553,9 @@ export const GetComportamentoPorStatus = (
                         metodoAvancar={() => setShowConcluirAnalise(true)}
                         metodoRetroceder={() => setShowVoltarParaAnalise()}
                         disabledBtnAvancar={true}
-                        disabledBtnRetroceder={!TEMPERMISSAO}
+                        disabledBtnRetroceder={bloqueiaBtnRetroceder() || !TEMPERMISSAO}
                         esconderBotaoAvancar={true}
+                        tooltipRetroceder={tooltipRetroceder()}
                     />
                     <TrilhaDeStatus
                         prestacaoDeContas={prestacaoDeContas}
@@ -645,8 +646,9 @@ export const GetComportamentoPorStatus = (
                         metodoAvancar={() => setShowConcluirAnalise(true)}
                         metodoRetroceder={() => setShowVoltarParaAnalise(true)}
                         disabledBtnAvancar={true}
-                        disabledBtnRetroceder={!TEMPERMISSAO}
+                        disabledBtnRetroceder={bloqueiaBtnRetroceder() || !TEMPERMISSAO}
                         esconderBotaoAvancar={true}
+                        tooltipRetroceder={tooltipRetroceder()}
                     />
                     <TrilhaDeStatus
                         prestacaoDeContas={prestacaoDeContas}

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
@@ -1055,8 +1055,16 @@ export const DetalhePrestacaoDeContas = () =>{
         }
     }
 
+    const pcConcluida = () => {
+        if(prestacaoDeContas && (prestacaoDeContas.status === "APROVADA" || prestacaoDeContas.status === "APROVADA_RESSALVA" || prestacaoDeContas.status === "REPROVADA")){
+            return true;
+        }
+
+        return false;
+    }
+
     const bloqueiaBtnRetroceder = () => {
-        if((prestacaoDeContas && (prestacaoDeContas.status === "EM_ANALISE" || prestacaoDeContas.status === "RECEBIDA") && pcEmRetificacao())){
+        if((prestacaoDeContas && (prestacaoDeContas.status === "EM_ANALISE" || prestacaoDeContas.status === "RECEBIDA" || pcConcluida()) && pcEmRetificacao())){
             return true;
         }
         
@@ -1069,6 +1077,10 @@ export const DetalhePrestacaoDeContas = () =>{
         }
 
         if(prestacaoDeContas && prestacaoDeContas.status === "EM_ANALISE" && pcEmRetificacao()) {
+            return "Não é possível retornar o status da PC em retificação."
+        }
+
+        if(pcConcluida() && pcEmRetificacao()) {
             return "Não é possível retornar o status da PC em retificação."
         }
     


### PR DESCRIPTION
fix(100511): Desfazer analise de pc em retificação

Esse PR:

- Bloqueia botão para desfazer analise quando uma PC está em retificação

História: [AB#100511](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/100511)