### PR TITLE
feat(103823): Tratamento data inicial conta no crédito da escola

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
+++ b/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {ReceitaSchema} from "../Schemas";
 import {visoesService} from "../../../../services/visoes.service";
 import {DatePickerField} from "../../../Globais/DatePickerField";
@@ -76,6 +76,7 @@ export const ReceitaFormFormik = ({
                                       validacoesPersonalizadasCredito,
                                       formDateErrors,
                                       escondeBotaoDeletar,
+                                      mensagemDataInicialConta
                                   }) => {
 
     return (
@@ -224,7 +225,10 @@ export const ReceitaFormFormik = ({
                                         name="data"
                                         id="data"
                                         value={values.data}
-                                        onChange={setFieldValue}
+                                        onChange={(name, value) => {
+                                            setFieldValue('conta_associacao', '');
+                                            setFieldValue(name, value);
+                                        }}
                                         onCalendarClose={async () => {
                                             validacoesPersonalizadasCredito(values, setFieldValue, "credito_principal")
                                         }}
@@ -249,14 +253,20 @@ export const ReceitaFormFormik = ({
                                         onChange={props.handleChange}
                                         onBlur={props.handleBlur}
                                         className="form-control"
-                                        disabled={readOnlyEstorno || readOnlyValor || readOnlyCampos || readOnlyContaAssociacaoReceita || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
+                                        disabled={mensagemDataInicialConta || readOnlyEstorno || readOnlyValor || readOnlyCampos || readOnlyContaAssociacaoReceita || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes) || !values.data}
                                     >
-                                        {receita.conta_associacao
-                                            ? null
-                                            : <option key="" value="">Escolha uma conta</option>}
+
+                                        {!receita.conta_associacao || props.values.conta_associacao === "" ? (
+                                                <option key="" value="">
+                                                    Escolha uma conta
+                                                </option>
+                                            ) : null}
 
                                         {retornaTiposDeContas(props.values)}
                                     </select>
+                                    {mensagemDataInicialConta && <span
+                                            className="span_erro text-danger mt-1"> {mensagemDataInicialConta}</span>
+                                    }
                                     {props.touched.conta_associacao && props.errors.conta_associacao &&
                                         <span
                                             className="span_erro text-danger mt-1"> {props.errors.conta_associacao}</span>}

--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -101,6 +101,7 @@ export const ReceitaForm = () => {
     const [classificacoesAceitas, setClassificacoesAceitas] = useState([])
     const [tituloModalCancelar, setTituloModalCancelar] = useState("Deseja cancelar a inclusão de crédito?")
     const [periodosValidosAssociacaoencerrada, setPeriodosValidosAssociacaoencerrada] = useState([])
+    const [mensagemDataInicialConta, setMensagemDataInicialConta] = useState("")
 
     // ************* Modo Estorno
     const [readOnlyEstorno, setReadOnlyEstorno] = useState(false);
@@ -888,6 +889,27 @@ export const ReceitaForm = () => {
         }
     };
 
+    const filtraContasPelaDataInicial = ({contasNaoFiltradas = [], dataDigitadaFormulario = initialValue.data}) => {
+        let contasFiltradasPelaDataInicial = []
+
+        if(contasNaoFiltradas && dataDigitadaFormulario) {
+            contasFiltradasPelaDataInicial = contasNaoFiltradas.filter((acc) => { 
+                if (acc.data_inicio && moment(acc.data_inicio, 'YYYY-MM-DD').isValid()) {
+                  return moment(acc.data_inicio, 'YYYY-MM-DD').toDate() <= moment(dataDigitadaFormulario, 'YYYY-MM-DD').toDate();
+                }
+                return false;
+              });
+            
+            if(!contasFiltradasPelaDataInicial.length) {
+                setMensagemDataInicialConta("Não existem contas disponíveis para a data do crédito.")
+            } else {
+                setMensagemDataInicialConta("")
+            }
+        }
+
+        return contasFiltradasPelaDataInicial;
+    }
+
 
     const retornaTiposDeContas = (values) => {
         if (tabelas.contas_associacao !== undefined && tabelas.contas_associacao.length > 0  && values.tipo_receita && e_repasse(values) && Object.keys(repasse).length !== 0) {
@@ -915,9 +937,11 @@ export const ReceitaForm = () => {
                     return <option {...defaultProps} disabled>{item.nome} {informacaoExtra}</option>
                 }
             }
-            // Filtra as contas pelos tipos aceitos
+            
+            const contasFiltradasPelaDataInicialEPeloTipo = filtraContasPelaDataInicial({contasNaoFiltradas: tabelas.contas_associacao.filter(conta => (tipos_conta.includes(conta.nome))), dataDigitadaFormulario: values.data})
+
             return (
-                tabelas.contas_associacao.filter(conta => (tipos_conta.includes(conta.nome))).map((item, key) => (
+                contasFiltradasPelaDataInicialEPeloTipo.map((item, key) => (
                     getOptionPorStatus(item)
                 )))
         }
@@ -1280,6 +1304,7 @@ export const ReceitaForm = () => {
                         validacoesPersonalizadasCredito={validacoesPersonalizadasCredito}
                         formDateErrors={formDateErrors}
                         escondeBotaoDeletar={escondeBotaoDeletar}
+                        mensagemDataInicialConta={mensagemDataInicialConta}
                     />
                     <section>
                         <CancelarModalReceitas


### PR DESCRIPTION
Esse PR:

- Adiciona a verificação da data inicial das contas ao digitar a data do crédito que vai ser editado ou adicionado.
- Adiciona mensagem de aviso caso não exita contas para selecionar na data especificada no crédito.

História: AB#103823