### PR TITLE
feat(126749): Ajustes na tela de listagem de ações pdde

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/Paginacao.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/Paginacao.js
@@ -12,7 +12,7 @@ export const Paginacao = ({acoes, setCurrentPage, firstPage, setFirstPage, isLoa
             {!isLoading && acoes.results && acoes.results.length > 0 ? (
                     <Paginator
                         first={firstPage}
-                        rows={5}
+                        rows={20}
                         totalRecords={acoes.count}
                         template="PrevPageLink PageLinks NextPageLink"
                         onPageChange={onPageChange}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/index.js
@@ -9,6 +9,8 @@ import { ModalBootstrap } from "../../../../Globais/ModalBootstrap";
 import { useAcoesPDDE } from "./hooks/useAcoesPDDE";
 import { Paginacao } from "./Paginacao"
 import {ModalConfirmarExclusao as ModalConfirmar} from "../../componentes/ModalConfirmarExclusao";
+import Img404 from "../../../../../assets/img/img-404.svg"
+import { MsgImgCentralizada } from "../../../../Globais/Mensagens/MsgImgCentralizada";
 
 export const AcoesPDDE = ()=>{
     const {
@@ -73,11 +75,22 @@ export const AcoesPDDE = ()=>{
                     categorias={categorias}
                 />
 
-                <Tabela 
-                    rowsPerPage={5} 
-                    data={acoes} 
-                    handleOpenModalForm={handleOpenModalForm}
-                />
+                { acoes.count > 0 ?
+                    <>
+                    <Tabela
+                        rowsPerPage={20}
+                        data={acoes}
+                        handleOpenModalForm={handleOpenModalForm}
+                    />
+                    </>
+                    :
+                    <MsgImgCentralizada
+                        data-qa="imagem-lista-sem-tipos-documentos"
+                        texto='Nenhum resultado encontrado.'
+                        img={Img404}
+                        dataQa=""
+                    />
+                }
 
                 <ModalForm
                     show={modalForm.open}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/AcoesPDDE/index.js
@@ -85,7 +85,7 @@ export const AcoesPDDE = ()=>{
                     </>
                     :
                     <MsgImgCentralizada
-                        data-qa="imagem-lista-sem-tipos-documentos"
+                        data-qa="imagem-lista-sem-acoes-pdde"
                         texto='Nenhum resultado encontrado.'
                         img={Img404}
                         dataQa=""


### PR DESCRIPTION
Esse PR:

- Ajusta a paginação para 20 itens
- Adiciona imagem de "não encontrado" quando não há ações disponíveis na listagem

História: AB#126749