### PR TITLE
feat(126467): Congelar saldo

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/DetalhamentoAcoesPdde/hooks/usePatchReceitaPrevistaPdde.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/DetalhamentoAcoesPdde/hooks/usePatchReceitaPrevistaPdde.js
@@ -7,8 +7,6 @@ export const usePatchReceitaPrevistaPdde = (setModalForm) => {
 
     const mutationPatch = useMutation({
         mutationFn: ({uuid, payload}) => {
-            console.log('payload', payload)
-            console.log('uuid', uuid)
             return patchReceitaPrevistaPDDE(uuid, payload)
         },
         onSuccess: () => {

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/ModalConfirmarPararAtualizacaoSaldo.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/ModalConfirmarPararAtualizacaoSaldo.js
@@ -1,0 +1,78 @@
+import { memo } from "react";
+import { Row, Spin, Modal } from "antd";
+import { useAtivarSaldoPAA, useDesativarSaldoPAA } from './hooks/usePararAtualizacaoSaldoPaa';
+import IconeAvisoVermelho from "../../../../../../assets/img/icone-modal-aviso-vermelho.svg"
+
+
+const ModalConfirmaPararAtualizacaoSaldo = ({ open, onClose, check, paa, onSubmitParadaSaldo}) => {
+
+  const onSuccess = (data) => {
+    // Disparar o Submit para o index somente se o request for sucesso
+    onSubmitParadaSaldo()
+    onClose()
+  }
+
+  const onError = (e) => {
+    onClose()
+    console.error('onError Data', e)
+  }
+
+  const { mutationPost: mutationPostAtivar } = useAtivarSaldoPAA(onSuccess, onError);
+  const { mutationPost: mutationPostDesativar } = useDesativarSaldoPAA(onSuccess, onError);
+
+  const onSubmit = () => {
+    if (check) {
+      mutationPostDesativar.mutate({ uuid: paa.uuid });
+    } else {
+      mutationPostAtivar.mutate({ uuid: paa.uuid });
+    }
+  };
+
+  return (
+    <div>
+        <Modal
+            zIndex={1060}
+            centered
+            open={open}
+            onOk={onSubmit}
+            okText="Confirmar"
+            okButtonProps={
+              {
+                "data-testid": "botao-confirmar-congelamento",
+                disabled: mutationPostAtivar.isLoading ||
+                          mutationPostDesativar.isLoading
+              }}
+            onCancel={onClose}
+            cancelText="Cancelar"
+            cancelButtonProps={
+              {
+                "data-testid": "botao-cancelar-confirmar-congelamento",
+                disabled: mutationPostAtivar.isLoading ||
+                          mutationPostDesativar.isLoading
+              }}
+            wrapClassName={'modal-ant-design'}
+        >
+          <Spin spinning={mutationPostAtivar.isLoading || mutationPostDesativar.isLoading }>
+            <Row justify="center">
+              <img src={IconeAvisoVermelho} alt="" className="img-fluid my-3"/>
+            </Row>
+            <Row justify="center">
+                <p className="title-modal-antdesign-aviso">{`${check ? 'Parar' : 'Habilitar'} atualização do saldo`}</p>
+            </Row>
+            <Row justify="center">
+                <div className="body-text-modal-antdesign-aviso my-3 text-center">
+                  {check ? 
+                    <>O saldo reprogramado do PTRF será bloqueado na data e hora atual para a realização do cálculo das receitas previstas no PAA.</>
+                    :
+                    <>O saldo reprogramado do PTRF será desbloqueado e atualizado  para a realização do cálculo das receitas previstas no PAA.</>
+                  }
+                </div>
+            </Row>
+          </Spin>
+        </Modal>
+    </div>
+  );
+  
+};
+
+export default memo(ModalConfirmaPararAtualizacaoSaldo);

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/ReceitasPrevistasModalForm.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/ReceitasPrevistasModalForm.js
@@ -24,6 +24,8 @@ const initialValues = {
 const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
   const [form] = Form.useForm();
 
+  const dadosPaaLocalStorage = () => JSON.parse(localStorage.getItem('DADOS_PAA'))
+
   const data = acaoAssociacao.saldos;
   const isLoading = false;
   const { mutationPost } = usePostReceitasPrevistasPaa(onClose);
@@ -37,6 +39,11 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
   Form.useWatch("saldo_atual_custeio", form);
   Form.useWatch("saldo_atual_livre", form);
 
+ const valorZeroOuPositivo = (valor) => {
+    const val = parseFloat(valor || 0)
+    return val < 0 ? 0 : val
+ }
+
   useEffect(() => {
     if (data && acaoAssociacao) {
       const valor_custeio = receitaPrevistaPaa
@@ -48,9 +55,9 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
       const total_livre = receitaPrevistaPaa
         ? parseFloat(receitaPrevistaPaa.previsao_valor_livre)
         : null;
-      const saldo_atual_custeio = data.saldo_atual_custeio;
-      const saldo_atual_capital = data.saldo_atual_capital;
-      const saldo_atual_livre = data.saldo_atual_livre;
+      const saldo_atual_custeio = receitaPrevistaPaa?.saldo_congelado_custeio || data.saldo_atual_custeio;
+      const saldo_atual_capital = receitaPrevistaPaa?.saldo_congelado_capital || data.saldo_atual_capital;
+      const saldo_atual_livre = receitaPrevistaPaa?.saldo_congelado_livre || data.saldo_atual_livre;
 
       form.setFieldsValue({
         saldo_atual_capital: saldo_atual_capital,
@@ -59,9 +66,9 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
         valor_capital: valor_capital * 100,
         valor_custeio: valor_custeio * 100,
         valor_livre: total_livre * 100,
-        total_custeio: valor_custeio + saldo_atual_custeio,
-        total_capital: valor_capital + saldo_atual_capital,
-        total_livre: total_livre + saldo_atual_livre,
+        total_custeio: valor_custeio + valorZeroOuPositivo(saldo_atual_custeio),
+        total_capital: valor_capital + valorZeroOuPositivo(saldo_atual_capital),
+        total_livre: total_livre + valorZeroOuPositivo(saldo_atual_livre),
       });
     }
   }, [data, acaoAssociacao]);
@@ -72,19 +79,19 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
     if (values.valor_custeio) {
       form.setFieldValue(
         "total_custeio",
-        formValues.saldo_atual_custeio + parseFloat(values.valor_custeio) / 100
+        valorZeroOuPositivo(formValues.saldo_atual_custeio) + parseFloat(values.valor_custeio) / 100
       );
     }
     if (values.valor_capital) {
       form.setFieldValue(
         "total_capital",
-        formValues.saldo_atual_capital + parseFloat(values.valor_capital) / 100
+        valorZeroOuPositivo(formValues.saldo_atual_capital) + parseFloat(values.valor_capital) / 100
       );
     }
     if (values.valor_livre) {
       form.setFieldValue(
         "total_livre",
-        formValues.saldo_atual_livre + parseFloat(values.valor_livre) / 100
+        valorZeroOuPositivo(formValues.saldo_atual_livre) + parseFloat(values.valor_livre) / 100
       );
     }
   };
@@ -114,6 +121,26 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
     },
   ];
 
+  const toolTip = (texto) => (
+    <Icon
+      tooltipMessage={texto}
+      icon="faExclamationCircle"
+      iconProps={
+        { style: { fontSize: "16px", marginLeft: 4, color: "#086397" }}
+      }
+    />
+  )
+
+  const toolTipValorNegativo = () => {
+    const texto = "O saldo negativo não será computado para o cálculo, será considerado o valor R$0,00."
+    return toolTip(texto)
+  }
+
+  const toolTipReceitaPrevistaOrientacao = () => {
+    const texto = "Orienta-se somar todos os valores recebidos de Custeio, Capital e Livre Aplicação ao longo do último ano."
+    return toolTip(texto)
+  }
+
   return (
     <ModalFormBodyText
       show={open}
@@ -138,21 +165,13 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
               gutter={[16, 16]}
               style={{ marginBottom: 16, color: "rgba(66, 71, 74, 1)" }}
             >
-              <Col md={8}>Saldo em {formataData(new Date())}</Col>
+              <Col md={8}>
+                Saldo em {formataData(dadosPaaLocalStorage()?.saldo_congelado_em || new Date())}
+              </Col>
+
               <Col md={8}>
                 <Flex align="center">
-                  Receita Prevista
-                  <Icon
-                    tooltipMessage="Orienta-se somar todos os valores recebidos de Custeio, Capital e Livre Aplicação ao longo do último ano."
-                    icon="faExclamationCircle"
-                    iconProps={{
-                      style: {
-                        fontSize: "16px",
-                        marginLeft: 4,
-                        color: "#086397",
-                      },
-                    }}
-                  />
+                  Receita Prevista {toolTipReceitaPrevistaOrientacao()}
                 </Flex>
               </Col>
               <Col md={8}>Total</Col>
@@ -163,7 +182,15 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
                 <Col md={8}>
                   <Flex align="end" gap={8}>
                     <Form.Item
-                      label="Custeio"
+                      label={
+                        <>
+                          Custeio {
+                            /* Exibe tooltip quando o valor for negativo */
+                            (form?.getFieldsValue()?.saldo_atual_custeio||0) < 0 &&
+                            toolTipValorNegativo()
+                          }
+                        </>
+                      }
                       name="saldo_atual_custeio"
                       labelCol={{ span: 24 }}
                       style={{ marginBottom: 8 }}
@@ -232,7 +259,15 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
                 <Col md={8}>
                   <Flex align="end" gap={8}>
                     <Form.Item
-                      label="Capital"
+                      label={
+                        <>
+                          Capital {
+                            /* Exibe tooltip quando o valor for negativo */
+                            (form?.getFieldsValue()?.saldo_atual_capital||0) < 0 &&
+                            toolTipValorNegativo()
+                          }
+                        </>
+                      }
                       name="saldo_atual_capital"
                       labelCol={{ span: 24 }}
                       style={{ marginBottom: 8 }}
@@ -278,7 +313,7 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
                 </Col>
                 <Col md={8}>
                   <Form.Item
-                    label="Custeio"
+                    label="Capital"
                     name="total_capital"
                     labelCol={{ span: 24 }}
                     style={{ marginBottom: 8 }}
@@ -301,7 +336,15 @@ const ReceitasPrevistasModalForm = ({ open, onClose, acaoAssociacao }) => {
                 <Col md={8}>
                   <Flex align="end" gap={8}>
                     <Form.Item
-                      label="Livre Aplicação"
+                      label={
+                        <>
+                          Livre Aplicação {
+                            /* Exibe tooltip quando o valor for negativo */
+                            (form?.getFieldsValue()?.saldo_atual_livre||0) < 0 &&
+                            toolTipValorNegativo()
+                          }
+                        </>
+                      }
                       name="saldo_atual_livre"
                       labelCol={{ span: 24 }}
                       style={{ marginBottom: 8 }}

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/TabelaReceitasPrevistas.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/TabelaReceitasPrevistas.js
@@ -13,6 +13,26 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar }) => {
     );
   }, []);
 
