### PR TITLE
feat(116393): Modifica botão de download demo financeiro

### DIFF
--- a/src/componentes/escolas/PrestacaoDeContas/DemonstrativoFinanceiroPorConta/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DemonstrativoFinanceiroPorConta/index.js
@@ -6,8 +6,6 @@ import moment from "moment";
 import Spinner from "../../../../assets/img/spinner.gif"
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
 import {faDownload} from '@fortawesome/free-solid-svg-icons'
-import { SplitButton } from 'primereact/splitbutton';
-import {logDOM} from "@testing-library/react";
 
 export default class DemonstrativoFinanceiroPorConta extends Component {
     _isMounted = false;
@@ -172,6 +170,7 @@ export default class DemonstrativoFinanceiroPorConta extends Component {
         const {mensagem, status, previaEmAndamento} = this.state;
         const exibeLoading = status === 'EM_PROCESSAMENTO' || previaEmAndamento;
         const documentoPrevio = mensagem.includes('prévio');
+        const documentoFinal = mensagem.includes('final');
         let classeMensagem = "documento-gerado";
         if (mensagem.includes('pendente') || mensagem.includes('Não houve')) {
             classeMensagem = "documento-pendente"
@@ -179,13 +178,13 @@ export default class DemonstrativoFinanceiroPorConta extends Component {
         if (mensagem.includes('Aguarde')) {
             classeMensagem = "documento-processando"
         }
-        const formatos = [
-            {
-                label: 'Baixar em .PDF',
-                command: () => {this.downloadDocumentoFinal("PDF")}
-            },
 
-        ];
+        const apresentarDownloadDocumentoFinal = () => {
+            const documentosGeradosNaoExistem = this.props.statusPrestacaoDeConta && this.props.statusPrestacaoDeConta.prestacao_contas_status && !this.props.statusPrestacaoDeConta.prestacao_contas_status.documentos_gerados;
+
+            return this.props.podeBaixarDocumentos && (!documentosGeradosNaoExistem || !mensagem.includes('Não houve'));
+        }
+
         return (
             <div className="relacao-bens-container mt-5">
                 <p className="relacao-bens-title">Demonstrativo financeiro</p>
@@ -208,7 +207,23 @@ export default class DemonstrativoFinanceiroPorConta extends Component {
                                     style={{fontSize: '18px',}}
                                     icon={faDownload}
                                 />
-                                &nbsp;PDF
+                                &nbsp;
+                            </button>
+                        </>
+                        }
+                        {status === 'CONCLUIDO' && documentoFinal && apresentarDownloadDocumentoFinal &&
+                        <>
+                            <button 
+                                className='btn-editar-membro'
+                                type='button'
+                                onClick={() => {this.downloadDocumentoFinal("PDF")}}
+                                data-qa='btn-baixar-documento-final-demonstrativo-financeiro'
+                            >
+                                <FontAwesomeIcon
+                                    style={{fontSize: '18px',}}
+                                    icon={faDownload}
+                                />
+                                &nbsp;
                             </button>
                         </>
                         }
@@ -227,23 +242,6 @@ export default class DemonstrativoFinanceiroPorConta extends Component {
                                 prévia 
                             </button>
                         }
-                        {this.props.podeBaixarDocumentos &&
-                            <SplitButton
-                                className="btn-split"
-                                label="documento final"
-                                onClick={
-                                    () => {
-                                        this.downloadDocumentoFinal("PDF");
-                                    }
-                                }
-                                model={formatos}
-                                menuStyle={{textAlign: "left"}}
-                                disabled={(this.props.statusPrestacaoDeConta && this.props.statusPrestacaoDeConta.prestacao_contas_status && !this.props.statusPrestacaoDeConta.prestacao_contas_status.documentos_gerados) || mensagem.includes('Não houve')}
-                                data-qa='btn-baixar-documento-final-demonstrativo-financeiro'
-                            >
-                            </SplitButton>
-                        }
-
                     </div>
                 </article>
                 <ModalPrevia 


### PR DESCRIPTION
Esse PR:

- Remove botão split do downlaod do demonstrativo financeiro;
- Adiciona ícone de download seguindo novo padrão do sistema;
- Retira texto PDF do lado do ícone de download.

História: AB#116393