### PR TITLE
fix(103479): Remove etiqueta das tabelas e legendas

### DIFF
--- a/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
+++ b/src/componentes/Globais/EscolheUnidade/ListaDeUnidades.js
@@ -63,6 +63,7 @@ export const ListaDeUnidades = ({
             showModalLegendaInformacao={showModalLegendaInformacao}
             setShowModalLegendaInformacao={setShowModalLegendaInformacao}
             entidadeDasTags="associacao"
+            excludedTags={["Encerramento de conta pendente"]}
         />
 
         <DataTable
@@ -88,7 +89,7 @@ export const ListaDeUnidades = ({
                 field="informacao"
                 header="Informações"
                 className="align-middle text-center"
-                body={(rowData) => <TableTags data={rowData} coresTags={coresTagsAssociacoes}/>}
+                body={(rowData) => <TableTags data={rowData} coresTags={coresTagsAssociacoes} excludeTags={["Encerramento de conta pendente"]}/>}
                 style={{width: '15%'}}
             />
             <Column

--- a/src/componentes/Globais/TableTags/index.js
+++ b/src/componentes/Globais/TableTags/index.js
@@ -2,10 +2,14 @@ import React from 'react';
 import ReactTooltip from "react-tooltip";
 import './tableTags.scss';
 
-export const TableTags = ({data, coresTags}) => {
+export const TableTags = ({data, coresTags, excludeTags = []}) => {
     return (
         <>
             {data.informacoes ? data.informacoes?.map((tag, index) => {
+                if(excludeTags.includes(tag.tag_nome)) {
+                    return ''
+                }
+
                 let toolTip = ""
 
                 if (typeof (tag.tag_hint) === 'string') {

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Acoes/TabelaAssociacaoAcao.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Acoes/TabelaAssociacaoAcao.js
@@ -21,6 +21,7 @@ export const TabelaAssociacaoAcao = ({
                 showModalLegendaInformacao={showModalLegendaInformacao}
                 setShowModalLegendaInformacao={setShowModalLegendaInformacao}
                 entidadeDasTags="associacao"
+                excludedTags={["Encerramento de conta pendente"]}
             />
             <DataTable
                 value={unidades}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/TabelaAcoesDasAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/TabelaAcoesDasAssociacoes.js
@@ -20,7 +20,8 @@ export const TabelaAcoesDasAssociacoes = ({
             <LegendaInformacao
                 showModalLegendaInformacao={showModalLegendaInformacao}
                 setShowModalLegendaInformacao={setShowModalLegendaInformacao}  
-                entidadeDasTags="associacao"            
+                entidadeDasTags="associacao"
+                excludedTags={["Encerramento de conta pendente"]}     
             />
             <DataTable
                 value={todasAsAcoes}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/TabelaAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/TabelaAssociacoes.js
@@ -17,7 +17,8 @@ export const TabelaAssociacoes = ({
         <LegendaInformacao
             showModalLegendaInformacao={showModalLegendaInformacao}
             setShowModalLegendaInformacao={setShowModalLegendaInformacao}  
-            entidadeDasTags="associacao"  
+            entidadeDasTags="associacao"
+            excludedTags={["Encerramento de conta pendente"]}
         />
         <DataTable
             value={listaDeAssociacoes}
@@ -31,7 +32,7 @@ export const TabelaAssociacoes = ({
                 field="informacao"
                 header="Informações"
                 className="align-middle text-center"
-                body={(rowData) => <TableTags data={rowData} coresTags={coresTagsAssociacoes}/>}
+                body={(rowData) => <TableTags data={rowData} coresTags={coresTagsAssociacoes} excludeTags={["Encerramento de conta pendente"]}/>}
                 style={{width: '15%'}}
             />
             <Column field="unidade.nome_dre" header="DRE"/>


### PR DESCRIPTION
Esse PR:

- Cria a condicionar de exclusão de tags das tabelas de associações.
- Remove a tag de encerramento de conta das tabelas de parametrização e legendas de informações.

História: AB#103479