### PR TITLE
feat(124082): Não apagar dados na edição de rateio no acerto

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -714,7 +714,7 @@ export const CadastroFormFormik = ({
                                                                     value={rateio.aplicacao_recurso ? rateio.aplicacao_recurso : ""}
                                                                     onChange={(e) => {
                                                                         props.handleChange(e);
-                                                                        aux.limpaTipoDespesaCusteio(setFieldValue)
+                                                                        aux.limpaTipoDespesaCusteio(setFieldValue, index)
                                                                         aux.handleAvisoCapital(e.target.value, setShowAvisoCapital);
                                                                         aux.setaValoresCusteioCapital(props.values.mais_de_um_tipo_despesa, values, setFieldValue);
                                                                         aux.setValoresRateiosOriginal(props.values.mais_de_um_tipo_despesa, values, setFieldValue);

--- a/src/componentes/escolas/Despesas/metodosAuxiliares.js
+++ b/src/componentes/escolas/Despesas/metodosAuxiliares.js
@@ -187,8 +187,8 @@ const setValorRealizado = (setFieldValue, valor) =>{
     setFieldValue("valor_total", trataNumericos(valor))
 };
 
-const limpaTipoDespesaCusteio = (setFieldValue) => {
-    setFieldValue('rateios[0].tipo_custeio', null)
+const limpaTipoDespesaCusteio = (setFieldValue, index) => {
+    setFieldValue(`rateios[${index}].tipo_custeio`, null)
 }
 
 const setaValoresCusteioCapital = (mais_de_um_tipo_de_despesa = null, values, setFieldValue) =>{


### PR DESCRIPTION
Esse PR:

- Adiciona o index no momento de limpar os dados do select de rateio, assim apagando os dados do rateio correto.

História: AB#124082