### PR TITLE
feat(104192): Não permite concluir analise pc com conta não zerada

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/Modais/ModalBloqueioConclusaoContaEncerradaNaoZerada.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/Modais/ModalBloqueioConclusaoContaEncerradaNaoZerada.js
@@ -1,0 +1,16 @@
+import {ModalBootstrap} from "../../../../../Globais/ModalBootstrap";
+import React from "react";
+
+export const ModalBloqueioConclusaoContaEncerradaNaoZerada = (props) => {
+    return (
+        <ModalBootstrap
+            show={props.show}
+            onHide={props.handleClose}
+            titulo={props.titulo}
+            bodyText={props.texto}
+            primeiroBotaoOnclick={props.handleClose}
+            primeiroBotaoTexto={props.primeiroBotaoTexto}
+            primeiroBotaoCss={props.primeiroBotaoCss}
+        />
+    )
+};

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -61,7 +61,8 @@ export const GetComportamentoPorStatus = (
         onClickDeletarAcertoSaldo,
         setAnalisesDeContaDaPrestacao,
         bloqueiaBtnRetroceder,
-        tooltipRetroceder
+        tooltipRetroceder,
+        handleConcluirPCemAnalise
     }) => {
 
         const TEMPERMISSAO = RetornaSeTemPermissaoEdicaoAcompanhamentoDePc()
@@ -162,7 +163,7 @@ export const GetComportamentoPorStatus = (
                         prestacaoDeContas={prestacaoDeContas}
                         textoBtnAvancar={"Concluir análise"}
                         textoBtnRetroceder={"Recebida"}
-                        metodoAvancar={() => setShowConcluirAnalise(true)}
+                        metodoAvancar={() => handleConcluirPCemAnalise()}
                         metodoRetroceder={() => setShowRecebida(true)}
                         disabledBtnAvancar={!TEMPERMISSAO}
                         disabledBtnRetroceder={bloqueiaBtnRetroceder() || !TEMPERMISSAO}

--- a/src/services/dres/PrestacaoDeContas.service.js
+++ b/src/services/dres/PrestacaoDeContas.service.js
@@ -420,3 +420,7 @@ export const getTagsConferenciaLancamento = async () => {
 export const getTagsConferenciaDocumento = async () => {
     return (await api.get(`/api/analises-documento-prestacao-conta/tags-informacoes-conferencia/`, authHeader)).data
 }
+
+export const getStatusPeriodo = async (uuid_associacao, data_incial_periodo) => {
+    return(await api.get(`/api/associacoes/${uuid_associacao}/status-periodo/?data=${data_incial_periodo}`, authHeader)).data
+  };


### PR DESCRIPTION
Esse PR:

- Adiciona bloqueio de conclusão de PC em análise quando existem contas encerradas com saldo diferente de zero.
- Adiciona modal de bloqueio informativo.

História: AB#104192