### PR TITLE
feat(129378): adiciona bloqueio de selecao na listagem despesa

### DIFF
--- a/src/componentes/escolas/SituacaoPatrimonial/FormularioBemProduzido/VincularDespesas/index.css
+++ b/src/componentes/escolas/SituacaoPatrimonial/FormularioBemProduzido/VincularDespesas/index.css
@@ -1,0 +1,4 @@
+.row-disabled-situacao-patrimonial {
+  opacity: 0.5;
+  pointer-events: none;
+} 

--- a/src/componentes/escolas/SituacaoPatrimonial/FormularioBemProduzido/VincularDespesas/index.js
+++ b/src/componentes/escolas/SituacaoPatrimonial/FormularioBemProduzido/VincularDespesas/index.js
@@ -13,6 +13,7 @@ import { useCarregaTabelaDespesa } from "../../../../../hooks/Globais/useCarrega
 import { useGetPeriodos } from "../../../../../hooks/Globais/useGetPeriodo";
 import moment from "moment";
 import { useNavigate } from 'react-router-dom';
+import './index.css';
 
 const filtroInicial = {
   fornecedor: "",
@@ -22,6 +23,13 @@ const filtroInicial = {
   data_inicio: "",
   data_fim: "",
 };
+
+function isRowDisabled(rowData, despesasSelecionadas) {
+  if (Array.isArray(despesasSelecionadas) && despesasSelecionadas.some(despesa => despesa.uuid === rowData.uuid)) {
+    return false;
+  }
+  return !(rowData.rateios || []).some(rateio => rateio.valor_disponivel > 0);
+}
 
 export const VincularDespesas = ({
   uuid,
@@ -200,10 +208,23 @@ export const VincularDespesas = ({
                 autoLayout={true}
                 dataKey="uuid"
                 selection={despesasSelecionadas}
-                onSelectionChange={(e) => setDespesasSelecionadas(e.value)}
+                onSelectionChange={(e) => {
+                  const disabledSelectedRows = (despesasSelecionadas || []).filter(
+                    row => isRowDisabled(row)
+                  );
+                  const newSelection = Array.isArray(e.value)
+                    ? [
+                        ...e.value.filter(row => !isRowDisabled(row)),
+                        ...disabledSelectedRows
+                      ]
+                    : disabledSelectedRows;
+                  setDespesasSelecionadas(newSelection);
+                }}
+                selectableRowDisabled={rowData => isRowDisabled(rowData)}
                 expandedRows={expandedRows}
                 onRowToggle={(e) => setExpandedRows(e.data)}
                 rowExpansionTemplate={expandedRowTemplate}
+                rowClassName={data => ({ 'row-disabled-situacao-patrimonial': isRowDisabled(data, despesasSelecionadas) })}
               >
                 <Column selectionMode="multiple" style={{ width: "3em" }} />
                 <Column field="periodo_referencia" header="Período" />


### PR DESCRIPTION
Esse PR:

- Adiciona o bloqueio de seleção de despesa com valores totais utilizados na criação de bens produzidos, deixando desbloqueado apenas na edição que já possuía esse despesa.
- Adiciona correções na visualização de valores disponíveis na seção de informar valores de bens produzidos.

História: [AB#129378](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/129378)