+  const getCongeladoOuCapital = (row) => {
+    const saldo_congelado_receita_prevista = parseFloat(
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_capital
+    )
+    return saldo_congelado_receita_prevista || row?.saldos?.saldo_atual_capital
+  }
+  const getCongeladoOuCusteio = (row) => {
+    const saldo_congelado_receita_prevista = parseFloat(
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_custeio
+    )
+    return saldo_congelado_receita_prevista ||
+            row?.saldos?.saldo_atual_custeio
+  }
+  const getCongeladoOuLivre = (row) => {
+    const saldo_congelado_receita_prevista = parseFloat(
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_livre
+    )
+    return saldo_congelado_receita_prevista || row?.saldos?.saldo_atual_livre
+  }
+
   const dataTemplate = useCallback(
     (rowData, column) => {
       if (rowData?.acao?.nome === "Total do PTRF") {
@@ -21,8 +41,7 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar }) => {
             acc +
             (parseFloat(
               row?.receitas_previstas_paa?.[0]?.previsao_valor_capital
-            ) || 0) +
-            row?.saldos?.saldo_atual_capital
+            ) || 0) + getCongeladoOuCapital(row)
           );
         }, 0);
 
@@ -31,8 +50,7 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar }) => {
             acc +
             (parseFloat(
               row?.receitas_previstas_paa?.[0]?.previsao_valor_custeio
-            ) || 0) +
-            row?.saldos?.saldo_atual_custeio
+            ) || 0) + getCongeladoOuCusteio(row)
           );
         }, 0);
 
