### PR TITLE
feat(100076): Utiliza a data da reuniao na assinatura da ata

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/Assinaturas/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/Assinaturas/index.js
@@ -8,7 +8,14 @@ moment.updateLocale('pt', {
     ]
 });
 
-export const Assinaturas = ({presentes_na_ata}) => {
+export const Assinaturas = ({data_assinatura, presentes_na_ata}) => {
+    const renderAssinatura = () => {
+        if(data_assinatura) {
+            return <strong>São Paulo, {moment(data_assinatura).format('DD [de] MMMM [de] YYYY')}.</strong>
+        }
+        return <strong>São Paulo, {moment().format('DD [de] MMMM [de] YYYY')}.</strong>
+    }
+
     return (
         <>
             <p className="mt-3 titulo-assinaturas">
@@ -17,7 +24,7 @@ export const Assinaturas = ({presentes_na_ata}) => {
             </p>
 
             <p className="mt-5 mb-5 titulo-assinaturas">
-                <strong>São Paulo, {moment().format('DD [de] MMMM [de] YYYY')}.</strong>
+                {renderAssinatura()}
             </p>
 
 

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/FormularioEditarAta/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/FormularioEditarAta/index.js
@@ -2,10 +2,11 @@ import React, {useState, useEffect } from "react";
 import {FieldArray, Formik} from "formik";
 import { DatePickerField } from "../../../../../../Globais/DatePickerField";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faTimesCircle} from "@fortawesome/free-solid-svg-icons";
+import {faInfoCircle, faTimesCircle} from "@fortawesome/free-solid-svg-icons";
 import { consultarRF } from "../../../../../../../services/escolas/Associacao.service";
 import {visoesService} from "../../../../../../../services/visoes.service"
 import {apenasNumero} from "../../../../../../../utils/ValidacoesAdicionaisFormularios";
+import ReactTooltip from "react-tooltip";
 
 
 export const FormularioEditaAta = ({listaPresentesPadrao, listaPresentes, stateFormEditarAta, uuid_ata, formRef, onSubmitFormEdicaoAta, setDisableBtnSalvar}) => {
@@ -157,7 +158,15 @@ export const FormularioEditaAta = ({listaPresentesPadrao, listaPresentes, stateF
 
                                     <div className="form-row mt-4">
                                         <div className="col">
-                                            <label htmlFor="stateFormEditarAta.numero_ata">Número da Ata</label>
+                                            <label htmlFor="stateFormEditarAta.numero_ata" data-tip={"Informar apenas o número da ata."} data-html={true} data-for="numero-ata-tooltip">
+                                                <span>Número da Ata</span>
+                                                <FontAwesomeIcon
+                                                    style={{fontSize: '12px', marginLeft: "3px", color: '#2B7D83'}}
+                                                    icon={faInfoCircle}
+                                                    id="numero-ata-tooltip"
+                                                />
+                                                <ReactTooltip id="numero-ata-tooltip" html={true}/>
+                                            </label>
                                             <input
                                                 value={values.stateFormEditarAta.numero_ata ? values.stateFormEditarAta.numero_ata : ''}
                                                 onChange={(e) => {

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/index.js
@@ -275,6 +275,7 @@ export const VisualizacaoDaAtaParecerTecnico = () => {
                         }
                         {dadosAta && Object.entries(dadosAta).length > 0 && dadosAta.presentes_na_ata &&
                             <Assinaturas
+                                data_assinatura={dadosAta.data_reuniao}
                                 presentes_na_ata={dadosAta.presentes_na_ata}
                             />
                         }


### PR DESCRIPTION
Esse PR:

- Adiciona tooltip na ata de parecer técnico.
- Modifica na visualização prévia e na final da ata a data da assinatura para a data de preenchimento da reunião.

História: AB#100076