### PR TITLE
feat(118536): Adiciona loading no carregamento de associações na parametrização de ações

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/ModalFormAcoesDasAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/ModalFormAcoesDasAssociacoes.js
@@ -2,6 +2,7 @@ import React from "react";
 import {ModalFormParametrizacoesAcoesDaAssociacao} from "../../../../Globais/ModalBootstrap";
 import AutoCompleteAssociacoes from "./AutoCompleteAssociacoes";
 import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../../sme/Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import Spinner from "../../../../../assets/img/spinner.gif"
 
 export const ModalFormAcoesDaAssociacao = (props) => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
@@ -33,6 +34,7 @@ export const ModalFormAcoesDaAssociacao = (props) => {
                     ) :
                         <>
                             <label htmlFor="selectedAcao">Unidade Educacional *</label>
+                             {props.ĺoadingAssociacoes && <p>Carregando unidades <img alt="" src={Spinner} style={{height: "22px"}}/></p>}
                             <AutoCompleteAssociacoes
                                 todasAsAcoesAutoComplete={props.todasAsAcoesAutoComplete}
                                 recebeAcaoAutoComplete={props.recebeAcaoAutoComplete}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
@@ -42,6 +42,7 @@ export const AcoesDasAssociacoes = () => {
     const [tabelaAssociacoes, setTabelaAssociacoes] = useState({});
     const [currentPage, setCurrentPage] = useState(1);
     const [firstPage, setFirstPage] = useState(1);
+    const [ĺoadingAssociacoes, setLoadingAssociacoes] = useState(true);
 
     const carregaTodasAsAcoes = useCallback(async (page=1, filtrar_por_nome_cod_eol='', filtrar_por_acao='', filtrar_por_status='', filtro_informacoes='') => {
         setLoading(true);
@@ -52,6 +53,7 @@ export const AcoesDasAssociacoes = () => {
 
     const fetchAssociacoes = async () => {
         let todas_associacoes = await getAssociacoes();
+        setLoadingAssociacoes(false);
         setTodasAsAcoesAutoComplete(todas_associacoes);
     };
 
@@ -327,6 +329,7 @@ export const AcoesDasAssociacoes = () => {
                         primeiroBotaoTexto="Cancelar"
                         primeiroBotaoCss="outline-success"
                         todasAsAcoesAutoComplete={todasAsAcoesAutoComplete}
+                        ĺoadingAssociacoes={ĺoadingAssociacoes}
                     />
                 </section>
                 <section>


### PR DESCRIPTION
Esse PR:

- Adiciona um loading para informar ao usuario sobre o carregamento das unidades em tela.

História: [AB#118536](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/118536)