### PR TITLE
feat(118552): Adiciona permissão na rota de parametrização de motivos de estorno

### DIFF
--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -586,7 +586,7 @@ const routesConfig = [
         exact: true,
         path: "/parametro-motivos-estorno",
         component: ParametrizacoesMotivosDeEstorno,
-        permissoes: ['access_painel_parametrizacoes'],
+        permissoes: ['access_painel_parametrizacoes', 'change_painel_parametrizacoes'],
     },
     {
         exact: true,


### PR DESCRIPTION
Esse PR:

- Adiciona permissão na rota de parametrização de motivos de estorno.

História: [AB#118552](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/118552)