### PR TITLE
feat(119648): Remove PDF de apresentacao ao editar ata e adiciona modal de aviso

### DIFF
--- a/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
+++ b/src/componentes/escolas/GeracaoAtaRetificadora/BoxAtaRetificadora/index.js
@@ -87,7 +87,7 @@ export const BoxAtaRetificadora = ({
                                             style={{fontSize: '18px'}}
                                             icon={faDownload}
                                         />
-                                        &nbsp;PDF
+                                        &nbsp;
                                     </button>
                                 }
 

--- a/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/GeracaoAtaApresentacao/index.js
@@ -91,7 +91,7 @@ export const GeracaoAtaApresentacao = (
                                             style={{fontSize: '18px'}}
                                             icon={faDownload}
                                         />
-                                        &nbsp;PDF
+                                        &nbsp;
                                     </button>
                                 }
                             </p>

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/ModalNotificarRegeracaoAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/ModalNotificarRegeracaoAta/index.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { Modal } from 'antd';
+import "./modal.scss"
+import IconeConfirmacao from "../../../../../../../assets/img/icone-modal-confirmacao.svg"
+
+export const ModalNotificarRegeracaoAta = (propriedades) => {
+    return(
+        <div className="modal-ant-design">
+            <Modal 
+                open={propriedades.handleShow} 
+                onOk={propriedades.handleOk} 
+                onCancel={propriedades.handleOk}
+                okText={propriedades.okText}
+                wrapClassName={'modal-ant-design'}
+                cancelButtonProps={propriedades.cancelButtonProps}
+            >
+                <div className="row">
+                    <div className="col-md-auto col-lg-12 mt-3">
+                        <div className="text-center">
+                            <p className="title-modal-antdesign-aviso">{propriedades.titulo}</p>
+                        </div>
+                        <div className="col-md-auto col-lg-12">
+                        <div className="text-center">
+                            <img src={IconeConfirmacao} alt="" className="img-fluid"/>
+                        </div>
+                    </div>
+                        <div className="text-center mt-2">
+                            <p className="body-text-modal-antdesign-aviso">{propriedades.bodyText}</p>
+                        </div>
+                    </div>
+                </div>
+            </Modal>
+        </div>   
+    )
+}

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/ModalNotificarRegeracaoAta/modal.scss
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/ModalNotificarRegeracaoAta/modal.scss
@@ -1,0 +1,20 @@
+.ant-modal-footer{
+    text-align: center !important;
+}
+.modal-ant-design.modal-conclusao-analise-nao-permitida{
+    font-family: "Roboto";
+
+    .title-modal-antdesign-aviso{
+        font-weight: 700;
+        font-size: 24px;
+        line-height: 28px;
+        color: #42474A;
+    }
+
+    .body-text-modal-antdesign-aviso{
+        font-weight: 400;
+        font-size: 18px;
+        line-height: 24px;
+        color: #000000;
+    } 
+}

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/NovoFormularioEditaAta/index.js
@@ -17,6 +17,7 @@ import {
     getCargosComposicaoData
 } from "../../../../../../services/Mandatos.service";
 import { ModalAntDesignConfirmacao } from "../../../../../Globais/ModalAntDesign";
+import {ModalNotificarRegeracaoAta} from "./ModalNotificarRegeracaoAta";
 import {getParticipantesOrdenadosPorCargo} from "../../../../../../services/escolas/PresentesAta.service";
 
 export const NovoFormularioEditaAta = ({
@@ -28,6 +29,8 @@ export const NovoFormularioEditaAta = ({
                                        setDisableBtnSalvar,
                                        repassesPendentes,
                                        erros,
+                                       showModalAvisoRegeracaoAta,
+                                       setShowModalAvisoRegeracaoAta
                                    }) => {
 
     const podeEditarAta = [['change_ata_prestacao_contas']].some(visoesService.getPermissoes)
@@ -1066,6 +1069,17 @@ export const NovoFormularioEditaAta = ({
                                         okText="Confirmar"
                                         handleCancel={() => handleCancelarRemocaoParticipantes()}
                                         cancelText="Cancelar"
+                                    />
+                                </section>
+                                <section>
+                                    <ModalNotificarRegeracaoAta
+                                        handleShow={showModalAvisoRegeracaoAta}
+                                        titulo={"Edição da ata"}
+                                        bodyText={"A ata foi editada e é necessário gerar novo documento de ata."}
+                                        handleOk={() => setShowModalAvisoRegeracaoAta(false)}
+                                        handleCancel={() => setShowModalAvisoRegeracaoAta(false)}
+                                        okText="OK"
+                                        cancelButtonProps={{ style: { display: 'none' } }}
                                     />
                                 </section>
                             </>

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAta/index.js
@@ -59,6 +59,7 @@ export const EdicaoAta = () => {
     const [disableBtnSalvar, setDisableBtnSalvar] = useState(false)
     const [dadosAta, setDadosAta] = useState({});
     const [erros, setErros] = useState({});
+    const [showModalAvisoRegeracaoAta, setShowModalAvisoRegeracaoAta] = useState(false);
 
 
     useEffect(() => {
@@ -256,8 +257,11 @@ export const EdicaoAta = () => {
         }
 
         try {
-            await postEdicaoAta(uuid_ata, payload)
+            const response = await postEdicaoAta(uuid_ata, payload)
             let tipo_ata = dadosAta.tipo_ata === 'RETIFICACAO' ? 'retificação' : 'apresentação'
+            if(response.pdf_gerado_previamente) {
+                setShowModalAvisoRegeracaoAta(true);
+            };
             toastCustom.ToastCustomSuccess('Ata salva com sucesso', `As edições da ata de ${tipo_ata} foram salvas com sucesso.`)
         } catch (e) {
             console.log("Erro ao fazer edição da Ata ", e.response)
@@ -288,6 +292,8 @@ export const EdicaoAta = () => {
                         setDisableBtnSalvar={setDisableBtnSalvar}
                         repassesPendentes={repassesPendentes}
                         erros={erros}
+                        showModalAvisoRegeracaoAta={showModalAvisoRegeracaoAta}
+                        setShowModalAvisoRegeracaoAta={setShowModalAvisoRegeracaoAta}
                     >
                     </NovoFormularioEditaAta> : <FormularioEditaAta
                         listaPresentesPadrao={listaPresentesPadrao}


### PR DESCRIPTION
Esse PR:

- Adiciona modal de aviso de necessidade de gerar novamente a ata;
- Modifica texto de ata para download.

História: [AB#119648](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/119648)