### PR TITLE
fix(107877): Corrige selecao de conta quando nao e ajuste despesa

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -84,6 +84,10 @@ export const CadastroForm = ({verbo_http}) => {
     const [objetoParaComparacao, setObjetoParaComparacao] = useState({});
     const [showDespesaIncompletaNaoPermitida, setShowDespesaIncompletaNaoPermitida] = useState(false);
 
+    const isEditing = () => {
+        return despesaContext.verboHttp === "PUT";
+    }
+
     const retornaPeriodo = async (periodo_uuid) => {
         let periodo = await getPeriodoPorUuid(periodo_uuid);
         return periodo;
@@ -175,12 +179,24 @@ export const CadastroForm = ({verbo_http}) => {
             ).format('DD/MM/YYYY')}`;
       
 
-            if (!imposto && item.dataEncerramentoMaiorOuIgualQueDataTransacao) {
-                desativarSelecaoOption = false;
-            } else if (imposto && item.dataEncerramentoMaiorOuIgualQueDataTransacaoImposto) {
-                desativarSelecaoOption = false;
+            if(aux.origemAnaliseLancamento(parametroLocation)) {
+                if (!imposto && item.dataEncerramentoMaiorOuIgualQueDataTransacao) {
+                    desativarSelecaoOption = false;
+                } else if (imposto && item.dataEncerramentoMaiorOuIgualQueDataTransacaoImposto) {
+                    desativarSelecaoOption = false;
+                } else {
+                    desativarSelecaoOption = true;
+                }
             } else {
-                desativarSelecaoOption = true;
+                if(item.solicitacao_encerramento.status === STATUS_SOLICITACAO_ENCERRAMENTO_CONTA_ASSOCIACAO.PENDENTE && !isEditing()) {
+                    desativarSelecaoOption = true;
+                } else if(item.solicitacao_encerramento.status === STATUS_SOLICITACAO_ENCERRAMENTO_CONTA_ASSOCIACAO.APROVADA && !isEditing()) {
+                    return
+                } else if(item.solicitacao_encerramento.status === STATUS_SOLICITACAO_ENCERRAMENTO_CONTA_ASSOCIACAO.PENDENTE && isEditing()) {
+                    desativarSelecaoOption = true;
+                } else if(item.solicitacao_encerramento.status === STATUS_SOLICITACAO_ENCERRAMENTO_CONTA_ASSOCIACAO.APROVADA && isEditing()) {
+                    return
+                }
             }
           }
       


### PR DESCRIPTION
Esse PR:

- Corrige a seleção de contas encerradas quando o fluxo de acesso a edição e inclusão de despesa não é de ajuste solicitado pela DRE.


História: AB#107877