### PR TITLE
tec(128815): Adiciona configuracao jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,13 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.(js|jsx)$": "babel-jest"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!axios)/"
+    ]
   }
 }


### PR DESCRIPTION
Esse PR:

- Adiciona configuração para remover erro que acontece devido a nova versão do axios que usa esm com import/export nativos, sendo que o Jest por padrão ainda trata os arquivos como commonjs.

História: [AB#128815](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/128815)