@@ -41,8 +59,7 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar }) => {
             acc +
             (parseFloat(
               row?.receitas_previstas_paa?.[0]?.previsao_valor_livre
-            ) || 0) +
-            row?.saldos?.saldo_atual_livre
+            ) || 0) + getCongeladoOuLivre(row)
           );
         }, 0);
 
@@ -77,11 +94,13 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar }) => {
       };
 
       const valor_capital =
-        valores.previsao_valor_capital + rowData?.saldos?.saldo_atual_capital;
+        valores.previsao_valor_capital + getCongeladoOuCapital(rowData);
+
       const valor_custeio =
-        valores.previsao_valor_custeio + rowData?.saldos?.saldo_atual_custeio;
+        valores.previsao_valor_custeio + getCongeladoOuCusteio(rowData);
+
       const valor_livre =
-        valores.previsao_valor_livre + rowData?.saldos?.saldo_atual_livre;
+        valores.previsao_valor_livre + getCongeladoOuLivre(rowData);
 
       const fieldMapping = {
         valor_capital: valor_capital,

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/hooks/useGetAcoesAssociacao.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/hooks/useGetAcoesAssociacao.js
@@ -4,6 +4,7 @@ import { getAcoesAssociacao } from "../../../../../../../services/escolas/Associ
 export const useGetAcoesAssociacao = () => {
   const {
     isLoading,
+    isFetching,
     isError,
     data = { results: [] },
     error,
@@ -13,5 +14,5 @@ export const useGetAcoesAssociacao = () => {
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,
   });
-  return { isLoading, isError, data: data.results, error, refetch };
+  return { isLoading, isError, data: data.results, error, refetch, isFetching };
 };

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/hooks/usePararAtualizacaoSaldoPaa.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/ReceitasPrevistas/hooks/usePararAtualizacaoSaldoPaa.js
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { 
+  postAtivarAtualizacaoSaldoPAA,
+  postDesativarAtualizacaoSaldoPAA
+} from "../../../../../../../services/escolas/Paa.service";
+import { toastCustom } from "../../../../../../Globais/ToastCustom";
+
+export const useAtivarSaldoPAA = (onSuccess, onError) => {
+  const mutationPost = useMutation({
+    mutationFn: ({ uuid }) => postAtivarAtualizacaoSaldoPAA(uuid),
+    onSuccess: (data) => {
+      toastCustom.ToastCustomSuccess("As atualizações de saldo estão desbloqueadas.");
+      onSuccess && onSuccess(data);
+    },
+    onError: (e) => {
+      toastCustom.ToastCustomError("Houve um erro ao ativar o saldo.");
+      onError && onError(e);
+    },
+  });
+
+  return { mutationPost };
+};
+
+export const useDesativarSaldoPAA = (onSuccess, onError) => {
+  const mutationPost = useMutation({
+    mutationFn: ({ uuid }) => postDesativarAtualizacaoSaldoPAA(uuid),
+    onSuccess: (data) => {
+      toastCustom.ToastCustomSuccess("As atualizações de saldo estão bloqueadas.");
+      onSuccess && onSuccess(data);
+    },
+    onError: (e) => {
+      toastCustom.ToastCustomError("Houve um erro ao desativar o saldo.");
+      onError && onError(e);
+      console.error(e)
+    },
+  });
+
+  return { mutationPost };
+};

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/index.js
@@ -14,6 +14,7 @@ export const ElaboracaoPaa = () => {
 
   const [notValidPaa, setNotValidPaa] = useState(true);
   const [loading, setLoading] = useState(true);
+  const [loadingPaa, setLoadingPaa] = useState(false);
   const [validMonthPaa, setValidMonthPaa] = useState('');
   const [textoPaa, setTextoPaa] = useState('');
   const { mutationPost } = usePostPaa();
@@ -24,14 +25,17 @@ export const ElaboracaoPaa = () => {
   const dataAtual = new Date();
 
   const carregaPaa = useCallback(async ()=>{
+    setLoadingPaa(true);
     try {
         let response = await getPaaVigente(associacao_uuid)
         localStorage.setItem("PAA", response.data.uuid);
+        localStorage.setItem("DADOS_PAA", JSON.stringify(response.data));
         setNotValidPaa(false);
     } catch (error) {
         setNotValidPaa(true);
     }
-    }, [])
+    setLoadingPaa(false);
+  }, [])
 
     useEffect(()=>{
       carregaPaa()

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -123,3 +123,15 @@ export const patchReceitaPrevistaPDDE = async (uuid, payload) => {
     await api.patch(`api/receitas-previstas-pdde/${uuid}/`, payload, authHeader())
   ).data;
 };
+
+export const postDesativarAtualizacaoSaldoPAA = async (uuid) => {
+  return (
+    await api.post(`api/paa/${uuid}/desativar-atualizacao-saldo/`, {}, authHeader())
+  ).data;
+};
+
+export const postAtivarAtualizacaoSaldoPAA = async (uuid) => {
+  return (
+    await api.post(`api/paa/${uuid}/ativar-atualizacao-saldo/`, {}, authHeader())
+  ).data;
+};


### PR DESCRIPTION
Esse PR:

Adiciona a feature de Congelamento de Saldo,
- Modal de confirmação
- Services de ativação/desativação do congelamento
- Inclusão de DADOS_PAA no locastorage para salvar o objeto, inclusive a data de congelamento que será utilizada para determinar se um saldo está ou não "congelado".
- Considera valor zero para soma de totais quando os saldos atuais são negativos (inclusive, exibição de tootips para os respectivos campos - custeio, capital e Livre)

História #126467