### PR TITLE
fix(108395): Corrige o retorno de conta encerrada em nova solicitação de acerto

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeDocumentos/DetalharAcertosDocumentos/index.js
@@ -118,7 +118,12 @@ const DetalharAcertosDocumentos = () =>{
     const contaEncerrada = async(conta_associacao) => {
         let contas_com_movimento = await getContasComMovimentoNaPc(prestacaoDeContas.uuid)
         let conta_encontrada = contas_com_movimento.find(elemento => elemento.uuid === conta_associacao)
-        return conta_encontrada.status === "INATIVA" && prestacaoDeContas.periodo_referencia === conta_associacao.periodo_encerramento_conta ? true : false;
+
+        if(conta_encontrada) {
+            return conta_encontrada.status === "INATIVA" && prestacaoDeContas.periodo_referencia === conta_associacao.periodo_encerramento_conta ? true : false;
+        } else {
+            return null;
+        }
     }
 
     const possuiAcertosQuePodemAlterarSaldo = (solicitacoes_acerto) => {

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
@@ -331,7 +331,11 @@ export const DetalharAcertos = () => {
         let contas_com_movimento = await getContasComMovimentoNaPc(prestacaoDeContas.uuid)
         let conta_encontrada = contas_com_movimento.find(elemento => elemento.uuid === conta_associacao_dos_lancamentos)
 
-        return conta_encontrada.status === "INATIVA" && prestacaoDeContas.periodo_referencia === conta_encontrada.periodo_encerramento_conta ? true : false;
+        if (conta_encontrada) {
+            return conta_encontrada.status === "INATIVA" && prestacaoDeContas.periodo_referencia === conta_encontrada.periodo_encerramento_conta ? true : false;    
+        } else {
+            return null;
+        }
     }
 
     const possuiAcertosQuePodemAlterarSaldo = (solicitacoes_acerto) => {


### PR DESCRIPTION
Esse PR:

- Corrige o retorno de conta encerrada em nova solicitação de acerto.

História: AB#108395