### PR TITLE
fix(122298): Corrige retorno ao voltar da inclusão de crédito

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -528,16 +528,23 @@ export const ReceitaForm = () => {
     }
 
     const onCancelarTrue = () => {
+        console.log("onCancelarTrue")
         setShow(false);
         setRedirectTo('');
         getPath('');
     };
 
     const onCancelarEstornoTrue = () => {
-        setShow(false);
+        console.log("readOnlyEstorno", readOnlyEstorno)
         console.log(despesa.uuid)
-        const path = `/edicao-de-despesa/${despesa.uuid}`;
-        history.push(path);
+        setShow(false);
+        if (readOnlyEstorno) {
+            const path = `/edicao-de-despesa/${despesa.uuid}`;
+            history.push(path);
+        } else {
+            setRedirectTo('');
+            getPath('');
+        }
     }
 
     const onHandleClose = () => {


### PR DESCRIPTION
Esse PR,  corrige a confirmação de cancelamento da ação de incluir um crédito que estava sempre abrindo a janela de edição de despesa, o que devia ocorrer apenas no caso de tratar-se da inclusão de um 
estorno.

Resolve AB#122298
