### PR TITLE
fix(120323): Corrige dados do filtro de cnpj do modal de associacao

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Associacoes/index.js
@@ -41,7 +41,7 @@ export const Associacoes = () => {
         setLoading(true);
         let todas_associacoes = await getParametrizacoesAssociacoes(page, filtrar_por_tipo_ue, filtrar_por_dre, filtrar_por_associacao, filtrar_por_informacao);
         setListaDeAssociacoes(todas_associacoes);
-        setListaDeAssociacoesFiltrarCnpj(todas_associacoes);
+        setListaDeAssociacoesFiltrarCnpj(todas_associacoes.results);
         setLoading(false);
     }, []);
 


### PR DESCRIPTION
Esse PR:

- Corrige dados repassados para o estado de associações para o filtro de cnpj.

História: [AB#120323](https://dev.azure.com/amcomgov/df80ad90-407b-4f58-8a29-430604912a37/_workitems/edit/120323)