### PR TITLE
feat(110183): Membros - Exibir a aba de Mandatos anteriores quando houver mandato anterior e inserir as datas da composição na composição atual do mandato vigente

### DIFF
--- a/src/componentes/escolas/MembrosDaAssociacao/components/MandatoInfo.js
+++ b/src/componentes/escolas/MembrosDaAssociacao/components/MandatoInfo.js
@@ -9,9 +9,8 @@ export const MandatoInfo = () => {
         <>
             {!isLoading && data && data.uuid &&
                 <div className="p-2 pt-3 flex-grow-1 bd-highlight" data-qa='mandato-info'>
-                    <p className='mb-0 fonte-16'><strong>Mandato</strong></p>
                     <p className='mb-0'>
-                        <span><strong>Período atual: </strong></span>{dataTemplate('', '', data.data_inicial)} até {dataTemplate('', '', data.data_final)}
+                        <span><strong>Mandato atual: </strong></span>{dataTemplate('', '', data.data_inicial)} até {dataTemplate('', '', data.data_final)}
                     </p>
                 </div>
             }

--- a/src/componentes/escolas/MembrosDaAssociacao/hooks/useGetMandatosAnteriores.js
+++ b/src/componentes/escolas/MembrosDaAssociacao/hooks/useGetMandatosAnteriores.js
@@ -1,5 +1,6 @@
 import {getMandatosAnteriores} from "../../../../services/Mandatos.service";
 import {useQuery} from "@tanstack/react-query";
+import {useMemo} from "react";
 
 export const useGetMandatosAnteriores = () => {
     const { isLoading, isError, data = {uuid: null, composicoes: [] }, error } = useQuery(
@@ -12,5 +13,7 @@ export const useGetMandatosAnteriores = () => {
         }
     );
 
-    return {isLoading_mandatos_anteriores: isLoading, isError, data_mandatos_anteriores: data, error}
+    const count_mandatos_anteriores = useMemo(() => data.length, [data]);
+
+    return {isLoading_mandatos_anteriores: isLoading, isError, data_mandatos_anteriores: data, error, count_mandatos_anteriores}
 }

--- a/src/componentes/escolas/MembrosDaAssociacao/index.js
+++ b/src/componentes/escolas/MembrosDaAssociacao/index.js
@@ -7,10 +7,12 @@ import {ExportaDadosDaAsssociacao} from "../Associacao/ExportaDadosAssociacao";
 import {MembrosDaAssociacaoProvider} from "./context/MembrosDaAssociacao";
 import {useGetStatusCadastroAssociacao} from "./hooks/useGetStatusCadastroAssociacao";
 import "./membros-da-associacao.scss"
+import {useGetMandatosAnteriores} from "./hooks/useGetMandatosAnteriores";
 
 export const MembrosDaAssociacao = () => {
 
     const {data_status_cadastro_associacao} = useGetStatusCadastroAssociacao()
+    const {count_mandatos_anteriores} = useGetMandatosAnteriores()
 
     const [isActiveMandatoVigente, setIsActiveMandatoVigente] = useState(true)
     const [isActiveMandatosAnteriores, setIsActiveMandatosAnteriores] = useState(false)
@@ -54,29 +56,33 @@ export const MembrosDaAssociacao = () => {
                     >
                         Mandato vigente
                     </button>
-                    <button
-                        disabled={isActiveMandatosAnteriores}
-                        onClick={isActive}
-                        className={`nav-link ${isActiveMandatosAnteriores && 'active'}`}
-                        id="nav-mandatos-anteriores-tab"
-                        data-toggle="tab"
-                        data-target="#nav-mandatos-anteriores"
-                        type="button"
-                        role="tab"
-                        aria-controls="nav-mandatos-anteriores"
-                        aria-selected="false"
-                    >
-                        Mandatos anteriores
-                    </button>
+                    {count_mandatos_anteriores > 0 &&
+                        <button
+                            disabled={isActiveMandatosAnteriores}
+                            onClick={isActive}
+                            className={`nav-link ${isActiveMandatosAnteriores && 'active'}`}
+                            id="nav-mandatos-anteriores-tab"
+                            data-toggle="tab"
+                            data-target="#nav-mandatos-anteriores"
+                            type="button"
+                            role="tab"
+                            aria-controls="nav-mandatos-anteriores"
+                            aria-selected="false"
+                        >
+                            Mandatos anteriores
+                        </button>
+                    }
                 </div>
             </nav>
             <div className="tab-membros-associacao tab-content" id="nav-tabContent">
-                <div className="tab-pane fade show active" id="nav-mandato-vigente" role="tabpanel" aria-labelledby="nav-mandato-vigente-tab">
+                <div className="tab-pane fade show active" id="nav-mandato-vigente" role="tabpanel"
+                     aria-labelledby="nav-mandato-vigente-tab">
                     {isActiveMandatoVigente &&
                         <PaginaMandatoVigente/>
                     }
                 </div>
-                <div className="tab-pane fade" id="nav-mandatos-anteriores" role="tabpanel" aria-labelledby="nav-mandatos-anteriores-tab">
+                <div className="tab-pane fade" id="nav-mandatos-anteriores" role="tabpanel"
+                     aria-labelledby="nav-mandatos-anteriores-tab">
                     {isActiveMandatosAnteriores &&
                         <PaginaMandatosAnteriores/>
                     }

--- a/src/componentes/escolas/MembrosDaAssociacao/pages/PaginaMandatoVigente.js
+++ b/src/componentes/escolas/MembrosDaAssociacao/pages/PaginaMandatoVigente.js
@@ -46,9 +46,9 @@ export const PaginaMandatoVigente = () => {
 
     return (
         <>
-            <div className="d-flex bd-highlight mt-2">
+            <div className="d-flex bd-highlight align-items-end mt-2">
                 <MandatoInfo/>
-                {composicaoUuid && currentPage !== 1 &&
+                {composicaoUuid &&
                     <ComposicaoInfo/>
                 }
             </div>


### PR DESCRIPTION
Esse PR:

- Passa a exibe mandato anterior apenas quando existir
- Inseri as datas da composição na composição atual do mandato vigente

História: AB#110183