### PR TITLE
tec(107735): Preparação para atualização de versão - NodeJS 14.21.3 --> 15.14.0 - atualizar react-datepicker da versão 3.0.0 para 4.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1675,25 +1675,6 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -9990,11 +9971,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw=="
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -17121,11 +17097,6 @@
         "ts-pnp": "^1.1.6"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -18927,15 +18898,16 @@
       }
     },
     "react-datepicker": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.8.0.tgz",
-      "integrity": "sha512-iFVNEp8DJoX5yEvEiciM7sJKmLGrvE70U38KhpG13XrulNSijeHw1RZkhd/0UmuXR71dcZB/kdfjiidifstZjw==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.23.0.tgz",
+      "integrity": "sha512-w+msqlOZ14v6H1UknTKtZw/dw9naFMgAOspf59eY130gWpvy5dvKj/bgsFICDdvxB7PtKWxDcbGlAqCloY1d2A==",
       "requires": {
+        "@popperjs/core": "^2.11.8",
         "classnames": "^2.2.6",
-        "date-fns": "^2.0.1",
+        "date-fns": "^2.30.0",
         "prop-types": "^15.7.2",
-        "react-onclickoutside": "^6.10.0",
-        "react-popper": "^1.3.8"
+        "react-onclickoutside": "^6.13.0",
+        "react-popper": "^2.3.0"
       }
     },
     "react-dev-utils": {
@@ -19302,31 +19274,18 @@
       }
     },
     "react-popper": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@hypnosphi/create-react-context": "^0.3.1",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
+        "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
       },
       "dependencies": {
-        "deep-equal": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-          "requires": {
-            "is-arguments": "^1.1.1",
-            "is-date-object": "^1.0.5",
-            "is-regex": "^1.1.4",
-            "object-is": "^1.1.5",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.5.1"
-          }
+        "react-fast-compare": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+          "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
         },
         "warning": {
           "version": "4.0.3",
@@ -22420,11 +22379,6 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "1.0.1",
     "react-currency-input": "^1.3.6",
-    "react-datepicker": "^3.0.0",
+    "react-datepicker": "^4.23.0",
     "react-dom": "^18.2.0",
     "react-loading": "^2.0.3",
     "react-number-format": "^4.9.4",


### PR DESCRIPTION
Esse PR:

- Atualiza dependências

História: AB#107735