### PR TITLE
feat(103047): Permitir saldo negativo na análise de extrato

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
@@ -274,7 +274,7 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
                                             <label htmlFor="saldo_extrato"><strong>Saldo corrigido</strong></label>
                                             <CurrencyInput
                                                 disabled={!editavel || !adicaoAjusteSaldo}
-                                                allowNegative={false}
+                                                allowNegative={true}
                                                 prefix='R$'
                                                 decimalSeparator=","
                                                 thousandSeparator="."

--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -478,16 +478,27 @@ export const round = (num, places) => {
   return +(parseFloat(num).toFixed(places));
 }
 
-export const trataNumericos = (valor) =>{
+export const trataNumericos = (valor) => {
+  if (typeof valor === "string") {
+    // Extrai o sinal negativo, se existir.
+    const isNegative = valor.startsWith('-');
 
-  if (typeof (valor) === "string"){
-    return Number(valor.replace(/\./gi,'').replace(/R/gi,'').replace(/,/gi,'.').replace(/\$/, ""));
+    // Remove todos os caracteres não numéricos, exceto a vírgula.
+    const cleaned = valor.replace(/[^\d,]/g, "");
 
-  }else {
+    // Converte a vírgula em um ponto para torná-la uma string numérica válida.
+    const converted = cleaned.replace(/,/g, ".");
 
-    return valor
+    // Converte a string numérica em um número.
+    const numberValue = Number(converted);
+
+    // Aplica de volta o sinal negativo, se necessário.
+    return isNegative ? -numberValue : numberValue;
+  } else {
+    return valor;
   }
 }
+
 
 export const calculaValorRateio = (valor1, valor2) => {
 


### PR DESCRIPTION
Esse PR:
- Alterar a análise de PC para permitir saldos negativos na solicitação de ajuste em saldos de extrato

Atende AB#103047