### PR TITLE
feat(118557): Adiciona permissão de acesso e edição na parametrização do texto fique olho

### DIFF
--- a/src/componentes/Globais/EditorWysiwyg/index.js
+++ b/src/componentes/Globais/EditorWysiwyg/index.js
@@ -2,7 +2,7 @@ import React, {memo, useState} from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import "./editor-wysiwyg.scss"
 
-const EditorWysiwyg = ({textoInicialEditor, tituloEditor, handleSubmitEditor})=>{
+const EditorWysiwyg = ({textoInicialEditor, tituloEditor, handleSubmitEditor, disabled=false})=>{
 
     let REACT_APP_EDITOR_KEY = "EDITOR_KEY_REPLACE_ME";
 
@@ -35,9 +35,10 @@ const EditorWysiwyg = ({textoInicialEditor, tituloEditor, handleSubmitEditor})=>
                         bullist numlist outdent indent | removeformat | link | table | code | help '
                 }}
                 onEditorChange={setTextoEditor}
+                disabled={disabled}
             />
             <div className="d-flex  justify-content-end pb-3 mt-3">
-                <button className='btn btn-success' onClick={()=>handleSubmitEditor(textoEditor)} type='button'>Salvar</button>
+                <button className='btn btn-success' onClick={()=>handleSubmitEditor(textoEditor)} type='button' disabled={disabled}>Salvar</button>
             </div>
         </>
     )

--- a/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/index.js
+++ b/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/index.js
@@ -13,9 +13,12 @@ import {
 import EditorWysiwyg from "../../../../Globais/EditorWysiwyg";
 import {ModalInfoFiqueDeOlho} from "./ModalInfoFiqueDeOlho";
 import Loading from "../../../../../utils/Loading";
+import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes"
+import {toastCustom} from "../../../../Globais/ToastCustom";
 
 export const FiqueDeOlho = () => {
 
+    const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const initalTextos = {
         textoAssociacao: '',
         textoDre: ''
@@ -77,7 +80,7 @@ export const FiqueDeOlho = () => {
         if (tipoDeTexto === 'associacoes') {
             try {
                 await patchAlterarFiqueDeOlhoPrestacoesDeContas(payload);
-                console.log("Texto alterado com sucesso");
+                toastCustom.ToastCustomSuccess('Edição do texto Fique de Olho realizado com sucesso.', 'O texto Fique de Olho foi editado no sistema com sucesso.')
                 setInfoModalFiqueDeOlho('Texto alterado com sucesso');
                 setShowModalInfoFiqueDeOlho(true);
                 await carregaTextos();
@@ -89,7 +92,7 @@ export const FiqueDeOlho = () => {
         } else if (tipoDeTexto === 'dre') {
             try {
                 await patchAlterarFiqueDeOlhoRelatoriosConsolidadosDre(payload);
-                console.log("Texto alterado com sucesso");
+                toastCustom.ToastCustomSuccess('Edição do texto Fique de Olho realizado com sucesso.', 'O texto Fique de Olho foi editado no sistema com sucesso.')
                 setInfoModalFiqueDeOlho('Texto alterado com sucesso');
                 setShowModalInfoFiqueDeOlho(true);
                 await carregaTextos();
@@ -134,6 +137,7 @@ export const FiqueDeOlho = () => {
                             textoInicialEditor={textoInicialEditor}
                             tituloEditor={tituloEditor}
                             handleSubmitEditor={handleSubmitEditor}
+                            disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                         />
                 }
             </div>

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -544,7 +544,7 @@ const routesConfig = [
         exact: true,
         path: "/parametro-textos-fique-de-olho",
         component: FiqueDeOlho,
-        permissoes: ['access_painel_parametrizacoes'],
+        permissoes: ['access_painel_parametrizacoes', 'change_painel_parametrizacoes'],
     },
     {
         exact: true,


### PR DESCRIPTION
Esse PR:

- Adiciona permissão de acesso e edição no bloco de texto da parametrização de fique de olho.

História: [AB#118557](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/118557)