### PR TITLE
feat(124182): Tipos de documentos - lógica para set de valores dos campos radio no formulário

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/ModalForm.js
@@ -23,7 +23,7 @@ const ModalForm = ({show, stateFormModal, handleClose, handleSubmitModalForm, se
                     {props => {
                         const { values, setFieldValue } = props;
                         return(
-                            <form data-qa="form-tipo-documento"	onSubmit={props.handleSubmit}>
+                            <form data-qa="form-tipo-documento" onSubmit={props.handleSubmit}>
 
                                 <div className='row'>
                                     <div className='col-12' data-qa="legenda-campos-obrigatorios">
@@ -75,7 +75,10 @@ const ModalForm = ({show, stateFormModal, handleClose, handleSubmitModalForm, se
                                                 id="numero_documento_digitado_false"
                                                 value="False"
                                                 checked={values.numero_documento_digitado === false}
-                                                onChange={() => setFieldValue("numero_documento_digitado", false)}
+                                                onChange={() => {
+                                                    setFieldValue("numero_documento_digitado", false);
+                                                    setFieldValue("apenas_digitos", false);
+                                                }}
                                                 disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                             />
                                             <label data-qa="label-numero-documento-digitado-false" className="form-check-label" htmlFor="numero_documento_digitado_false">Não</label>
@@ -150,7 +153,10 @@ const ModalForm = ({show, stateFormModal, handleClose, handleSubmitModalForm, se
                                                 id="documento_comprobatorio_de_despesa_false"
                                                 value="False"
                                                 checked={values.documento_comprobatorio_de_despesa === false}
-                                                onChange={() => setFieldValue("documento_comprobatorio_de_despesa", false)}
+                                                onChange={() => {
+                                                    setFieldValue("documento_comprobatorio_de_despesa",false);
+                                                    setFieldValue("pode_reter_imposto", false);
+                                                }}
                                                 disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                             />
                                             <label data-qa="label-documento-comprobatorio-de-despesa-false" className="form-check-label" htmlFor="documento_comprobatorio_de_despesa_false">Não</label>

--- a/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/Tabela.js
+++ b/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/Tabela.js
@@ -24,6 +24,8 @@ const Tabela = (props)=>{
     }
     return(
         <DataTable
+            sortField="nome"
+            sortOrder={1}
             data-qa="tabela-tipo-documento"
             value={props.lista}
             rows={props.rowsPerPage}

--- a/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/Tabela.js
+++ b/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/Tabela.js
@@ -7,7 +7,7 @@ import ReactTooltip from 'react-tooltip';
 
 const Tabela = (props)=>{
     const templateHeaderApenasDigito = ()=>{
-        const header ="No número do documento deve constar apenas dígitos?"
+        const header ="No número do documento deve constar apenas dígitos"
         return (
             <p data-qa="legenda-apenas-digitos" className="mb-0">
                 {header}

--- a/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/__tests__/ModalForm.test.js
+++ b/src/componentes/sme/Parametrizacoes/Despesas/TiposDocumento/__tests__/ModalForm.test.js
@@ -60,6 +60,8 @@ describe("Controle Condicional de radio button", () => {
       const radioApenasDigitosNao = screen.getByLabelText("Não", { selector: 'input[name="apenas_digitos_false"]' });
       
       fireEvent.click(radioNumeroDocumentoNao);
+      expect(radioApenasDigitosSim).not.toBeChecked()
+      expect(radioApenasDigitosNao).toBeChecked()
       expect(radioApenasDigitosSim).toBeDisabled();
       expect(radioApenasDigitosNao).toBeDisabled();
     }
@@ -76,6 +78,8 @@ describe("Controle Condicional de radio button", () => {
       const radioApenasDigitosNao = screen.getByLabelText("Não", { selector: 'input[name="apenas_digitos_false"]' });
       
       fireEvent.click(radioNumeroDocumentoSim);
+      expect(radioApenasDigitosSim).not.toBeChecked();
+      expect(radioApenasDigitosNao).toBeChecked();
       expect(radioApenasDigitosSim).toBeEnabled();
       expect(radioApenasDigitosNao).toBeEnabled();
     }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,26 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+
+const originalError = console.error;
+const originalWarn = console.warn;
+
+beforeAll(()=>{
+    console.error = (...args) => {
+        if(args[0].includes('Warning:') || args[0].includes('DeprecationWarning:') ){
+            return;
+        }
+        originalError(...args)
+    }
+    console.warn = (...args) => {
+        if(args[0].includes('Warning:')){
+            return;
+        }
+        originalWarn(...args)
+    }
+})
+
+afterAll(()=>{
+    console.error = originalError
+    console.warn = originalWarn
+})


### PR DESCRIPTION
Esse PR:

Inclui a lógica de redefinir para valor padrão dos elementos radio quando estes forem reabilitados
Inclui os testes unitários para esta implementação, inclusive as configurações no setup de testes para redução de logs Warning no terminal

História AB#124182