### PR TITLE
fix(106045): Altera exibição valor extrato para mostrar zeros e não "-"

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/AnalisesDeContaDaPrestacao.js
@@ -60,7 +60,7 @@ export const AnalisesDeContaDaPrestacao = ({infoAta, analisesDeContaDaPrestacao,
         }
 
         if (info){
-            dados.saldo_extrato = info.saldo_extrato ? info.saldo_extrato : '-';
+            dados.saldo_extrato = info.saldo_extrato;
             dados.data_extrato = info.data_extrato ? moment(info.data_extrato).format('DD/MM/YYYY') : '-';
             dados.extrato_bancario = extrato_bancario.length > 0 ? extrato_bancario[0] : null;
         }


### PR DESCRIPTION
Esse PR:
- Altera exibição do valor extrato na análise de PC, para mostrar zeros e não "-"

Resolve AB#106045