### PR TITLE
feat(118536): Remove modal de sucesso e altera localizacao do loading de carregamento

### DIFF
--- a/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/index.js
+++ b/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/index.js
@@ -81,8 +81,6 @@ export const FiqueDeOlho = () => {
             try {
                 await patchAlterarFiqueDeOlhoPrestacoesDeContas(payload);
                 toastCustom.ToastCustomSuccess('Edição do texto Fique de Olho realizado com sucesso.', 'O texto Fique de Olho foi editado no sistema com sucesso.')
-                setInfoModalFiqueDeOlho('Texto alterado com sucesso');
-                setShowModalInfoFiqueDeOlho(true);
                 await carregaTextos();
             } catch (e) {
                 console.log("Erro ao alterar texto ", e.response);
@@ -93,8 +91,6 @@ export const FiqueDeOlho = () => {
             try {
                 await patchAlterarFiqueDeOlhoRelatoriosConsolidadosDre(payload);
                 toastCustom.ToastCustomSuccess('Edição do texto Fique de Olho realizado com sucesso.', 'O texto Fique de Olho foi editado no sistema com sucesso.')
-                setInfoModalFiqueDeOlho('Texto alterado com sucesso');
-                setShowModalInfoFiqueDeOlho(true);
                 await carregaTextos();
             } catch (e) {
                 console.log("Erro ao alterar texto ", e.response);

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/AutoCompleteAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/AutoCompleteAssociacoes.js
@@ -4,7 +4,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faSearch} from "@fortawesome/free-solid-svg-icons";
 import { Tag } from '../../../../Globais/Tag';
 
-const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComplete, disabled}) => {
+const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComplete, disabled = false, loadingAssociacoes = false}) => {
     const [selectedAcao, setSelectedAcao] = useState(null);
     const [filteredAcoes, setFilteredAcoes] = useState(null);
 
@@ -66,7 +66,8 @@ const AutoCompleteAssociacoes = ({todasAsAcoesAutoComplete, recebeAcaoAutoComple
                     onSelect={handleSelect}
                     style={{width: "100%", borderLeft:'none'}}
                     itemTemplate={itemTemplate}
-                    disabled={disabled}
+                    disabled={disabled || loadingAssociacoes}
+                    placeholder={`${loadingAssociacoes ? "Carregando unidades" : ""}`}
                 />
             </div>
             <div className="bd-highlight ml-0 py-1 px-3 ml-n3 border-top border-right border-bottom">

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/ModalFormAcoesDasAssociacoes.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/ModalFormAcoesDasAssociacoes.js
@@ -33,12 +33,12 @@ export const ModalFormAcoesDaAssociacao = (props) => {
                         </div>
                     ) :
                         <>
-                            <label htmlFor="selectedAcao">Unidade Educacional *</label>
-                             {props.ĺoadingAssociacoes && <p>Carregando unidades <img alt="" src={Spinner} style={{height: "22px"}}/></p>}
+                            <label htmlFor="selectedAcao">Unidade Educacional *{props.loadingAssociacoes && <img alt="" src={Spinner} style={{height: "22px"}}/>}</label>
                             <AutoCompleteAssociacoes
                                 todasAsAcoesAutoComplete={props.todasAsAcoesAutoComplete}
                                 recebeAcaoAutoComplete={props.recebeAcaoAutoComplete}
                                 disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                loadingAssociacoes={props.loadingAssociacoes}
                             />
                         </>
                     }

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesDasAssociacoes/index.js
@@ -42,7 +42,7 @@ export const AcoesDasAssociacoes = () => {
     const [tabelaAssociacoes, setTabelaAssociacoes] = useState({});
     const [currentPage, setCurrentPage] = useState(1);
     const [firstPage, setFirstPage] = useState(1);
-    const [ĺoadingAssociacoes, setLoadingAssociacoes] = useState(true);
+    const [loadingAssociacoes, setLoadingAssociacoes] = useState(true);
 
     const carregaTodasAsAcoes = useCallback(async (page=1, filtrar_por_nome_cod_eol='', filtrar_por_acao='', filtrar_por_status='', filtro_informacoes='') => {
         setLoading(true);
@@ -329,7 +329,7 @@ export const AcoesDasAssociacoes = () => {
                         primeiroBotaoTexto="Cancelar"
                         primeiroBotaoCss="outline-success"
                         todasAsAcoesAutoComplete={todasAsAcoesAutoComplete}
-                        ĺoadingAssociacoes={ĺoadingAssociacoes}
+                        loadingAssociacoes={loadingAssociacoes}
                     />
                 </section>
                 <section>


### PR DESCRIPTION
Esse PR:

- Remove modal de sucesso, para seguir o padrão do projeto de apenas apresentar a mensagem por toast;
- Altera a localização do loading de carregamento de associação e bloqueia input enquanto está carregando.

História: [AB#118536](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/118536)