### PR TITLE
fix(106430): Erro ao digitar data em crédito tipo repasse

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
+++ b/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
@@ -226,7 +226,10 @@ export const ReceitaFormFormik = ({
                                         id="data"
                                         value={values.data}
                                         onChange={(name, value) => {
-                                            setFieldValue('conta_associacao', '');
+                                            if (!repasses || repasses.length === 0) {
+                                                // Como o repasse seta a conta automaticamente ela não pode ser apagada.
+                                                setFieldValue('conta_associacao', '');
+                                            }
                                             setFieldValue(name, value);
                                         }}
                                         onCalendarClose={async () => {


### PR DESCRIPTION
Esse PR:

-  Corrige erro que ocorria ao digitar a data de um crédito do tipo repasse.

Resolve AB#106430