### PR TITLE
feature(127464): Ajuste na legenda da coluna de Ação - botões

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
@@ -100,7 +100,7 @@ export const Tabela = ({ data }) => {
                 body={(rowData) => formatMoneyBRL(rowData.valor_total)}
             />
             <Column
-                header="Ação"
+                header="Ações"
                 style={{ width: "75px", borderLeft: "none", textAlign: 'center' }}
                 body={rowData => {
                     return (


### PR DESCRIPTION
Esse PR:

Ajusta a legendado da coluna de Ações (botões)

História [AB#127464](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/127464)