### PR TITLE
feat(112558): Adiciona periodo na barra de falha pc

### DIFF
--- a/src/componentes/escolas/PrestacaoDeContas/BarraAvisoErroProcessamentoPC.js
+++ b/src/componentes/escolas/PrestacaoDeContas/BarraAvisoErroProcessamentoPC.js
@@ -14,7 +14,7 @@ export const BarraAvisoErroProcessamentoPC = ({registroFalhaGeracaoPc}) => {
                                     className="icone-barra-aviso-erro-conclusao-pc"
                                     icon={faExclamationCircle}
                                 />
-                                {registroFalhaGeracaoPc.excede_tentativas ? "Já foram feitas diversas tentativas para a conclusão do período. Entre em contato com a DRE para que a geração da PC possa ser concluída." : "Erro no processamento da conclusão do período, conclua o período novamente. " }
+                                {registroFalhaGeracaoPc.excede_tentativas ? `Já foram feitas diversas tentativas para a conclusão do período ${registroFalhaGeracaoPc.periodo_referencia}. Entre em contato com a DRE para que a geração da PC possa ser concluída.` : `Erro no processamento da conclusão do período ${registroFalhaGeracaoPc.periodo_referencia}, conclua o período novamente.`}
                             </p>
                         </div>
                 </section>

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -564,6 +564,10 @@ export const PrestacaoDeContas = ({setStatusPC, registroFalhaGeracaoPc, setRegis
             if(statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status && status_a_considerar().includes(statusPrestacaoDeConta.prestacao_contas_status.status_prestacao )) {
                 return setApresentaBarraAvisoErroProcessamentoPc(false);
             }
+
+            if(statusPrestacaoDeConta && statusPrestacaoDeConta.prestacao_contas_status && statusPrestacaoDeConta.prestacao_contas_status.status_prestacao  === "NAO_RECEBIDA") {
+                return setApresentaBarraAvisoErroProcessamentoPc(false);
+            }
             return setApresentaBarraAvisoErroProcessamentoPc(true);
         }
         return setApresentaBarraAvisoErroProcessamentoPc(false);
@@ -571,7 +575,7 @@ export const PrestacaoDeContas = ({setStatusPC, registroFalhaGeracaoPc, setRegis
 
     useEffect(() => {
         verificaBarraAvisoErroProcessamentoPc()
-    }, [registroFalhaGeracaoPc, statusPrestacaoDeConta, periodoPrestacaoDeConta.periodo_uuid])
+    }, [registroFalhaGeracaoPc, statusPrestacaoDeConta, periodoPrestacaoDeConta.periodo_uuid, statusPrestacaoDeConta.prestacao_contas_status])
 
     return (
         <>


### PR DESCRIPTION
Esse PR:

- Adiciona condicao para quando a pc ja foi entregue nao aparecer a barra de falha de processamento;
- Adiciona referencia do periodo na barra;

História: AB#112558