### PR TITLE
feat(129997): Volta campos obrigatórios em conciliação bancária

### DIFF
--- a/src/componentes/escolas/Associacao/IconeDadosDaAssociacaoPendentes.js
+++ b/src/componentes/escolas/Associacao/IconeDadosDaAssociacaoPendentes.js
@@ -1,6 +1,12 @@
 import React from "react";
-import {Icon} from "../../../componentes/Globais/UI/Icon";
+import { Icon } from "../../../componentes/Globais/UI/Icon";
 
 export const IconeDadosDaAssociacaoPendentes = () => {
-    return <Icon tooltipMessage='Há campos pendentes para preenchimento' icon='icone-exclamacao-vermelho'/>;
-}
+  return (
+    <Icon
+      tooltipMessage="Há campos pendentes para preenchimento"
+      icon="icone-exclamacao-vermelho"
+      iconProps={{ className: "mb-1" }}
+    />
+  );
+};

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/IconeDataSaldoBancarioPendentes.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/IconeDataSaldoBancarioPendentes.js
@@ -1,6 +1,12 @@
 import React from "react";
-import {Icon} from "../../../../Globais/UI/Icon";
+import { Icon } from "../../../../Globais/UI/Icon";
 
 export const IconeDataSaldoBancarioPendentes = () => {
-    return <Icon tooltipMessage='Há campos pendentes para preenchimento' icon='icone-exclamacao-vermelho'/>;
-}
+  return (
+    <Icon
+      tooltipMessage="Há campos pendentes para preenchimento"
+      icon="icone-exclamacao-vermelho"
+      iconProps={{ className: "mb-1" }}
+    />
+  );
+};

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/DataSaldoBancario/index.js
@@ -57,7 +57,6 @@ const DataSaldoBancario = ({
         return new Date();
     }
 
-    //  TODO códigos comentados propositalmente em função da história 102412 - Sprint 73 (Conciliação Bancária: Retirar validação e obrigatoriedade de preenchimento dos campos do Saldo bancário da conta ao concluir acerto/período) - que entrou como Hotfix
     return(
         <>
             <form method="post" encType="multipart/form-data">
@@ -66,20 +65,20 @@ const DataSaldoBancario = ({
                         <div className="card container-extrato">
                             <div className="card-body">
                                 <h5 className="card-title titulo">Saldo bancário da conta {pendenciaSaldoBancario ? IconeDataSaldoBancarioPendentes() :  null}</h5>
-                                {/*<p className='text-right'><span className='font-weight-bold'>* Preenchimento obrigatório</span></p>*/}
+                                <p className='text-right'><span className='font-weight-bold'>* Preenchimento obrigatório</span></p>
                                 <div className='row'>
                                     <div className='col-6'>
                                         <div className='row'>
                                             <div className="col">
-                                                <label htmlFor="data_extrato">Data</label>
-                                                {/*<label htmlFor="data_extrato">Data *</label>*/}
+                                                <label htmlFor="data_extrato">Data *</label>
                                                 <DatePickerField
-                                                    value={dataSaldoBancario.data_extrato ? dataSaldoBancario.data_extrato : ''}
+                                                    value={dataSaldoBancario.data_extrato}
                                                     onChange={handleChangaDataSaldo}
                                                     name='data_extrato'
                                                     type="date"
                                                     className="form-control"
-                                                    disabled={!permiteEditarCamposExtrato || !visoesService.getPermissoes(['change_conciliacao_bancaria'])}
+                                                    // disabled={!permiteEditarCamposExtrato || !visoesService.getPermissoes(['change_conciliacao_bancaria'])}
+                                                    disabled
                                                     maxDate={dataLimite()}
                                                 />
                                                 {erroDataSaldo && <span className="span_erro text-danger mt-1"> {erroDataSaldo}</span>}
@@ -93,8 +92,7 @@ const DataSaldoBancario = ({
 
                                         <div className='row' style={{ paddingTop: '10px' }}>
                                             <div className="col">
-                                                <label htmlFor="saldo_extrato">Saldo</label>
-                                                {/*<label htmlFor="saldo_extrato">Saldo *</label>*/}
+                                                <label htmlFor="saldo_extrato">Saldo *</label>
                                                 <CurrencyInput
                                                     allowNegative={true}
                                                     prefix='R$'
@@ -120,8 +118,7 @@ const DataSaldoBancario = ({
                                     </div>
                                     <div className="col-6">
                                         <div className="form-group">
-                                            <label htmlFor="upload_extrato" className="ml-1">Comprovante do saldo da conta</label>
-                                            {/*<label htmlFor="upload_extrato" className="ml-1">Comprovante do saldo da conta {dataSaldoBancario.saldo_extrato !== 0 && dataSaldoBancario.saldo_extrato !== "R$0,00" ? "*" : ""}</label>*/}
+                                            <label htmlFor="upload_extrato" className="ml-1">Comprovante do saldo da conta {dataSaldoBancario.saldo_extrato !== 0 && dataSaldoBancario.saldo_extrato !== "R$0,00" ? "*" : ""}</label>
                                             <div className='container-upload-extrato'>
                                                 <Upload
                                                     beforeUpload={() => false}

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/Justivicativa/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/Justivicativa/index.js
@@ -1,69 +1,93 @@
-import React, {useState} from "react";
-import {visoesService} from "../../../../../services/visoes.service";
-import {faCheck} from '@fortawesome/free-solid-svg-icons'
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
-
+import React, { useState } from "react";
+import { visoesService } from "../../../../../services/visoes.service";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export const Justificativa = ({
-    textareaJustificativa, handleChangeTextareaJustificativa, periodoFechado, 
-    btnSalvarJustificativaDisable, setBtnJustificativaSalvarDisable, checkSalvarJustificativa,
-    setCheckSalvarJustificativa, salvarJustificativa, classBtnSalvarJustificativa, lancamentosSelecionados,
-    setClassBtnSalvarJustificativa}) => {
+  textareaJustificativa,
+  handleChangeTextareaJustificativa,
+  periodoFechado,
+  btnSalvarJustificativaDisable,
+  setBtnJustificativaSalvarDisable,
+  checkSalvarJustificativa,
+  setCheckSalvarJustificativa,
+  salvarJustificativa,
+  classBtnSalvarJustificativa,
+  lancamentosSelecionados,
+  setClassBtnSalvarJustificativa,
+  justificativaObrigatoria,
+}) => {
+  const handleOnClick = () => {
+    setBtnJustificativaSalvarDisable(true);
+    setCheckSalvarJustificativa(true);
+    setClassBtnSalvarJustificativa("secondary");
+    salvarJustificativa(lancamentosSelecionados);
+  };
 
+  return (
+    <div className="form-group mt-4">
+      <p className="justificativas-e-informacoes-adicionais mt-5 mb-3">
+        Justificativas e informações adicionais
+      </p>
+      {justificativaObrigatoria ? (
+        <>
+          <p className="text-left">
+            <span className="font-weight-bold">
+              * Preenchimento obrigatório
+            </span>
+          </p>
+          <p>
+            Adicione justificativas e informações adicionais se necessário *
+          </p>
+        </>
+      ) : (
+        <p>
+          Adicione justificativas e informações adicionais se necessário
+          (opcional)
+        </p>
+      )}
 
-    const handleOnClick = () => {
-        setBtnJustificativaSalvarDisable(true);
-        setCheckSalvarJustificativa(true);
-        setClassBtnSalvarJustificativa("secondary");
-        salvarJustificativa(lancamentosSelecionados);
-    }
+      <textarea
+        value={textareaJustificativa}
+        onChange={handleChangeTextareaJustificativa}
+        className="form-control"
+        rows="3"
+        id="justificativa"
+        name="justificativa"
+        placeholder="Escreva o comentário"
+        required={justificativaObrigatoria}
+        disabled={
+          periodoFechado ||
+          !visoesService.getPermissoes(["change_conciliacao_bancaria"])
+        }
+      ></textarea>
 
+      {visoesService.getPermissoes(["change_conciliacao_bancaria"]) && (
+        <div className="bd-highlight d-flex justify-content-end align-items-center">
+          {checkSalvarJustificativa && (
+            <div className="">
+              <p className="mr-2 mt-3">
+                <span className="mr-1">
+                  <FontAwesomeIcon
+                    style={{ fontSize: "16px", color: "#297805" }}
+                    icon={faCheck}
+                  />
+                </span>
+                Salvo
+              </p>
+            </div>
+          )}
 
-    return(
-        <div className="form-group mt-4">
-            <p className="justificativas-e-informacoes-adicionais mt-5 mb-3">Justificativas e informações adicionais</p>
-            <p>Adicione justificativas e informações adicionais se necessário (opcional)</p>
-
-            <textarea
-                value={textareaJustificativa}
-                onChange={handleChangeTextareaJustificativa}
-                className="form-control"
-                rows="3"
-                id="justificativa"
-                name="justificativa"
-                placeholder="Escreva o comentário"
-                disabled={periodoFechado || !visoesService.getPermissoes(['change_conciliacao_bancaria'])}
-            >
-            </textarea>
-
-            {visoesService.getPermissoes(['change_conciliacao_bancaria']) &&
-                <div className="bd-highlight d-flex justify-content-end align-items-center">
-
-                    {checkSalvarJustificativa &&
-                        <div className="">
-                            <p className="mr-2 mt-3">
-                                <span className="mr-1">
-                                <FontAwesomeIcon
-                                    style={{fontSize: '16px', color:'#297805'}}
-                                    icon={faCheck}
-                                />
-                                </span>Salvo
-                            </p>
-                        </div>
-                    }
-                    
-                    <button 
-                        disabled={btnSalvarJustificativaDisable} 
-                        type="button" 
-                        className={`btn btn-${classBtnSalvarJustificativa} mt-2`}
-                        onClick={handleOnClick}
-                        >
-                            <strong>Salvar Justificativas</strong>
-                    </button>
-                </div>
-            }
-            
+          <button
+            disabled={btnSalvarJustificativaDisable}
+            type="button"
+            className={`btn btn-${classBtnSalvarJustificativa} mt-2`}
+            onClick={handleOnClick}
+          >
+            <strong>Salvar Justificativas</strong>
+          </button>
         </div>
-    );
+      )}
+    </div>
+  );
 };
-

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -1,734 +1,965 @@
-import React, {useCallback, useEffect, useState, useContext} from "react";
-import {useLocation, useParams, useNavigate} from "react-router-dom";
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useContext,
+  useMemo,
+} from "react";
+import { useLocation, useParams, useNavigate } from "react-router-dom";
 import moment from "moment";
-import {TopoComBotoes} from "./TopoComBotoes";
+import { TopoComBotoes } from "./TopoComBotoes";
 import TabelaValoresPendentesPorAcao from "./TabelaValoresPendentesPorAcao";
-import {Justificativa} from "./Justivicativa";
-import {getTabelasReceita} from "../../../../services/escolas/Receitas.service";
+import { Justificativa } from "./Justivicativa";
+import { getTabelasReceita } from "../../../../services/escolas/Receitas.service";
 import {
-    getConciliar,
-    getDesconciliar,
-    getObservacoes,
-    getStatusPeriodoPorData,
-    getTransacoes,
-    patchConciliarDespesa,
-    patchDesconciliarDespesa,
-    getDownloadExtratoBancario,
-    pathSalvarJustificativaPrestacaoDeConta,
-    pathExtratoBancarioPrestacaoDeConta    
+  getConciliar,
+  getDesconciliar,
+  getObservacoes,
+  getStatusPeriodoPorData,
+  getTransacoes,
+  patchConciliarDespesa,
+  patchDesconciliarDespesa,
+  getDownloadExtratoBancario,
+  pathSalvarJustificativaPrestacaoDeConta,
+  pathExtratoBancarioPrestacaoDeConta,
 } from "../../../../services/escolas/PrestacaoDeContas.service";
-import {getContas, getPeriodosDePrestacaoDeContasDaAssociacao} from "../../../../services/escolas/Associacao.service";
+import {
+  getContas,
+  getPeriodosDePrestacaoDeContasDaAssociacao,
+} from "../../../../services/escolas/Associacao.service";
 import Loading from "../../../../utils/Loading";
-import {SelectPeriodoConta} from "../SelectPeriodoConta";
-import {MsgImgCentralizada} from "../../../Globais/Mensagens/MsgImgCentralizada";
+import { SelectPeriodoConta } from "../SelectPeriodoConta";
+import { MsgImgCentralizada } from "../../../Globais/Mensagens/MsgImgCentralizada";
 import Img404 from "../../../../assets/img/img-404.svg";
-import {ASSOCIACAO_UUID} from "../../../../services/auth.service";
-import {tabelaValoresPendentes} from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
+import { ASSOCIACAO_UUID } from "../../../../services/auth.service";
+import { tabelaValoresPendentes } from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
 import DataSaldoBancario from "./DataSaldoBancario";
-import {trataNumericos} from "../../../../utils/ValidacoesAdicionaisFormularios";
+import { trataNumericos } from "../../../../utils/ValidacoesAdicionaisFormularios";
 import TabelaTransacoes from "./TabelaTransacoes";
-import {getDespesasTabelas} from "../../../../services/escolas/Despesas.service";
-import {FiltrosTransacoes} from "./FiltrosTransacoes";
+import { getDespesasTabelas } from "../../../../services/escolas/Despesas.service";
+import { FiltrosTransacoes } from "./FiltrosTransacoes";
 import { SidebarLeftService } from "../../../../services/SideBarLeft.service";
 import { SidebarContext } from "../../../../context/Sidebar";
-import {toastCustom} from "../../../Globais/ToastCustom";
+import { toastCustom } from "../../../Globais/ToastCustom";
 import { ModalSalvarDataSaldoExtrato } from "../ModalSalvarDataSaldoExtrato";
 
 export const DetalheDasPrestacoes = () => {
-    let {periodo_uuid, conta_uuid} = useParams();
-    const contextSideBar = useContext(SidebarContext);
-    const navigate = useNavigate();
-    const origem = (new URLSearchParams(window.location.search)).get("origem")
+  let { periodo_uuid, conta_uuid } = useParams();
+  const contextSideBar = useContext(SidebarContext);
+  const navigate = useNavigate();
+  const origem = new URLSearchParams(window.location.search).get("origem");
 
-    // Alteracoes
-    const [loading, setLoading] = useState(true);
-    const [loadingConciliadas, setLoadingConciliadas] = useState(true);
-    const [loadingNaoConciliadas, setLoadingNaoConciliadas] = useState(true);
+  // Alteracoes
+  const [loading, setLoading] = useState(true);
+  const [loadingConciliadas, setLoadingConciliadas] = useState(true);
+  const [loadingNaoConciliadas, setLoadingNaoConciliadas] = useState(true);
 
-    const [observacaoUuid, setObservacaoUuid] = useState("");
-    const [periodoConta, setPeriodoConta] = useState("");
-    const [periodoFechado, setPeriodoFechado] = useState(true);
-    const [permiteEditarCamposExtrato, setPermiteEditarCamposExtrato] = useState(false);
-    const [contasAssociacao, setContasAssociacao] = useState(false);
-    const [periodosAssociacao, setPeriodosAssociacao] = useState(false);
-    const [contaConciliacao, setContaConciliacao] = useState("");
-    const [acaoLancamento, setAcaoLancamento] = useState("");
-    const [acoesAssociacao, setAcoesAssociacao] = useState(false);
+  const [observacaoUuid, setObservacaoUuid] = useState("");
+  const [periodoConta, setPeriodoConta] = useState("");
+  const [periodoFechado, setPeriodoFechado] = useState(true);
+  const [permiteEditarCamposExtrato, setPermiteEditarCamposExtrato] =
+    useState(false);
+  const [contasAssociacao, setContasAssociacao] = useState(false);
+  const [periodosAssociacao, setPeriodosAssociacao] = useState(false);
+  const [contaConciliacao, setContaConciliacao] = useState("");
+  const [acaoLancamento, setAcaoLancamento] = useState("");
+  const [acoesAssociacao, setAcoesAssociacao] = useState(false);
 
-    const [textareaJustificativa, setTextareaJustificativa] = useState("");
-    const [btnSalvarJustificativaDisable, setBtnSalvarJustificativaDisable] = useState(true);
-    const [classBtnSalvarJustificativa, setClassBtnSalvarJustificativa] = useState("secondary");
-    const [checkSalvarJustificativa, setCheckSalvarJustificativa] = useState(false);
+  const [textareaJustificativa, setTextareaJustificativa] = useState("");
+  const [btnSalvarJustificativaDisable, setBtnSalvarJustificativaDisable] =
+    useState(true);
+  const [classBtnSalvarJustificativa, setClassBtnSalvarJustificativa] =
+    useState("secondary");
+  const [checkSalvarJustificativa, setCheckSalvarJustificativa] =
+    useState(false);
 
-    const [btnSalvarExtratoBancarioDisable, setBtnSalvarExtratoBancarioDisable] = useState(true);
-    const [classBtnSalvarExtratoBancario, setClassBtnSalvarExtratoBancario] = useState("secondary");
-    const [checkSalvarExtratoBancario, setCheckSalvarExtratoBancario] = useState(false);
+  const [btnSalvarExtratoBancarioDisable, setBtnSalvarExtratoBancarioDisable] =
+    useState(true);
+  const [classBtnSalvarExtratoBancario, setClassBtnSalvarExtratoBancario] =
+    useState("secondary");
+  const [checkSalvarExtratoBancario, setCheckSalvarExtratoBancario] =
+    useState(false);
 
-    const [showModalLegendaInformacao, setShowModalLegendaInformacao] = useState(false);
-    const [pendenciaSaldoBancario, setPendenciaSaldoBancario] = useState(false);
-    const parametros = useLocation();
+  const [showModalLegendaInformacao, setShowModalLegendaInformacao] =
+    useState(false);
+  const [pendenciaSaldoBancario, setPendenciaSaldoBancario] = useState(false);
+  const parametros = useLocation();
 
-    useEffect(()=>{
-        getPeriodoConta();
-        getAcaoLancamento();
-        carregaTabelas();
-        carregaPeriodos();
-    }, []);
+  useEffect(() => {
+    getPeriodoConta();
+    getAcaoLancamento();
+    carregaTabelas();
+    carregaPeriodos();
+  }, []);
 
-    useEffect(() => {
-        if(periodoConta) {
-            localStorage.setItem('periodoConta', JSON.stringify(periodoConta));
-            carregaContas();
+  useEffect(() => {
+    if (periodoConta) {
+      localStorage.setItem("periodoConta", JSON.stringify(periodoConta));
+      carregaContas();
+    }
+  }, [periodoConta]);
+
+  useEffect(() => {
+    if (periodoConta) {
+      carregaObservacoes();
+    }
+  }, [periodoConta, acoesAssociacao, acaoLancamento]);
+
+  useEffect(() => {
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (periodoConta) {
+      verificaSePeriodoEstaAberto(periodoConta.periodo);
+    }
+  }, [periodoConta, periodosAssociacao]);
+
+  const getPeriodoConta = () => {
+    if (periodo_uuid) {
+      setPeriodoConta({
+        periodo: periodo_uuid,
+        conta: conta_uuid ? conta_uuid : "",
+      });
+    } else if (localStorage.getItem("periodoConta")) {
+      const periodoConta = JSON.parse(localStorage.getItem("periodoConta"));
+      setPeriodoConta(periodoConta);
+    } else {
+      setPeriodoConta({ periodo: "", conta: "" });
+    }
+  };
+
+  const getAcaoLancamento = () => {
+    let acao_lancamento = JSON.parse(localStorage.getItem("acaoLancamento"));
+    if (acao_lancamento) {
+      const files = JSON.parse(localStorage.getItem("acaoLancamento"));
+      setAcaoLancamento(files);
+    } else {
+      setAcaoLancamento({ acao: "", lancamento: "" });
+    }
+  };
+
+  const carregaTabelas = async () => {
+    await getTabelasReceita()
+      .then((response) => {
+        setAcoesAssociacao(response.data.acoes_associacao);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  const carregaPeriodos = async () => {
+    let ignorar_devolvidas = false;
+    let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao(
+      ignorar_devolvidas
+    );
+    setPeriodosAssociacao(periodos);
+  };
+
+  const carregaContas = async () => {
+    setLoading(true);
+    let period_uuid = periodoConta ? periodoConta.periodo : "";
+    await getContas(period_uuid)
+      .then((response) => {
+        setContasAssociacao(response);
+        const files = JSON.parse(localStorage.getItem("periodoConta"));
+        if (files && files.conta !== "") {
+          const conta = response.find((conta) => conta.uuid === files.conta);
+          setContaConciliacao(conta.tipo_conta.nome);
         }
-    }, [periodoConta]);
+      })
+      .catch((error) => {
+        console.log(error);
+      })
+      .finally(() => setLoading(false));
+  };
 
-    useEffect(()=>{
-        if(periodoConta) {
-            carregaObservacoes();
-        }
-    }, [periodoConta, acoesAssociacao, acaoLancamento]);
+  const conciliar = useCallback(
+    async (rateio_uuid) => {
+      await getConciliar(rateio_uuid, periodoConta.periodo);
+    },
+    [periodoConta.periodo]
+  );
 
-    useEffect(()=>{
-        setLoading(false)
-    }, []);
+  const desconciliar = useCallback(
+    async (rateio_uuid) => {
+      await getDesconciliar(rateio_uuid, periodoConta.periodo);
+    },
+    [periodoConta.periodo]
+  );
 
-    useEffect(() => {
-        if(periodoConta) {
-            verificaSePeriodoEstaAberto(periodoConta.periodo);
-        }
-    }, [periodoConta, periodosAssociacao]);
+  const handleChangePeriodoConta = (name, value, periodoOuConta) => {
+    setCheckSalvarJustificativa(false);
+    setCheckSalvarExtratoBancario(false);
+    setBtnSalvarExtratoBancarioDisable(true);
+    setExibeBtnDownload(false);
 
-    const getPeriodoConta = () => {
-        if(periodo_uuid){
-            setPeriodoConta({periodo: periodo_uuid, conta: conta_uuid ? conta_uuid : ""});
-        } else if (localStorage.getItem('periodoConta')) {
-            const periodoConta = JSON.parse(localStorage.getItem('periodoConta'));
-            setPeriodoConta(periodoConta)
-        } else {
-            setPeriodoConta({periodo: "", conta: ""})
-        }
-    };
+    if (periodoOuConta === "periodo") {
+      setPeriodoConta({
+        conta: "",
+        [name]: value,
+      });
+    } else {
+      setPeriodoConta({
+        ...periodoConta,
+        [name]: value,
+      });
+    }
+  };
 
-    const getAcaoLancamento = () => {
-        let acao_lancamento = JSON.parse(localStorage.getItem('acaoLancamento'));
-        if (acao_lancamento) {
-            const files = JSON.parse(localStorage.getItem('acaoLancamento'));
-            setAcaoLancamento(files);
-        } else {
-            setAcaoLancamento({acao: "", lancamento: ""})
-        }
-    };
+  const handleChangeTextareaJustificativa = (event) => {
+    setTextareaJustificativa(event.target.value);
+    setBtnSalvarJustificativaDisable(false);
+    setCheckSalvarJustificativa(false);
+    setClassBtnSalvarJustificativa("success");
+  };
 
-    const carregaTabelas = async () => {
-        await getTabelasReceita().then(response => {
-            setAcoesAssociacao(response.data.acoes_associacao);
-        }).catch(error => {
+  const parseLocalDate = (dateStr) => {
+    if (!dateStr) return null;
+    const [year, month, day] = dateStr.split("-").map(Number);
+    return new Date(year, month - 1, day);
+  };
+
+  const carregaObservacoes = async () => {
+    if (periodosAssociacao && periodoConta.periodo && periodoConta.conta) {
+      const periodo_uuid = periodoConta.periodo;
+      const conta_uuid = periodoConta.conta;
+      const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
+
+      const periodo = periodosAssociacao.find((o) => o.uuid === periodo_uuid);
+
+      const observacao = await getObservacoes(
+        periodo_uuid,
+        conta_uuid,
+        associacaoUuid
+      );
+
+      if (observacao) {
+        setPermiteEditarCamposExtrato(observacao.permite_editar_campos_extrato);
+      }
+
+      if (observacao && observacao.possui_solicitacao_encerramento) {
+        const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
+
+        await getStatusPeriodoPorData(
+          associacaoUuid,
+          periodo.data_inicio_realizacao_despesas
+        )
+          .then((response) => {
+            const periodo_bloqueado = response.prestacao_contas_status
+              ? response.prestacao_contas_status.periodo_bloqueado
+              : true;
+            if (!periodo_bloqueado) {
+              setBtnSalvarExtratoBancarioDisable(false);
+              setCheckSalvarExtratoBancario(false);
+              setClassBtnSalvarExtratoBancario("success");
+            }
+          })
+          .catch((error) => {
             console.log(error);
-        });
-    };
-
-    const carregaPeriodos = async () => {
-        let ignorar_devolvidas = false
-        let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao(ignorar_devolvidas);
-        setPeriodosAssociacao(periodos);
-    };
-
-    const carregaContas = async () => {
-        setLoading(true);
-        let period_uuid = periodoConta ? periodoConta.periodo : '';
-        await getContas(period_uuid).then(response => {
-            setContasAssociacao(response);
-            const files = JSON.parse(localStorage.getItem('periodoConta'));
-            if (files && files.conta !== "") {
-                const conta = response.find(conta => conta.uuid === files.conta);
-                setContaConciliacao(conta.tipo_conta.nome);
-            }
-        }).catch(error => {
-            console.log(error);
-        }).finally(() => setLoading(false))
-    };
-
-    const conciliar = useCallback(async (rateio_uuid) => {
-        await getConciliar(rateio_uuid, periodoConta.periodo);
-    }, [periodoConta.periodo]) ;
-
-    const desconciliar = useCallback(async (rateio_uuid) => {
-        await getDesconciliar(rateio_uuid, periodoConta.periodo);
-    }, [periodoConta.periodo]) ;
-
-
-    const handleChangePeriodoConta = (name, value, periodoOuConta) => {
-        setCheckSalvarJustificativa(false);
-        setCheckSalvarExtratoBancario(false);
-        setBtnSalvarExtratoBancarioDisable(true);
-        setExibeBtnDownload(false);
-
-        if(periodoOuConta === 'periodo') {
-            setPeriodoConta({
-                conta: '',
-                [name]: value
-            });
-        } else {
-            setPeriodoConta({
-                ...periodoConta,
-                [name]: value
-            });
-        } 
-    };
-
-    const handleChangeTextareaJustificativa = (event) => {
-        setTextareaJustificativa(event.target.value);
-        setBtnSalvarJustificativaDisable(false);
-        setCheckSalvarJustificativa(false);
-        setClassBtnSalvarJustificativa("success");
-    };
-
-    const carregaObservacoes = async () => {
-
-        if (periodoConta.periodo && periodoConta.conta) {
-            let periodo_uuid = periodoConta.periodo;
-            let conta_uuid = periodoConta.conta;
-            const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
-
-            let observacao = await getObservacoes(periodo_uuid, conta_uuid, associacaoUuid);
-
-            if(observacao) {
-                setPermiteEditarCamposExtrato(observacao.permite_editar_campos_extrato)
-            }
-
-            if(observacao && observacao.possui_solicitacao_encerramento){
-                if (periodosAssociacao){
-                    const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
-                    const periodo = periodosAssociacao.find(o => o.uuid === periodo_uuid);
-                    
-                    await getStatusPeriodoPorData(associacaoUuid, periodo.data_inicio_realizacao_despesas).then(response => {
-                        
-                        let periodo_bloqueado = response.prestacao_contas_status ? response.prestacao_contas_status.periodo_bloqueado : true
-                        if(!periodo_bloqueado){
-                            setBtnSalvarExtratoBancarioDisable(false);
-                            setCheckSalvarExtratoBancario(false);
-                            setClassBtnSalvarExtratoBancario("success");
-                        }
-                    }).catch(error => {
-                        console.log(error);
-                    });
-                }
-
-
-                setDataSaldoBancario({
-                    data_extrato: observacao.data_extrato ? observacao.data_extrato : '',
-                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
-                })
-
-                setDataSaldoBancarioSolicitacaoEncerramento({
-                    data_extrato: observacao.data_extrato ? observacao.data_extrato : '',
-                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
-                    possui_solicitacao_encerramento: true,
-                    data_encerramento: observacao.data_encerramento ? observacao.data_encerramento : '',
-                    saldo_encerramento: observacao.saldo_encerramento ? observacao.saldo_encerramento : 0,
-                })
-
-                if(observacao.observacao_uuid){
-                    setObservacaoUuid(observacao.observacao_uuid)
-
-                    setTextareaJustificativa(observacao.observacao ? observacao.observacao : '');
-
-                    setNomeComprovanteExtrato(observacao.comprovante_extrato ? observacao.comprovante_extrato : '')
-                    setDataAtualizacaoComprovanteExtrato(moment(observacao.data_atualizacao_comprovante_extrato).format("YYYY-MM-DD HH:mm:ss"))
-                    setDataAtualizacaoComprovanteExtratoView(moment(observacao.data_atualizacao_comprovante_extrato).format("DD/MM/YYYY HH:mm:ss"))
-                    if (observacao.comprovante_extrato && observacao.data_extrato){
-                        setExibeBtnDownload(true)
-                    }
-                    else if(!observacao.comprovante_extrato){
-                        setExibeBtnDownload(false)
-                    }
-                }
-            }
-            else{
-                setObservacaoUuid(observacao.observacao_uuid)
-
-                setTextareaJustificativa(observacao.observacao ? observacao.observacao : '');
-                setDataSaldoBancario({
-                    data_extrato: observacao.data_extrato ? observacao.data_extrato : '',
-                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
-                })
-                setNomeComprovanteExtrato(observacao.comprovante_extrato ? observacao.comprovante_extrato : '')
-                setDataAtualizacaoComprovanteExtrato(moment(observacao.data_atualizacao_comprovante_extrato).format("YYYY-MM-DD HH:mm:ss"))
-                setDataAtualizacaoComprovanteExtratoView(moment(observacao.data_atualizacao_comprovante_extrato).format("DD/MM/YYYY HH:mm:ss"))
-                if (observacao.comprovante_extrato && observacao.data_extrato){
-                    setExibeBtnDownload(true)
-                }
-                else if(!observacao.comprovante_extrato){
-                    setExibeBtnDownload(false)
-                }
-
-                setDataSaldoBancarioSolicitacaoEncerramento({})
-            }
-        }
-    };
-
-    const salvarJustificativa = async () => {
-        let payload;
-
-        payload = {
-            "periodo_uuid": periodoConta.periodo,
-            "conta_associacao_uuid": periodoConta.conta,
-            "observacao": textareaJustificativa,
-        }
-
-        try {
-            await pathSalvarJustificativaPrestacaoDeConta(payload);
-            toastCustom.ToastCustomSuccess('Edição salva', 'A edição foi salva com sucesso!')
-            await carregaObservacoes();
-        } catch (e) {
-            console.log("Erro: ", e.message)
-        }
-    }
-
-    const salvarExtratoBancario = async () => {
-        setBtnSalvarExtratoBancarioDisable(true);
-        setCheckSalvarExtratoBancario(true);
-        setClassBtnSalvarExtratoBancario("secondary");
-
-        let payload;
-
-        payload = {
-            "periodo_uuid": periodoConta.periodo,
-            "conta_associacao_uuid": periodoConta.conta,
-            "data_extrato": dataSaldoBancario.data_extrato ? moment(dataSaldoBancario.data_extrato, "YYYY-MM-DD").format("YYYY-MM-DD"): null,
-            "saldo_extrato": dataSaldoBancario.saldo_extrato ? trataNumericos(dataSaldoBancario.saldo_extrato) : 0,
-            "comprovante_extrato": selectedFile,
-            "data_atualizacao_comprovante_extrato": dataAtualizacaoComprovanteExtrato ? moment(dataAtualizacaoComprovanteExtrato, "YYYY-MM-DD HH:mm:ss").format("YYYY-MM-DD HH:mm:ss"): null,
-        }
-
-        try {
-            await pathExtratoBancarioPrestacaoDeConta(payload);
-            setShowModalSalvarDataSaldoExtrato(false);
-            verificaSePeriodoEstaAberto(periodoConta.periodo);
-            toastCustom.ToastCustomSuccess('Edição salva', 'A edição foi salva com sucesso!')
-            setDataAtualizacaoComprovanteExtrato('')
-            setDataAtualizacaoComprovanteExtratoView('')
-            setSelectedFile(null)
-            setMsgErroExtensaoArquivo('')
-            await carregaObservacoes();
-        } catch (e) {
-            console.log("Erro: ", e.message)
-        }
-    }
-    const checaPendenciaSaldoBancario =  (statusPeriodo) => {
-        const pendenciaCadastral = statusPeriodo.pendencias_cadastrais;
-        const contaPendente = pendenciaCadastral?.conciliacao_bancaria?.contas_pendentes?.includes(periodoConta.conta);
-
-        setPendenciaSaldoBancario(contaPendente ? true : false);
-    };
-
-    const verificaSePeriodoEstaAberto = async (periodoUuid) => {
-        if (periodosAssociacao) {
-            const periodo = periodosAssociacao.find(o => o.uuid === periodoUuid);
-            if (periodo) {
-                const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
-                await getStatusPeriodoPorData(associacaoUuid, periodo.data_inicio_realizacao_despesas).then(response => {
-                    checaPendenciaSaldoBancario(response);
-                    const periodoBloqueado = response.prestacao_contas_status ? response.prestacao_contas_status.periodo_bloqueado : true
-                    setPeriodoFechado(periodoBloqueado)
-                }).catch(error => {
-                    console.log(error);
-                });
-            }
-        }
-    };
-
-    // Tabela Valores Pendentes por Ação
-    const [valoresPendentes, setValoresPendentes] = useState({});
-
-    const carregaValoresPendentes = useCallback(async ()=>{
-        let valores_pendentes = await tabelaValoresPendentes(periodoConta.periodo, periodoConta.conta);
-        setValoresPendentes(valores_pendentes)
-    }, [periodoConta.periodo, periodoConta.conta]);
-
-    useEffect(()=>{
-        if (periodoConta.periodo && periodoConta.conta){
-            carregaValoresPendentes()
-        }
-
-    }, [periodoConta.periodo, periodoConta.conta, carregaValoresPendentes]);
-
-    const valorTemplate = (valor) => {
-        let valor_formatado = Number(valor).toLocaleString('pt-BR', {
-            style: 'currency',
-            currency: 'BRL'
-        });
-        valor_formatado = valor_formatado.replace(/R/, "").replace(/\$/, "");
-        return valor_formatado
-    };
-
-    // Transacoes Conciliadas e Não Conciliadas
-    const [transacoesConciliadas, setTransacoesConciliadas] = useState([]);
-    const [transacoesNaoConciliadas, setTransacoesNaoConciliadas] = useState([]);
-    const [checkboxTransacoes, setCheckboxTransacoes] = useState(false);
-    const [tabelasDespesa, setTabelasDespesa] = useState([]);
-
-    const carregaTransacoes = useCallback(async ()=>{
-        setLoading(true)
-        if (periodoConta.periodo && periodoConta.conta){
-            handleTransacoesConciliadas();
-            handleTransacoesNaoConciliadas();
-        }
-        setLoading(false)
-    }, [periodoConta]);
-
-    useEffect(()=>{
-        carregaTransacoes();
-    }, [carregaTransacoes]);
-
-    useEffect(() => {
-        const carregaTabelasDespesa = async () => {
-            const resp = await getDespesasTabelas();
-            setTabelasDespesa(resp);
-        };
-        carregaTabelasDespesa();
-    }, []);
-
-
-    const handleChangeCheckboxTransacoes = useCallback(async (event, transacao_ou_rateio_uuid, documento_mestre=null, tipo_transacao) => {
-
-        setCheckboxTransacoes(event.target.checked);
-        if (event.target.checked) {
-            if (!documento_mestre){
-                await conciliar(transacao_ou_rateio_uuid);
-            }else {
-                await patchConciliarDespesa(periodoConta.periodo, periodoConta.conta, transacao_ou_rateio_uuid)
-            }
-        } else if (!event.target.checked) {
-            if (!documento_mestre){
-                await desconciliar(transacao_ou_rateio_uuid)
-            }else {
-                await patchDesconciliarDespesa(periodoConta.conta, transacao_ou_rateio_uuid)
-            }
-        }
-        await carregaTransacoes()
-        await carregaValoresPendentes()
-
-    }, [periodoConta, carregaTransacoes, conciliar, desconciliar, carregaValoresPendentes]);
-
-    // Filtros Transacoes
-    const [stateFiltros, setStateFiltros] = useState({});
-
-    const handleChangeFiltros = useCallback((name, value) => {
-        setStateFiltros({
-            ...stateFiltros,
-            [name]: value
-        });
-    }, [stateFiltros]);
-
-    // Data Saldo Bancário
-    const [dataSaldoBancario, setDataSaldoBancario]= useState({});
-    const [dataSaldoBancarioSolicitacaoEncerramento, setDataSaldoBancarioSolicitacaoEncerramento]= useState({});
-    const [showModalSalvarDataSaldoExtrato, setShowModalSalvarDataSaldoExtrato] = useState(false)
-    const [selectedFile, setSelectedFile] = useState(null);
-    const [nomeComprovanteExtrato, setNomeComprovanteExtrato] = useState('');
-    const [dataAtualizacaoComprovanteExtrato, setDataAtualizacaoComprovanteExtrato] = useState('');
-    const [dataAtualizacaoComprovanteExtratoView, setDataAtualizacaoComprovanteExtratoView] = useState('');
-    const [exibeBtnDownload, setExibeBtnDownload] = useState(false);
-    const [msgErroExtensaoArquivo, setMsgErroExtensaoArquivo] = useState('');
-
-    const validaUploadExtrato = (event) =>{
-        let ext = event.file.type
-        let tamanho = event.file.size
-        let array_extensoes = ['image/jpeg','image/jpg','image/bmp','image/png', 'image/tif', 'application/pdf' ]
-        if (tamanho <= 500395){
-            let result = array_extensoes.filter(item => ext.indexOf(item) > -1);
-            if (result <=0){
-                setMsgErroExtensaoArquivo(`A extensão ${ext} não é permitida, tente novamente`)
-                return false
-            }else {
-                setMsgErroExtensaoArquivo('')
-                return true
-            }
-        }else {
-            setMsgErroExtensaoArquivo('O tamanho do arquivo excede o limite de 500kb, tente novamente.')
-            return false
-        }
-    }
-
-    const changeUploadExtrato = (event) => {
-        if (validaUploadExtrato(event)){
-            setBtnSalvarExtratoBancarioDisable(false);
-            setCheckSalvarExtratoBancario(false);
-            setClassBtnSalvarExtratoBancario("success");
-            setSelectedFile(event.file);
-            setNomeComprovanteExtrato(event.file.name)
-            setDataAtualizacaoComprovanteExtrato(moment().format("YYYY-MM-DD HH:mm:ss"))
-            setDataAtualizacaoComprovanteExtratoView(moment().format("DD/MM/YYYY HH:mm:ss"))
-            setExibeBtnDownload(false)
-            setMsgErroExtensaoArquivo('')
-        }else {
-            reiniciaUploadExtrato()
-        }
-    };
-
-    const reiniciaUploadExtrato =()=>{
-
-        if(nomeComprovanteExtrato !== ""){
-            setBtnSalvarExtratoBancarioDisable(false);
-            setCheckSalvarExtratoBancario(false);
-            setClassBtnSalvarExtratoBancario("success");
-        }
-
-        setSelectedFile(null)
-        setDataAtualizacaoComprovanteExtrato('')
-        setDataAtualizacaoComprovanteExtratoView('')
-        setExibeBtnDownload(false)
-        setNomeComprovanteExtrato('')
-    }
-
-    const downloadComprovanteExtrato = useCallback(async ()=>{
-        try {
-            await getDownloadExtratoBancario(nomeComprovanteExtrato, observacaoUuid);
-            console.log("Download efetuado com sucesso");
-        }catch (e) {
-            console.log("Erro ao efetuar o download ", e.response);
-        }
-    }, [nomeComprovanteExtrato, observacaoUuid])
-
-    const [erroDataSaldo, setErroDataSaldo] = useState('')
-
-    const handleChangaDataSaldo = useCallback((name, value) => {
-        if (name === 'data_extrato'){
-            let hoje = moment(new Date());
-            let data_digitada = moment(value);
-            if (data_digitada > hoje){
-                setErroDataSaldo("Data do crédito não pode ser maior que a data de hoje")
-                setDataSaldoBancario(prevState => ({ ...prevState,  [name]: ''}));
-                return
-            }else {
-                setErroDataSaldo('')
-            }
-        }
-
-        setBtnSalvarExtratoBancarioDisable(false);
-        setCheckSalvarExtratoBancario(false);
-        setClassBtnSalvarExtratoBancario("success");
+          });
 
         setDataSaldoBancario({
-            ...dataSaldoBancario,
-            [name]: value
+          data_extrato: observacao.data_extrato
+            ? parseLocalDate(observacao.data_extrato)
+            : null,
+          saldo_extrato: observacao.saldo_extrato
+            ? observacao.saldo_extrato
+            : null,
         });
-    }, [dataSaldoBancario]);
 
-    const irParaAnaliseDre = async() => {
-        // Ao setar para false, quando a função a seguir setar o click do item do menu
-        // a pagina não ira automaticamente para a url do item
+        setDataSaldoBancarioSolicitacaoEncerramento({
+          data_extrato: observacao.data_extrato ? observacao.data_extrato : "",
+          saldo_extrato: observacao.saldo_extrato
+            ? observacao.saldo_extrato
+            : 0,
+          possui_solicitacao_encerramento: true,
+          data_encerramento: observacao.data_encerramento
+            ? observacao.data_encerramento
+            : "",
+          saldo_encerramento: observacao.saldo_encerramento
+            ? observacao.saldo_encerramento
+            : 0,
+        });
 
-        await contextSideBar.setIrParaUrl(false)
-        SidebarLeftService.setItemActive("analise_dre")
+        if (observacao.observacao_uuid) {
+          setObservacaoUuid(observacao.observacao_uuid);
 
-        // Necessário voltar o estado para true, para clicks nos itens do menu continuarem funcionando corretamente
-        contextSideBar.setIrParaUrl(true)
-    }
-    
-    const handleTransacoesConciliadas = async (ordenacao) => {
-        setLoadingConciliadas(true);
-        let transacoes_conciliadas = await getTransacoes(
-            periodoConta.periodo, 
-            periodoConta.conta, 
-            'True',
-            stateFiltros.filtrar_por_acao_CONCILIADO, 
-            ordenacao && ordenacao.ordenar_por_numero_do_documento ? ordenacao.ordenar_por_numero_do_documento : '',
-            ordenacao && ordenacao.ordenar_por_data_especificacao ? ordenacao.ordenar_por_data_especificacao : '',
-            ordenacao && ordenacao.ordenar_por_valor ? ordenacao.ordenar_por_valor : '',
-            ordenacao && ordenacao.ordenar_por_imposto ? ordenacao.ordenar_por_imposto : '',
+          setTextareaJustificativa(
+            observacao.observacao ? observacao.observacao : ""
+          );
+
+          setNomeComprovanteExtrato(
+            observacao.comprovante_extrato ? observacao.comprovante_extrato : ""
+          );
+          setDataAtualizacaoComprovanteExtrato(
+            moment(observacao.data_atualizacao_comprovante_extrato).format(
+              "YYYY-MM-DD HH:mm:ss"
+            )
+          );
+          setDataAtualizacaoComprovanteExtratoView(
+            moment(observacao.data_atualizacao_comprovante_extrato).format(
+              "DD/MM/YYYY HH:mm:ss"
+            )
+          );
+          if (observacao.comprovante_extrato && observacao.data_extrato) {
+            setExibeBtnDownload(true);
+          } else if (!observacao.comprovante_extrato) {
+            setExibeBtnDownload(false);
+          }
+        }
+      } else {
+        setObservacaoUuid(observacao.observacao_uuid);
+
+        setTextareaJustificativa(
+          observacao.observacao ? observacao.observacao : ""
         );
-        setTransacoesConciliadas(transacoes_conciliadas);
-        setLoadingConciliadas(false);
+        setDataSaldoBancario({
+          data_extrato: observacao.data_extrato
+            ? parseLocalDate(observacao.data_extrato)
+            : null,
+          saldo_extrato: observacao.saldo_extrato
+            ? observacao.saldo_extrato
+            : null,
+        });
+        setNomeComprovanteExtrato(
+          observacao.comprovante_extrato ? observacao.comprovante_extrato : ""
+        );
+        setDataAtualizacaoComprovanteExtrato(
+          moment(observacao.data_atualizacao_comprovante_extrato).format(
+            "YYYY-MM-DD HH:mm:ss"
+          )
+        );
+        setDataAtualizacaoComprovanteExtratoView(
+          moment(observacao.data_atualizacao_comprovante_extrato).format(
+            "DD/MM/YYYY HH:mm:ss"
+          )
+        );
+        if (observacao.comprovante_extrato && observacao.data_extrato) {
+          setExibeBtnDownload(true);
+        } else if (!observacao.comprovante_extrato) {
+          setExibeBtnDownload(false);
+        }
+
+        setDataSaldoBancarioSolicitacaoEncerramento({});
+      }
+    }
+  };
+
+  const salvarJustificativa = async () => {
+    let payload;
+
+    payload = {
+      periodo_uuid: periodoConta.periodo,
+      conta_associacao_uuid: periodoConta.conta,
+      observacao: textareaJustificativa,
     };
 
-    const handleTransacoesNaoConciliadas = async (ordenacao) => {
-        setLoadingNaoConciliadas(true);
-        let transacoes_nao_conciliadas = await getTransacoes(
-            periodoConta.periodo, 
-            periodoConta.conta, 
-            'False',
-            stateFiltros.filtrar_por_acao_NAO_CONCILIADO, 
-            ordenacao && ordenacao.ordenar_por_numero_do_documento ? ordenacao.ordenar_por_numero_do_documento : '',
-            ordenacao && ordenacao.ordenar_por_data_especificacao ? ordenacao.ordenar_por_data_especificacao : '',
-            ordenacao && ordenacao.ordenar_por_valor ? ordenacao.ordenar_por_valor : '',
-            ordenacao && ordenacao.ordenar_por_imposto ? ordenacao.ordenar_por_imposto : '',
-        );
-        setTransacoesNaoConciliadas(transacoes_nao_conciliadas);
-        setLoadingNaoConciliadas(false);
+    try {
+      await pathSalvarJustificativaPrestacaoDeConta(payload);
+      toastCustom.ToastCustomSuccess(
+        "Edição salva",
+        "A edição foi salva com sucesso!"
+      );
+      await carregaObservacoes();
+    } catch (e) {
+      console.log("Erro: ", e.message);
+    }
+  };
+
+  const salvarExtratoBancario = async () => {
+    setBtnSalvarExtratoBancarioDisable(true);
+    setCheckSalvarExtratoBancario(true);
+    setClassBtnSalvarExtratoBancario("secondary");
+
+    let payload;
+
+    payload = {
+      periodo_uuid: periodoConta.periodo,
+      conta_associacao_uuid: periodoConta.conta,
+      data_extrato: dataSaldoBancario.data_extrato
+        ? moment(dataSaldoBancario.data_extrato, "YYYY-MM-DD").format(
+            "YYYY-MM-DD"
+          )
+        : null,
+      saldo_extrato: dataSaldoBancario.saldo_extrato
+        ? trataNumericos(dataSaldoBancario.saldo_extrato)
+        : 0,
+      comprovante_extrato: selectedFile,
+      data_atualizacao_comprovante_extrato: dataAtualizacaoComprovanteExtrato
+        ? moment(
+            dataAtualizacaoComprovanteExtrato,
+            "YYYY-MM-DD HH:mm:ss"
+          ).format("YYYY-MM-DD HH:mm:ss")
+        : null,
     };
 
-    const onHandleCancelarModalSalvarDataSaldoExtrato = () => {
-        setShowModalSalvarDataSaldoExtrato(false);
-        // window.location.assign('/dados-das-contas-da-associacao')
+    try {
+      await pathExtratoBancarioPrestacaoDeConta(payload);
+      setShowModalSalvarDataSaldoExtrato(false);
+      verificaSePeriodoEstaAberto(periodoConta.periodo);
+      toastCustom.ToastCustomSuccess(
+        "Edição salva",
+        "A edição foi salva com sucesso!"
+      );
+      setDataAtualizacaoComprovanteExtrato("");
+      setDataAtualizacaoComprovanteExtratoView("");
+      setSelectedFile(null);
+      setMsgErroExtensaoArquivo("");
+      await carregaObservacoes();
+    } catch (e) {
+      console.log("Erro: ", e.message);
+    }
+  };
+  const checaPendenciaSaldoBancario = (statusPeriodo) => {
+    const pendenciaCadastral = statusPeriodo.pendencias_cadastrais;
+    const contaPendente =
+      pendenciaCadastral?.conciliacao_bancaria?.contas_pendentes?.includes(
+        periodoConta.conta
+      );
+
+    setPendenciaSaldoBancario(contaPendente ? true : false);
+  };
+
+  const verificaSePeriodoEstaAberto = async (periodoUuid) => {
+    if (periodosAssociacao) {
+      const periodo = periodosAssociacao.find((o) => o.uuid === periodoUuid);
+      if (periodo) {
+        const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
+        await getStatusPeriodoPorData(
+          associacaoUuid,
+          periodo.data_inicio_realizacao_despesas
+        )
+          .then((response) => {
+            checaPendenciaSaldoBancario(response);
+            const periodoBloqueado = response.prestacao_contas_status
+              ? response.prestacao_contas_status.periodo_bloqueado
+              : true;
+            setPeriodoFechado(periodoBloqueado);
+          })
+          .catch((error) => {
+            console.log(error);
+          });
+      }
+    }
+  };
+
+  // Tabela Valores Pendentes por Ação
+  const [valoresPendentes, setValoresPendentes] = useState({});
+
+  const carregaValoresPendentes = useCallback(async () => {
+    let valores_pendentes = await tabelaValoresPendentes(
+      periodoConta.periodo,
+      periodoConta.conta
+    );
+    setValoresPendentes(valores_pendentes);
+  }, [periodoConta.periodo, periodoConta.conta]);
+
+  useEffect(() => {
+    if (periodoConta.periodo && periodoConta.conta) {
+      carregaValoresPendentes();
+    }
+  }, [periodoConta.periodo, periodoConta.conta, carregaValoresPendentes]);
+
+  const valorTemplate = (valor) => {
+    let valor_formatado = Number(valor).toLocaleString("pt-BR", {
+      style: "currency",
+      currency: "BRL",
+    });
+    valor_formatado = valor_formatado.replace(/R/, "").replace(/\$/, "");
+    return valor_formatado;
+  };
+
+  // Transacoes Conciliadas e Não Conciliadas
+  const [transacoesConciliadas, setTransacoesConciliadas] = useState([]);
+  const [transacoesNaoConciliadas, setTransacoesNaoConciliadas] = useState([]);
+  const [checkboxTransacoes, setCheckboxTransacoes] = useState(false);
+  const [tabelasDespesa, setTabelasDespesa] = useState([]);
+
+  const carregaTransacoes = useCallback(async () => {
+    setLoading(true);
+    if (periodoConta.periodo && periodoConta.conta) {
+      handleTransacoesConciliadas();
+      handleTransacoesNaoConciliadas();
+    }
+    setLoading(false);
+  }, [periodoConta]);
+
+  useEffect(() => {
+    carregaTransacoes();
+  }, [carregaTransacoes]);
+
+  useEffect(() => {
+    const carregaTabelasDespesa = async () => {
+      const resp = await getDespesasTabelas();
+      setTabelasDespesa(resp);
+    };
+    carregaTabelasDespesa();
+  }, []);
+
+  const handleChangeCheckboxTransacoes = useCallback(
+    async (
+      event,
+      transacao_ou_rateio_uuid,
+      documento_mestre = null,
+      tipo_transacao
+    ) => {
+      setCheckboxTransacoes(event.target.checked);
+      if (event.target.checked) {
+        if (!documento_mestre) {
+          await conciliar(transacao_ou_rateio_uuid);
+        } else {
+          await patchConciliarDespesa(
+            periodoConta.periodo,
+            periodoConta.conta,
+            transacao_ou_rateio_uuid
+          );
+        }
+      } else if (!event.target.checked) {
+        if (!documento_mestre) {
+          await desconciliar(transacao_ou_rateio_uuid);
+        } else {
+          await patchDesconciliarDespesa(
+            periodoConta.conta,
+            transacao_ou_rateio_uuid
+          );
+        }
+      }
+      await carregaTransacoes();
+      await carregaValoresPendentes();
+    },
+    [
+      periodoConta,
+      carregaTransacoes,
+      conciliar,
+      desconciliar,
+      carregaValoresPendentes,
+    ]
+  );
+
+  // Filtros Transacoes
+  const [stateFiltros, setStateFiltros] = useState({});
+
+  const handleChangeFiltros = useCallback(
+    (name, value) => {
+      setStateFiltros({
+        ...stateFiltros,
+        [name]: value,
+      });
+    },
+    [stateFiltros]
+  );
+
+  // Data Saldo Bancário
+  const [dataSaldoBancario, setDataSaldoBancario] = useState({});
+  const [
+    dataSaldoBancarioSolicitacaoEncerramento,
+    setDataSaldoBancarioSolicitacaoEncerramento,
+  ] = useState({});
+  const [showModalSalvarDataSaldoExtrato, setShowModalSalvarDataSaldoExtrato] =
+    useState(false);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [nomeComprovanteExtrato, setNomeComprovanteExtrato] = useState("");
+  const [
+    dataAtualizacaoComprovanteExtrato,
+    setDataAtualizacaoComprovanteExtrato,
+  ] = useState("");
+  const [
+    dataAtualizacaoComprovanteExtratoView,
+    setDataAtualizacaoComprovanteExtratoView,
+  ] = useState("");
+  const [exibeBtnDownload, setExibeBtnDownload] = useState(false);
+  const [msgErroExtensaoArquivo, setMsgErroExtensaoArquivo] = useState("");
+
+  const validaUploadExtrato = (event) => {
+    let ext = event.file.type;
+    let tamanho = event.file.size;
+    let array_extensoes = [
+      "image/jpeg",
+      "image/jpg",
+      "image/bmp",
+      "image/png",
+      "image/tif",
+      "application/pdf",
+    ];
+    if (tamanho <= 500395) {
+      let result = array_extensoes.filter((item) => ext.indexOf(item) > -1);
+      if (result <= 0) {
+        setMsgErroExtensaoArquivo(
+          `A extensão ${ext} não é permitida, tente novamente`
+        );
+        return false;
+      } else {
+        setMsgErroExtensaoArquivo("");
+        return true;
+      }
+    } else {
+      setMsgErroExtensaoArquivo(
+        "O tamanho do arquivo excede o limite de 500kb, tente novamente."
+      );
+      return false;
+    }
+  };
+
+  const changeUploadExtrato = (event) => {
+    if (validaUploadExtrato(event)) {
+      setBtnSalvarExtratoBancarioDisable(false);
+      setCheckSalvarExtratoBancario(false);
+      setClassBtnSalvarExtratoBancario("success");
+      setSelectedFile(event.file);
+      setNomeComprovanteExtrato(event.file.name);
+      setDataAtualizacaoComprovanteExtrato(
+        moment().format("YYYY-MM-DD HH:mm:ss")
+      );
+      setDataAtualizacaoComprovanteExtratoView(
+        moment().format("DD/MM/YYYY HH:mm:ss")
+      );
+      setExibeBtnDownload(false);
+      setMsgErroExtensaoArquivo("");
+    } else {
+      reiniciaUploadExtrato();
+    }
+  };
+
+  const reiniciaUploadExtrato = () => {
+    if (nomeComprovanteExtrato !== "") {
+      setBtnSalvarExtratoBancarioDisable(false);
+      setCheckSalvarExtratoBancario(false);
+      setClassBtnSalvarExtratoBancario("success");
     }
 
-    return (
-        <>
-        <div className="detalhe-das-prestacoes-container mb-5 mt-5">
-            <div className="row">
-                <div className="col-12 d-flex bd-highlight mt-4">
-                    <div className="flex-grow-1 bd-highlight align-self-center detalhe-das-prestacoes-texto-cabecalho pl-0"><h3>Conciliação Bancária</h3></div>
+    setSelectedFile(null);
+    setDataAtualizacaoComprovanteExtrato("");
+    setDataAtualizacaoComprovanteExtratoView("");
+    setExibeBtnDownload(false);
+    setNomeComprovanteExtrato("");
+  };
 
-                    {parametros && parametros.state && parametros.state && parametros.state && parametros.state.origem === 'ir_para_conciliacao_bancaria' &&
-                        <div className="bd-highlight detalhe-das-prestacoes-texto-cabecalho">
-                            <button
-                                className="btn btn-outline-success"
-                                onClick={() => {
-                                    irParaAnaliseDre();
-                                    navigate(`/consulta-detalhamento-analise-da-dre/${parametros.state.prestacaoDeContasUuid}/`, {
-                                        state: {
-                                            origem: 'ir_para_conciliacao_bancaria',
-                                            periodoFormatado: parametros && parametros.state && parametros.state.periodoFormatado ? parametros.state.periodoFormatado : ""
-                                        }
-                                    });
-                                }}
-                            >
-                                Voltar para Análise DRE
-                            </button>
-                        </div>
-                    }
-                </div>
+  const downloadComprovanteExtrato = useCallback(async () => {
+    try {
+      await getDownloadExtratoBancario(nomeComprovanteExtrato, observacaoUuid);
+      console.log("Download efetuado com sucesso");
+    } catch (e) {
+      console.log("Erro ao efetuar o download ", e.response);
+    }
+  }, [nomeComprovanteExtrato, observacaoUuid]);
+
+  const [erroDataSaldo, setErroDataSaldo] = useState("");
+
+  const handleChangaDataSaldo = useCallback(
+    (name, value) => {
+      if (name === "data_extrato") {
+        let hoje = moment(new Date());
+        let data_digitada = moment(value);
+        if (data_digitada > hoje) {
+          setErroDataSaldo(
+            "Data do crédito não pode ser maior que a data de hoje"
+          );
+          setDataSaldoBancario((prevState) => ({ ...prevState, [name]: "" }));
+          return;
+        } else {
+          setErroDataSaldo("");
+        }
+      }
+
+      setBtnSalvarExtratoBancarioDisable(false);
+      setCheckSalvarExtratoBancario(false);
+      setClassBtnSalvarExtratoBancario("success");
+
+      setDataSaldoBancario({
+        ...dataSaldoBancario,
+        [name]: value,
+      });
+    },
+    [dataSaldoBancario]
+  );
+
+  const irParaAnaliseDre = async () => {
+    // Ao setar para false, quando a função a seguir setar o click do item do menu
+    // a pagina não ira automaticamente para a url do item
+
+    await contextSideBar.setIrParaUrl(false);
+    SidebarLeftService.setItemActive("analise_dre");
+
+    // Necessário voltar o estado para true, para clicks nos itens do menu continuarem funcionando corretamente
+    contextSideBar.setIrParaUrl(true);
+  };
+
+  const handleTransacoesConciliadas = async (ordenacao) => {
+    setLoadingConciliadas(true);
+    let transacoes_conciliadas = await getTransacoes(
+      periodoConta.periodo,
+      periodoConta.conta,
+      "True",
+      stateFiltros.filtrar_por_acao_CONCILIADO,
+      ordenacao && ordenacao.ordenar_por_numero_do_documento
+        ? ordenacao.ordenar_por_numero_do_documento
+        : "",
+      ordenacao && ordenacao.ordenar_por_data_especificacao
+        ? ordenacao.ordenar_por_data_especificacao
+        : "",
+      ordenacao && ordenacao.ordenar_por_valor
+        ? ordenacao.ordenar_por_valor
+        : "",
+      ordenacao && ordenacao.ordenar_por_imposto
+        ? ordenacao.ordenar_por_imposto
+        : ""
+    );
+    setTransacoesConciliadas(transacoes_conciliadas);
+    setLoadingConciliadas(false);
+  };
+
+  const handleTransacoesNaoConciliadas = async (ordenacao) => {
+    setLoadingNaoConciliadas(true);
+    let transacoes_nao_conciliadas = await getTransacoes(
+      periodoConta.periodo,
+      periodoConta.conta,
+      "False",
+      stateFiltros.filtrar_por_acao_NAO_CONCILIADO,
+      ordenacao && ordenacao.ordenar_por_numero_do_documento
+        ? ordenacao.ordenar_por_numero_do_documento
+        : "",
+      ordenacao && ordenacao.ordenar_por_data_especificacao
+        ? ordenacao.ordenar_por_data_especificacao
+        : "",
+      ordenacao && ordenacao.ordenar_por_valor
+        ? ordenacao.ordenar_por_valor
+        : "",
+      ordenacao && ordenacao.ordenar_por_imposto
+        ? ordenacao.ordenar_por_imposto
+        : ""
+    );
+    setTransacoesNaoConciliadas(transacoes_nao_conciliadas);
+    setLoadingNaoConciliadas(false);
+  };
+
+  const onHandleCancelarModalSalvarDataSaldoExtrato = () => {
+    setShowModalSalvarDataSaldoExtrato(false);
+    // window.location.assign('/dados-das-contas-da-associacao')
+  };
+
+  const justificativaObrigatoria = useMemo(
+    () =>
+      transacoesNaoConciliadas.length === 0 &&
+      valoresPendentes.saldo_posterior_total -
+        dataSaldoBancario.saldo_extrato !==
+        0,
+    [dataSaldoBancario, valoresPendentes, transacoesNaoConciliadas]
+  );
+
+  return (
+    <>
+      <div className="detalhe-das-prestacoes-container mb-5 mt-5">
+        <div className="row">
+          <div className="col-12 d-flex bd-highlight mt-4">
+            <div className="flex-grow-1 bd-highlight align-self-center detalhe-das-prestacoes-texto-cabecalho pl-0">
+              <h3>Conciliação Bancária</h3>
             </div>
-            {loading ? (
-                    <Loading
-                        corGrafico="black"
-                        corFonte="dark"
-                        marginTop="0"
-                        marginBottom="0"
-                    />
-                ) :
-                <>
-                    <SelectPeriodoConta
-                        periodoConta={periodoConta}
-                        handleChangePeriodoConta={handleChangePeriodoConta}
-                        periodosAssociacao={periodosAssociacao}
-                        contasAssociacao={contasAssociacao}
-                    />
 
-                    {periodoConta.periodo && periodoConta.conta ? (
-                        <>
-                            <TopoComBotoes
-                                contaConciliacao={contaConciliacao}
-                                periodoFechado={periodoFechado}
-                                origem={origem}
-                            />
-
-                            <TabelaValoresPendentesPorAcao
-                                valoresPendentes={valoresPendentes}
-                                valorTemplate={valorTemplate}
-                            />
-
-                            <DataSaldoBancario
-                                valoresPendentes={valoresPendentes}
-                                dataSaldoBancario={dataSaldoBancario}
-                                handleChangaDataSaldo={handleChangaDataSaldo}
-                                periodoFechado={periodoFechado}
-                                nomeComprovanteExtrato={nomeComprovanteExtrato}
-                                dataAtualizacaoComprovanteExtrato={dataAtualizacaoComprovanteExtratoView}
-                                exibeBtnDownload={exibeBtnDownload}
-                                msgErroExtensaoArquivo={msgErroExtensaoArquivo}
-                                changeUploadExtrato={changeUploadExtrato}
-                                reiniciaUploadExtrato={reiniciaUploadExtrato}
-                                downloadComprovanteExtrato={downloadComprovanteExtrato}
-                                salvarExtratoBancario={salvarExtratoBancario}
-                                btnSalvarExtratoBancarioDisable={btnSalvarExtratoBancarioDisable}
-                                setBtnSalvarExtratoBancarioDisable={setBtnSalvarExtratoBancarioDisable}
-                                classBtnSalvarExtratoBancario={classBtnSalvarExtratoBancario}
-                                setClassBtnSalvarExtratoBancario={setClassBtnSalvarExtratoBancario}
-                                checkSalvarExtratoBancario={checkSalvarExtratoBancario}
-                                setCheckSalvarExtratoBancario={setCheckSalvarExtratoBancario}
-                                erroDataSaldo={erroDataSaldo}
-                                permiteEditarCamposExtrato={permiteEditarCamposExtrato}
-                                pendenciaSaldoBancario={pendenciaSaldoBancario}
-                                dataSaldoBancarioSolicitacaoEncerramento={dataSaldoBancarioSolicitacaoEncerramento}
-                                setShowModalSalvarDataSaldoExtrato={setShowModalSalvarDataSaldoExtrato}
-                            />
-
-                            <p className="detalhe-das-prestacoes-titulo-lancamentos mt-3 mb-3">Gastos pendentes de conciliação</p>
-                            <FiltrosTransacoes
-                                conciliado='NAO_CONCILIADO'
-                                stateFiltros={stateFiltros}
-                                tabelasDespesa={tabelasDespesa}
-                                handleChangeFiltros={handleChangeFiltros}
-                                handleSubmitFiltros={handleTransacoesNaoConciliadas}
-                            />
-
-                            <TabelaTransacoes
-                                transacoes={transacoesNaoConciliadas}
-                                checkboxTransacoes={checkboxTransacoes}
-                                periodoFechado={periodoFechado}
-                                handleChangeCheckboxTransacoes={handleChangeCheckboxTransacoes}
-                                tabelasDespesa={tabelasDespesa}
-                                showModalLegendaInformacao={showModalLegendaInformacao}
-                                setShowModalLegendaInformacao={setShowModalLegendaInformacao}
-                                handleCallbackOrdernar={handleTransacoesNaoConciliadas}
-                                loading={loadingNaoConciliadas}
-                                emptyListComponent={<p className="mt-2"><strong>Não existem gastos não conciliados...</strong></p>}
-                            />                            
-
-                            <p className="detalhe-das-prestacoes-titulo-lancamentos mt-5 mb-3">Gastos conciliados</p>
-                            <FiltrosTransacoes
-                                conciliado='CONCILIADO'
-                                stateFiltros={stateFiltros}
-                                tabelasDespesa={tabelasDespesa}
-                                handleChangeFiltros={handleChangeFiltros}
-                                handleSubmitFiltros={handleTransacoesConciliadas}
-                            />
-
-                            <TabelaTransacoes
-                                transacoes={transacoesConciliadas}
-                                checkboxTransacoes={checkboxTransacoes}
-                                periodoFechado={periodoFechado}
-                                handleChangeCheckboxTransacoes={handleChangeCheckboxTransacoes}
-                                tabelasDespesa={tabelasDespesa}
-                                showModalLegendaInformacao={showModalLegendaInformacao}
-                                setShowModalLegendaInformacao={setShowModalLegendaInformacao}
-                                handleCallbackOrdernar={handleTransacoesConciliadas}
-                                loading={loadingConciliadas}
-                                emptyListComponent={<p className="mt-2"><strong>Não existem gastos conciliados...</strong></p>}
-                            />                            
-
-                            <Justificativa
-                                textareaJustificativa={textareaJustificativa}
-                                handleChangeTextareaJustificativa={handleChangeTextareaJustificativa}
-                                periodoFechado={periodoFechado}
-                                btnSalvarJustificativaDisable={btnSalvarJustificativaDisable}
-                                setBtnJustificativaSalvarDisable={setBtnSalvarJustificativaDisable}
-                                checkSalvarJustificativa={checkSalvarJustificativa}
-                                setCheckSalvarJustificativa={setCheckSalvarJustificativa}
-                                salvarJustificativa={salvarJustificativa}
-                                classBtnSalvarJustificativa={classBtnSalvarJustificativa}
-                                setClassBtnSalvarJustificativa={setClassBtnSalvarJustificativa}
-
-                            />
-                        </>
-                    ):
-                        <MsgImgCentralizada
-                            texto='Selecione um período e uma conta acima para visualizar os demonstrativos'
-                            img={Img404}
-                        />
-                    }
-                </>
-            }
+            {parametros &&
+              parametros.state &&
+              parametros.state &&
+              parametros.state &&
+              parametros.state.origem === "ir_para_conciliacao_bancaria" && (
+                <div className="bd-highlight detalhe-das-prestacoes-texto-cabecalho">
+                  <button
+                    className="btn btn-outline-success"
+                    onClick={() => {
+                      irParaAnaliseDre();
+                      navigate(
+                        `/consulta-detalhamento-analise-da-dre/${parametros.state.prestacaoDeContasUuid}/`,
+                        {
+                          state: {
+                            origem: "ir_para_conciliacao_bancaria",
+                            periodoFormatado:
+                              parametros &&
+                              parametros.state &&
+                              parametros.state.periodoFormatado
+                                ? parametros.state.periodoFormatado
+                                : "",
+                          },
+                        }
+                      );
+                    }}
+                  >
+                    Voltar para Análise DRE
+                  </button>
+                </div>
+              )}
+          </div>
         </div>
-
-        <section>
-            <ModalSalvarDataSaldoExtrato
-                show={showModalSalvarDataSaldoExtrato}
-                titulo="Salvar alterações."
-                texto='Os campos "data" e "saldo" foram alterados e podem não ser mais os mesmos cadastrados na solicitação de encerramento da conta. Confirma a alteração?'
-                segundoBotaoTexto="Confirmar"
-                segundoBotaoOnclick={salvarExtratoBancario}
-                segundoBotaoCss="success"
-                primeiroBotaoCss="outline-success"
-                primeiroBotaoTexto="Cancelar"
-                handleClose={onHandleCancelarModalSalvarDataSaldoExtrato}
-                primeiroBotaoOnclick={onHandleCancelarModalSalvarDataSaldoExtrato}
+        {loading ? (
+          <Loading
+            corGrafico="black"
+            corFonte="dark"
+            marginTop="0"
+            marginBottom="0"
+          />
+        ) : (
+          <>
+            <SelectPeriodoConta
+              periodoConta={periodoConta}
+              handleChangePeriodoConta={handleChangePeriodoConta}
+              periodosAssociacao={periodosAssociacao}
+              contasAssociacao={contasAssociacao}
             />
-        </section>
 
-        </>
-    )
+            {periodoConta.periodo && periodoConta.conta ? (
+              <>
+                <TopoComBotoes
+                  contaConciliacao={contaConciliacao}
+                  periodoFechado={periodoFechado}
+                  origem={origem}
+                />
+
+                <TabelaValoresPendentesPorAcao
+                  valoresPendentes={valoresPendentes}
+                  valorTemplate={valorTemplate}
+                />
+
+                <DataSaldoBancario
+                  valoresPendentes={valoresPendentes}
+                  dataSaldoBancario={dataSaldoBancario}
+                  handleChangaDataSaldo={handleChangaDataSaldo}
+                  periodoFechado={periodoFechado}
+                  nomeComprovanteExtrato={nomeComprovanteExtrato}
+                  dataAtualizacaoComprovanteExtrato={
+                    dataAtualizacaoComprovanteExtratoView
+                  }
+                  exibeBtnDownload={exibeBtnDownload}
+                  msgErroExtensaoArquivo={msgErroExtensaoArquivo}
+                  changeUploadExtrato={changeUploadExtrato}
+                  reiniciaUploadExtrato={reiniciaUploadExtrato}
+                  downloadComprovanteExtrato={downloadComprovanteExtrato}
+                  salvarExtratoBancario={salvarExtratoBancario}
+                  btnSalvarExtratoBancarioDisable={
+                    btnSalvarExtratoBancarioDisable
+                  }
+                  setBtnSalvarExtratoBancarioDisable={
+                    setBtnSalvarExtratoBancarioDisable
+                  }
+                  classBtnSalvarExtratoBancario={classBtnSalvarExtratoBancario}
+                  setClassBtnSalvarExtratoBancario={
+                    setClassBtnSalvarExtratoBancario
+                  }
+                  checkSalvarExtratoBancario={checkSalvarExtratoBancario}
+                  setCheckSalvarExtratoBancario={setCheckSalvarExtratoBancario}
+                  erroDataSaldo={erroDataSaldo}
+                  permiteEditarCamposExtrato={permiteEditarCamposExtrato}
+                  pendenciaSaldoBancario={pendenciaSaldoBancario}
+                  dataSaldoBancarioSolicitacaoEncerramento={
+                    dataSaldoBancarioSolicitacaoEncerramento
+                  }
+                  setShowModalSalvarDataSaldoExtrato={
+                    setShowModalSalvarDataSaldoExtrato
+                  }
+                />
+
+                <p className="detalhe-das-prestacoes-titulo-lancamentos mt-3 mb-3">
+                  Gastos pendentes de conciliação
+                </p>
+                <FiltrosTransacoes
+                  conciliado="NAO_CONCILIADO"
+                  stateFiltros={stateFiltros}
+                  tabelasDespesa={tabelasDespesa}
+                  handleChangeFiltros={handleChangeFiltros}
+                  handleSubmitFiltros={handleTransacoesNaoConciliadas}
+                />
+
+                <TabelaTransacoes
+                  transacoes={transacoesNaoConciliadas}
+                  checkboxTransacoes={checkboxTransacoes}
+                  periodoFechado={periodoFechado}
+                  handleChangeCheckboxTransacoes={
+                    handleChangeCheckboxTransacoes
+                  }
+                  tabelasDespesa={tabelasDespesa}
+                  showModalLegendaInformacao={showModalLegendaInformacao}
+                  setShowModalLegendaInformacao={setShowModalLegendaInformacao}
+                  handleCallbackOrdernar={handleTransacoesNaoConciliadas}
+                  loading={loadingNaoConciliadas}
+                  emptyListComponent={
+                    <p className="mt-2">
+                      <strong>Não existem gastos não conciliados...</strong>
+                    </p>
+                  }
+                />
+
+                <p className="detalhe-das-prestacoes-titulo-lancamentos mt-5 mb-3">
+                  Gastos conciliados
+                </p>
+                <FiltrosTransacoes
+                  conciliado="CONCILIADO"
+                  stateFiltros={stateFiltros}
+                  tabelasDespesa={tabelasDespesa}
+                  handleChangeFiltros={handleChangeFiltros}
+                  handleSubmitFiltros={handleTransacoesConciliadas}
+                />
+
+                <TabelaTransacoes
+                  transacoes={transacoesConciliadas}
+                  checkboxTransacoes={checkboxTransacoes}
+                  periodoFechado={periodoFechado}
+                  handleChangeCheckboxTransacoes={
+                    handleChangeCheckboxTransacoes
+                  }
+                  tabelasDespesa={tabelasDespesa}
+                  showModalLegendaInformacao={showModalLegendaInformacao}
+                  setShowModalLegendaInformacao={setShowModalLegendaInformacao}
+                  handleCallbackOrdernar={handleTransacoesConciliadas}
+                  loading={loadingConciliadas}
+                  emptyListComponent={
+                    <p className="mt-2">
+                      <strong>Não existem gastos conciliados...</strong>
+                    </p>
+                  }
+                />
+
+                <Justificativa
+                  justificativaObrigatoria={justificativaObrigatoria}
+                  textareaJustificativa={textareaJustificativa}
+                  handleChangeTextareaJustificativa={
+                    handleChangeTextareaJustificativa
+                  }
+                  periodoFechado={periodoFechado}
+                  btnSalvarJustificativaDisable={btnSalvarJustificativaDisable}
+                  setBtnJustificativaSalvarDisable={
+                    setBtnSalvarJustificativaDisable
+                  }
+                  checkSalvarJustificativa={checkSalvarJustificativa}
+                  setCheckSalvarJustificativa={setCheckSalvarJustificativa}
+                  salvarJustificativa={salvarJustificativa}
+                  classBtnSalvarJustificativa={classBtnSalvarJustificativa}
+                  setClassBtnSalvarJustificativa={
+                    setClassBtnSalvarJustificativa
+                  }
+                />
+              </>
+            ) : (
+              <MsgImgCentralizada
+                texto="Selecione um período e uma conta acima para visualizar os demonstrativos"
+                img={Img404}
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      <section>
+        <ModalSalvarDataSaldoExtrato
+          show={showModalSalvarDataSaldoExtrato}
+          titulo="Salvar alterações."
+          texto='Os campos "data" e "saldo" foram alterados e podem não ser mais os mesmos cadastrados na solicitação de encerramento da conta. Confirma a alteração?'
+          segundoBotaoTexto="Confirmar"
+          segundoBotaoOnclick={salvarExtratoBancario}
+          segundoBotaoCss="success"
+          primeiroBotaoCss="outline-success"
+          primeiroBotaoTexto="Cancelar"
+          handleClose={onHandleCancelarModalSalvarDataSaldoExtrato}
+          primeiroBotaoOnclick={onHandleCancelarModalSalvarDataSaldoExtrato}
+        />
+      </section>
+    </>
+  );
 };

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -1,965 +1,745 @@
-import React, {
-  useCallback,
-  useEffect,
-  useState,
-  useContext,
-  useMemo,
-} from "react";
-import { useLocation, useParams, useNavigate } from "react-router-dom";
+import React, {useCallback, useEffect, useState, useContext, useMemo} from "react";
+import {useLocation, useParams, useNavigate} from "react-router-dom";
 import moment from "moment";
-import { TopoComBotoes } from "./TopoComBotoes";
+import {TopoComBotoes} from "./TopoComBotoes";
 import TabelaValoresPendentesPorAcao from "./TabelaValoresPendentesPorAcao";
-import { Justificativa } from "./Justivicativa";
-import { getTabelasReceita } from "../../../../services/escolas/Receitas.service";
+import {Justificativa} from "./Justivicativa";
+import {getTabelasReceita} from "../../../../services/escolas/Receitas.service";
 import {
-  getConciliar,
-  getDesconciliar,
-  getObservacoes,
-  getStatusPeriodoPorData,
-  getTransacoes,
-  patchConciliarDespesa,
-  patchDesconciliarDespesa,
-  getDownloadExtratoBancario,
-  pathSalvarJustificativaPrestacaoDeConta,
-  pathExtratoBancarioPrestacaoDeConta,
+    getConciliar,
+    getDesconciliar,
+    getObservacoes,
+    getStatusPeriodoPorData,
+    getTransacoes,
+    patchConciliarDespesa,
+    patchDesconciliarDespesa,
+    getDownloadExtratoBancario,
+    pathSalvarJustificativaPrestacaoDeConta,
+    pathExtratoBancarioPrestacaoDeConta    
 } from "../../../../services/escolas/PrestacaoDeContas.service";
-import {
-  getContas,
-  getPeriodosDePrestacaoDeContasDaAssociacao,
-} from "../../../../services/escolas/Associacao.service";
+import {getContas, getPeriodosDePrestacaoDeContasDaAssociacao} from "../../../../services/escolas/Associacao.service";
 import Loading from "../../../../utils/Loading";
-import { SelectPeriodoConta } from "../SelectPeriodoConta";
-import { MsgImgCentralizada } from "../../../Globais/Mensagens/MsgImgCentralizada";
+import {SelectPeriodoConta} from "../SelectPeriodoConta";
+import {MsgImgCentralizada} from "../../../Globais/Mensagens/MsgImgCentralizada";
 import Img404 from "../../../../assets/img/img-404.svg";
-import { ASSOCIACAO_UUID } from "../../../../services/auth.service";
-import { tabelaValoresPendentes } from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
+import {ASSOCIACAO_UUID} from "../../../../services/auth.service";
+import {tabelaValoresPendentes} from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
 import DataSaldoBancario from "./DataSaldoBancario";
-import { trataNumericos } from "../../../../utils/ValidacoesAdicionaisFormularios";
+import {trataNumericos} from "../../../../utils/ValidacoesAdicionaisFormularios";
 import TabelaTransacoes from "./TabelaTransacoes";
-import { getDespesasTabelas } from "../../../../services/escolas/Despesas.service";
-import { FiltrosTransacoes } from "./FiltrosTransacoes";
+import {getDespesasTabelas} from "../../../../services/escolas/Despesas.service";
+import {FiltrosTransacoes} from "./FiltrosTransacoes";
 import { SidebarLeftService } from "../../../../services/SideBarLeft.service";
 import { SidebarContext } from "../../../../context/Sidebar";
-import { toastCustom } from "../../../Globais/ToastCustom";
+import {toastCustom} from "../../../Globais/ToastCustom";
 import { ModalSalvarDataSaldoExtrato } from "../ModalSalvarDataSaldoExtrato";
 
 export const DetalheDasPrestacoes = () => {
-  let { periodo_uuid, conta_uuid } = useParams();
-  const contextSideBar = useContext(SidebarContext);
-  const navigate = useNavigate();
-  const origem = new URLSearchParams(window.location.search).get("origem");
+    let {periodo_uuid, conta_uuid} = useParams();
+    const contextSideBar = useContext(SidebarContext);
+    const navigate = useNavigate();
+    const origem = (new URLSearchParams(window.location.search)).get("origem")
 
-  // Alteracoes
-  const [loading, setLoading] = useState(true);
-  const [loadingConciliadas, setLoadingConciliadas] = useState(true);
-  const [loadingNaoConciliadas, setLoadingNaoConciliadas] = useState(true);
+    // Alteracoes
+    const [loading, setLoading] = useState(true);
+    const [loadingConciliadas, setLoadingConciliadas] = useState(true);
+    const [loadingNaoConciliadas, setLoadingNaoConciliadas] = useState(true);
 
-  const [observacaoUuid, setObservacaoUuid] = useState("");
-  const [periodoConta, setPeriodoConta] = useState("");
-  const [periodoFechado, setPeriodoFechado] = useState(true);
-  const [permiteEditarCamposExtrato, setPermiteEditarCamposExtrato] =
-    useState(false);
-  const [contasAssociacao, setContasAssociacao] = useState(false);
-  const [periodosAssociacao, setPeriodosAssociacao] = useState(false);
-  const [contaConciliacao, setContaConciliacao] = useState("");
-  const [acaoLancamento, setAcaoLancamento] = useState("");
-  const [acoesAssociacao, setAcoesAssociacao] = useState(false);
+    const [observacaoUuid, setObservacaoUuid] = useState("");
+    const [periodoConta, setPeriodoConta] = useState("");
+    const [periodoFechado, setPeriodoFechado] = useState(true);
+    const [permiteEditarCamposExtrato, setPermiteEditarCamposExtrato] = useState(false);
+    const [contasAssociacao, setContasAssociacao] = useState(false);
+    const [periodosAssociacao, setPeriodosAssociacao] = useState(false);
+    const [contaConciliacao, setContaConciliacao] = useState("");
+    const [acaoLancamento, setAcaoLancamento] = useState("");
+    const [acoesAssociacao, setAcoesAssociacao] = useState(false);
 
-  const [textareaJustificativa, setTextareaJustificativa] = useState("");
-  const [btnSalvarJustificativaDisable, setBtnSalvarJustificativaDisable] =
-    useState(true);
-  const [classBtnSalvarJustificativa, setClassBtnSalvarJustificativa] =
-    useState("secondary");
-  const [checkSalvarJustificativa, setCheckSalvarJustificativa] =
-    useState(false);
+    const [textareaJustificativa, setTextareaJustificativa] = useState("");
+    const [btnSalvarJustificativaDisable, setBtnSalvarJustificativaDisable] = useState(true);
+    const [classBtnSalvarJustificativa, setClassBtnSalvarJustificativa] = useState("secondary");
+    const [checkSalvarJustificativa, setCheckSalvarJustificativa] = useState(false);
 
-  const [btnSalvarExtratoBancarioDisable, setBtnSalvarExtratoBancarioDisable] =
-    useState(true);
-  const [classBtnSalvarExtratoBancario, setClassBtnSalvarExtratoBancario] =
-    useState("secondary");
-  const [checkSalvarExtratoBancario, setCheckSalvarExtratoBancario] =
-    useState(false);
+    const [btnSalvarExtratoBancarioDisable, setBtnSalvarExtratoBancarioDisable] = useState(true);
+    const [classBtnSalvarExtratoBancario, setClassBtnSalvarExtratoBancario] = useState("secondary");
+    const [checkSalvarExtratoBancario, setCheckSalvarExtratoBancario] = useState(false);
 
-  const [showModalLegendaInformacao, setShowModalLegendaInformacao] =
-    useState(false);
-  const [pendenciaSaldoBancario, setPendenciaSaldoBancario] = useState(false);
-  const parametros = useLocation();
+    const [showModalLegendaInformacao, setShowModalLegendaInformacao] = useState(false);
+    const [pendenciaSaldoBancario, setPendenciaSaldoBancario] = useState(false);
+    const parametros = useLocation();
 
-  useEffect(() => {
-    getPeriodoConta();
-    getAcaoLancamento();
-    carregaTabelas();
-    carregaPeriodos();
-  }, []);
+    useEffect(()=>{
+        getPeriodoConta();
+        getAcaoLancamento();
+        carregaTabelas();
+        carregaPeriodos();
+    }, []);
 
-  useEffect(() => {
-    if (periodoConta) {
-      localStorage.setItem("periodoConta", JSON.stringify(periodoConta));
-      carregaContas();
-    }
-  }, [periodoConta]);
-
-  useEffect(() => {
-    if (periodoConta) {
-      carregaObservacoes();
-    }
-  }, [periodoConta, acoesAssociacao, acaoLancamento]);
-
-  useEffect(() => {
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-    if (periodoConta) {
-      verificaSePeriodoEstaAberto(periodoConta.periodo);
-    }
-  }, [periodoConta, periodosAssociacao]);
-
-  const getPeriodoConta = () => {
-    if (periodo_uuid) {
-      setPeriodoConta({
-        periodo: periodo_uuid,
-        conta: conta_uuid ? conta_uuid : "",
-      });
-    } else if (localStorage.getItem("periodoConta")) {
-      const periodoConta = JSON.parse(localStorage.getItem("periodoConta"));
-      setPeriodoConta(periodoConta);
-    } else {
-      setPeriodoConta({ periodo: "", conta: "" });
-    }
-  };
-
-  const getAcaoLancamento = () => {
-    let acao_lancamento = JSON.parse(localStorage.getItem("acaoLancamento"));
-    if (acao_lancamento) {
-      const files = JSON.parse(localStorage.getItem("acaoLancamento"));
-      setAcaoLancamento(files);
-    } else {
-      setAcaoLancamento({ acao: "", lancamento: "" });
-    }
-  };
-
-  const carregaTabelas = async () => {
-    await getTabelasReceita()
-      .then((response) => {
-        setAcoesAssociacao(response.data.acoes_associacao);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  };
-
-  const carregaPeriodos = async () => {
-    let ignorar_devolvidas = false;
-    let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao(
-      ignorar_devolvidas
-    );
-    setPeriodosAssociacao(periodos);
-  };
-
-  const carregaContas = async () => {
-    setLoading(true);
-    let period_uuid = periodoConta ? periodoConta.periodo : "";
-    await getContas(period_uuid)
-      .then((response) => {
-        setContasAssociacao(response);
-        const files = JSON.parse(localStorage.getItem("periodoConta"));
-        if (files && files.conta !== "") {
-          const conta = response.find((conta) => conta.uuid === files.conta);
-          setContaConciliacao(conta.tipo_conta.nome);
+    useEffect(() => {
+        if(periodoConta) {
+            localStorage.setItem('periodoConta', JSON.stringify(periodoConta));
+            carregaContas();
         }
-      })
-      .catch((error) => {
-        console.log(error);
-      })
-      .finally(() => setLoading(false));
-  };
+    }, [periodoConta]);
 
-  const conciliar = useCallback(
-    async (rateio_uuid) => {
-      await getConciliar(rateio_uuid, periodoConta.periodo);
-    },
-    [periodoConta.periodo]
-  );
+    useEffect(()=>{
+        if(periodoConta) {
+            carregaObservacoes();
+        }
+    }, [periodoConta, acoesAssociacao, acaoLancamento]);
 
-  const desconciliar = useCallback(
-    async (rateio_uuid) => {
-      await getDesconciliar(rateio_uuid, periodoConta.periodo);
-    },
-    [periodoConta.periodo]
-  );
+    useEffect(()=>{
+        setLoading(false)
+    }, []);
 
-  const handleChangePeriodoConta = (name, value, periodoOuConta) => {
-    setCheckSalvarJustificativa(false);
-    setCheckSalvarExtratoBancario(false);
-    setBtnSalvarExtratoBancarioDisable(true);
-    setExibeBtnDownload(false);
+    useEffect(() => {
+        if(periodoConta) {
+            verificaSePeriodoEstaAberto(periodoConta.periodo);
+        }
+    }, [periodoConta, periodosAssociacao]);
 
-    if (periodoOuConta === "periodo") {
-      setPeriodoConta({
-        conta: "",
-        [name]: value,
-      });
-    } else {
-      setPeriodoConta({
-        ...periodoConta,
-        [name]: value,
-      });
-    }
-  };
+    const getPeriodoConta = () => {
+        if(periodo_uuid){
+            setPeriodoConta({periodo: periodo_uuid, conta: conta_uuid ? conta_uuid : ""});
+        } else if (localStorage.getItem('periodoConta')) {
+            const periodoConta = JSON.parse(localStorage.getItem('periodoConta'));
+            setPeriodoConta(periodoConta)
+        } else {
+            setPeriodoConta({periodo: "", conta: ""})
+        }
+    };
 
-  const handleChangeTextareaJustificativa = (event) => {
-    setTextareaJustificativa(event.target.value);
-    setBtnSalvarJustificativaDisable(false);
-    setCheckSalvarJustificativa(false);
-    setClassBtnSalvarJustificativa("success");
-  };
+    const getAcaoLancamento = () => {
+        let acao_lancamento = JSON.parse(localStorage.getItem('acaoLancamento'));
+        if (acao_lancamento) {
+            const files = JSON.parse(localStorage.getItem('acaoLancamento'));
+            setAcaoLancamento(files);
+        } else {
+            setAcaoLancamento({acao: "", lancamento: ""})
+        }
+    };
 
-  const parseLocalDate = (dateStr) => {
-    if (!dateStr) return null;
-    const [year, month, day] = dateStr.split("-").map(Number);
-    return new Date(year, month - 1, day);
-  };
+    const carregaTabelas = async () => {
+        await getTabelasReceita().then(response => {
+            setAcoesAssociacao(response.data.acoes_associacao);
+        }).catch(error => {
+            console.log(error);
+        });
+    };
 
-  const carregaObservacoes = async () => {
-    if (periodosAssociacao && periodoConta.periodo && periodoConta.conta) {
-      const periodo_uuid = periodoConta.periodo;
-      const conta_uuid = periodoConta.conta;
-      const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
+    const carregaPeriodos = async () => {
+        let ignorar_devolvidas = false
+        let periodos = await getPeriodosDePrestacaoDeContasDaAssociacao(ignorar_devolvidas);
+        setPeriodosAssociacao(periodos);
+    };
 
-      const periodo = periodosAssociacao.find((o) => o.uuid === periodo_uuid);
-
-      const observacao = await getObservacoes(
-        periodo_uuid,
-        conta_uuid,
-        associacaoUuid
-      );
-
-      if (observacao) {
-        setPermiteEditarCamposExtrato(observacao.permite_editar_campos_extrato);
-      }
-
-      if (observacao && observacao.possui_solicitacao_encerramento) {
-        const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
-
-        await getStatusPeriodoPorData(
-          associacaoUuid,
-          periodo.data_inicio_realizacao_despesas
-        )
-          .then((response) => {
-            const periodo_bloqueado = response.prestacao_contas_status
-              ? response.prestacao_contas_status.periodo_bloqueado
-              : true;
-            if (!periodo_bloqueado) {
-              setBtnSalvarExtratoBancarioDisable(false);
-              setCheckSalvarExtratoBancario(false);
-              setClassBtnSalvarExtratoBancario("success");
+    const carregaContas = async () => {
+        setLoading(true);
+        let period_uuid = periodoConta ? periodoConta.periodo : '';
+        await getContas(period_uuid).then(response => {
+            setContasAssociacao(response);
+            const files = JSON.parse(localStorage.getItem('periodoConta'));
+            if (files && files.conta !== "") {
+                const conta = response.find(conta => conta.uuid === files.conta);
+                setContaConciliacao(conta.tipo_conta.nome);
             }
-          })
-          .catch((error) => {
+        }).catch(error => {
             console.log(error);
-          });
+        }).finally(() => setLoading(false))
+    };
+
+    const conciliar = useCallback(async (rateio_uuid) => {
+        await getConciliar(rateio_uuid, periodoConta.periodo);
+    }, [periodoConta.periodo]) ;
+
+    const desconciliar = useCallback(async (rateio_uuid) => {
+        await getDesconciliar(rateio_uuid, periodoConta.periodo);
+    }, [periodoConta.periodo]) ;
+
+
+    const handleChangePeriodoConta = (name, value, periodoOuConta) => {
+        setCheckSalvarJustificativa(false);
+        setCheckSalvarExtratoBancario(false);
+        setBtnSalvarExtratoBancarioDisable(true);
+        setExibeBtnDownload(false);
+
+        if(periodoOuConta === 'periodo') {
+            setPeriodoConta({
+                conta: '',
+                [name]: value
+            });
+        } else {
+            setPeriodoConta({
+                ...periodoConta,
+                [name]: value
+            });
+        } 
+    };
+
+    const handleChangeTextareaJustificativa = (event) => {
+        setTextareaJustificativa(event.target.value);
+        setBtnSalvarJustificativaDisable(false);
+        setCheckSalvarJustificativa(false);
+        setClassBtnSalvarJustificativa("success");
+    };
+
+    const parseLocalDate = (dateStr) => {
+        if (!dateStr) return null;
+        const [year, month, day] = dateStr.split('-').map(Number);
+        return new Date(year, month - 1, day);
+    };
+
+    const carregaObservacoes = async () => {
+        if (periodosAssociacao && periodoConta.periodo && periodoConta.conta) {
+            const periodo_uuid = periodoConta.periodo;
+            const conta_uuid = periodoConta.conta;
+            const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
+
+            const periodo = periodosAssociacao.find(o => o.uuid === periodo_uuid);
+
+            const observacao = await getObservacoes(periodo_uuid, conta_uuid, associacaoUuid);
+
+            if(observacao) {
+                setPermiteEditarCamposExtrato(observacao.permite_editar_campos_extrato)
+            }
+
+            if(observacao && observacao.possui_solicitacao_encerramento){
+                const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
+                
+                await getStatusPeriodoPorData(associacaoUuid, periodo.data_inicio_realizacao_despesas).then(response => {
+                    
+                    const periodo_bloqueado = response.prestacao_contas_status ? response.prestacao_contas_status.periodo_bloqueado : true
+                    if(!periodo_bloqueado){
+                        setBtnSalvarExtratoBancarioDisable(false);
+                        setCheckSalvarExtratoBancario(false);
+                        setClassBtnSalvarExtratoBancario("success");
+                    }
+                }).catch(error => {
+                    console.log(error);
+                });
+                
+                setDataSaldoBancario({
+                    data_extrato: observacao.data_extrato ? parseLocalDate(observacao.data_extrato) : null,
+                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : null,
+                })
+
+                setDataSaldoBancarioSolicitacaoEncerramento({
+                    data_extrato: observacao.data_extrato ? observacao.data_extrato : '',
+                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
+                    possui_solicitacao_encerramento: true,
+                    data_encerramento: observacao.data_encerramento ? observacao.data_encerramento : '',
+                    saldo_encerramento: observacao.saldo_encerramento ? observacao.saldo_encerramento : 0,
+                })
+
+                if(observacao.observacao_uuid){
+                    setObservacaoUuid(observacao.observacao_uuid)
+
+                    setTextareaJustificativa(observacao.observacao ? observacao.observacao : '');
+
+                    setNomeComprovanteExtrato(observacao.comprovante_extrato ? observacao.comprovante_extrato : '')
+                    setDataAtualizacaoComprovanteExtrato(moment(observacao.data_atualizacao_comprovante_extrato).format("YYYY-MM-DD HH:mm:ss"))
+                    setDataAtualizacaoComprovanteExtratoView(moment(observacao.data_atualizacao_comprovante_extrato).format("DD/MM/YYYY HH:mm:ss"))
+                    if (observacao.comprovante_extrato && observacao.data_extrato){
+                        setExibeBtnDownload(true)
+                    }
+                    else if(!observacao.comprovante_extrato){
+                        setExibeBtnDownload(false)
+                    }
+                }
+            }
+            else{
+                setObservacaoUuid(observacao.observacao_uuid)
+
+                setTextareaJustificativa(observacao.observacao ? observacao.observacao : '');
+                setDataSaldoBancario({
+                    data_extrato: observacao.data_extrato ? parseLocalDate(observacao.data_extrato) : null,
+                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : null,
+                })
+                setNomeComprovanteExtrato(observacao.comprovante_extrato ? observacao.comprovante_extrato : '')
+                setDataAtualizacaoComprovanteExtrato(moment(observacao.data_atualizacao_comprovante_extrato).format("YYYY-MM-DD HH:mm:ss"))
+                setDataAtualizacaoComprovanteExtratoView(moment(observacao.data_atualizacao_comprovante_extrato).format("DD/MM/YYYY HH:mm:ss"))
+                if (observacao.comprovante_extrato && observacao.data_extrato){
+                    setExibeBtnDownload(true)
+                }
+                else if(!observacao.comprovante_extrato){
+                    setExibeBtnDownload(false)
+                }
+
+                setDataSaldoBancarioSolicitacaoEncerramento({})
+            }
+        }
+    };
+
+    const salvarJustificativa = async () => {
+        let payload;
+
+        payload = {
+            "periodo_uuid": periodoConta.periodo,
+            "conta_associacao_uuid": periodoConta.conta,
+            "observacao": textareaJustificativa,
+        }
+
+        try {
+            await pathSalvarJustificativaPrestacaoDeConta(payload);
+            toastCustom.ToastCustomSuccess('Edição salva', 'A edição foi salva com sucesso!')
+            await carregaObservacoes();
+        } catch (e) {
+            console.log("Erro: ", e.message)
+        }
+    }
+
+    const salvarExtratoBancario = async () => {
+        setBtnSalvarExtratoBancarioDisable(true);
+        setCheckSalvarExtratoBancario(true);
+        setClassBtnSalvarExtratoBancario("secondary");
+
+        let payload;
+
+        payload = {
+            "periodo_uuid": periodoConta.periodo,
+            "conta_associacao_uuid": periodoConta.conta,
+            "data_extrato": dataSaldoBancario.data_extrato ? moment(dataSaldoBancario.data_extrato, "YYYY-MM-DD").format("YYYY-MM-DD"): null,
+            "saldo_extrato": dataSaldoBancario.saldo_extrato ? trataNumericos(dataSaldoBancario.saldo_extrato) : 0,
+            "comprovante_extrato": selectedFile,
+            "data_atualizacao_comprovante_extrato": dataAtualizacaoComprovanteExtrato ? moment(dataAtualizacaoComprovanteExtrato, "YYYY-MM-DD HH:mm:ss").format("YYYY-MM-DD HH:mm:ss"): null,
+        }
+
+        try {
+            await pathExtratoBancarioPrestacaoDeConta(payload);
+            setShowModalSalvarDataSaldoExtrato(false);
+            verificaSePeriodoEstaAberto(periodoConta.periodo);
+            toastCustom.ToastCustomSuccess('Edição salva', 'A edição foi salva com sucesso!')
+            setDataAtualizacaoComprovanteExtrato('')
+            setDataAtualizacaoComprovanteExtratoView('')
+            setSelectedFile(null)
+            setMsgErroExtensaoArquivo('')
+            await carregaObservacoes();
+        } catch (e) {
+            console.log("Erro: ", e.message)
+        }
+    }
+    const checaPendenciaSaldoBancario =  (statusPeriodo) => {
+        const pendenciaCadastral = statusPeriodo.pendencias_cadastrais;
+        const contaPendente = pendenciaCadastral?.conciliacao_bancaria?.contas_pendentes?.includes(periodoConta.conta);
+
+        setPendenciaSaldoBancario(contaPendente ? true : false);
+    };
+
+    const verificaSePeriodoEstaAberto = async (periodoUuid) => {
+        if (periodosAssociacao) {
+            const periodo = periodosAssociacao.find(o => o.uuid === periodoUuid);
+            if (periodo) {
+                const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID)
+                await getStatusPeriodoPorData(associacaoUuid, periodo.data_inicio_realizacao_despesas).then(response => {
+                    checaPendenciaSaldoBancario(response);
+                    const periodoBloqueado = response.prestacao_contas_status ? response.prestacao_contas_status.periodo_bloqueado : true
+                    setPeriodoFechado(periodoBloqueado)
+                }).catch(error => {
+                    console.log(error);
+                });
+            }
+        }
+    };
+
+    // Tabela Valores Pendentes por Ação
+    const [valoresPendentes, setValoresPendentes] = useState({});
+
+    const carregaValoresPendentes = useCallback(async ()=>{
+        let valores_pendentes = await tabelaValoresPendentes(periodoConta.periodo, periodoConta.conta);
+        setValoresPendentes(valores_pendentes)
+    }, [periodoConta.periodo, periodoConta.conta]);
+
+    useEffect(()=>{
+        if (periodoConta.periodo && periodoConta.conta){
+            carregaValoresPendentes()
+        }
+
+    }, [periodoConta.periodo, periodoConta.conta, carregaValoresPendentes]);
+
+    const valorTemplate = (valor) => {
+        let valor_formatado = Number(valor).toLocaleString('pt-BR', {
+            style: 'currency',
+            currency: 'BRL'
+        });
+        valor_formatado = valor_formatado.replace(/R/, "").replace(/\$/, "");
+        return valor_formatado
+    };
+
+    // Transacoes Conciliadas e Não Conciliadas
+    const [transacoesConciliadas, setTransacoesConciliadas] = useState([]);
+    const [transacoesNaoConciliadas, setTransacoesNaoConciliadas] = useState([]);
+    const [checkboxTransacoes, setCheckboxTransacoes] = useState(false);
+    const [tabelasDespesa, setTabelasDespesa] = useState([]);
+
+    const carregaTransacoes = useCallback(async ()=>{
+        setLoading(true)
+        if (periodoConta.periodo && periodoConta.conta){
+            handleTransacoesConciliadas();
+            handleTransacoesNaoConciliadas();
+        }
+        setLoading(false)
+    }, [periodoConta]);
+
+    useEffect(()=>{
+        carregaTransacoes();
+    }, [carregaTransacoes]);
+
+    useEffect(() => {
+        const carregaTabelasDespesa = async () => {
+            const resp = await getDespesasTabelas();
+            setTabelasDespesa(resp);
+        };
+        carregaTabelasDespesa();
+    }, []);
+
+
+    const handleChangeCheckboxTransacoes = useCallback(async (event, transacao_ou_rateio_uuid, documento_mestre=null, tipo_transacao) => {
+
+        setCheckboxTransacoes(event.target.checked);
+        if (event.target.checked) {
+            if (!documento_mestre){
+                await conciliar(transacao_ou_rateio_uuid);
+            }else {
+                await patchConciliarDespesa(periodoConta.periodo, periodoConta.conta, transacao_ou_rateio_uuid)
+            }
+        } else if (!event.target.checked) {
+            if (!documento_mestre){
+                await desconciliar(transacao_ou_rateio_uuid)
+            }else {
+                await patchDesconciliarDespesa(periodoConta.conta, transacao_ou_rateio_uuid)
+            }
+        }
+        await carregaTransacoes()
+        await carregaValoresPendentes()
+
+    }, [periodoConta, carregaTransacoes, conciliar, desconciliar, carregaValoresPendentes]);
+
+    // Filtros Transacoes
+    const [stateFiltros, setStateFiltros] = useState({});
+
+    const handleChangeFiltros = useCallback((name, value) => {
+        setStateFiltros({
+            ...stateFiltros,
+            [name]: value
+        });
+    }, [stateFiltros]);
+
+    // Data Saldo Bancário
+    const [dataSaldoBancario, setDataSaldoBancario]= useState({});
+    const [dataSaldoBancarioSolicitacaoEncerramento, setDataSaldoBancarioSolicitacaoEncerramento]= useState({});
+    const [showModalSalvarDataSaldoExtrato, setShowModalSalvarDataSaldoExtrato] = useState(false)
+    const [selectedFile, setSelectedFile] = useState(null);
+    const [nomeComprovanteExtrato, setNomeComprovanteExtrato] = useState('');
+    const [dataAtualizacaoComprovanteExtrato, setDataAtualizacaoComprovanteExtrato] = useState('');
+    const [dataAtualizacaoComprovanteExtratoView, setDataAtualizacaoComprovanteExtratoView] = useState('');
+    const [exibeBtnDownload, setExibeBtnDownload] = useState(false);
+    const [msgErroExtensaoArquivo, setMsgErroExtensaoArquivo] = useState('');
+
+    const validaUploadExtrato = (event) =>{
+        let ext = event.file.type
+        let tamanho = event.file.size
+        let array_extensoes = ['image/jpeg','image/jpg','image/bmp','image/png', 'image/tif', 'application/pdf' ]
+        if (tamanho <= 500395){
+            let result = array_extensoes.filter(item => ext.indexOf(item) > -1);
+            if (result <=0){
+                setMsgErroExtensaoArquivo(`A extensão ${ext} não é permitida, tente novamente`)
+                return false
+            }else {
+                setMsgErroExtensaoArquivo('')
+                return true
+            }
+        }else {
+            setMsgErroExtensaoArquivo('O tamanho do arquivo excede o limite de 500kb, tente novamente.')
+            return false
+        }
+    }
+
+    const changeUploadExtrato = (event) => {
+        if (validaUploadExtrato(event)){
+            setBtnSalvarExtratoBancarioDisable(false);
+            setCheckSalvarExtratoBancario(false);
+            setClassBtnSalvarExtratoBancario("success");
+            setSelectedFile(event.file);
+            setNomeComprovanteExtrato(event.file.name)
+            setDataAtualizacaoComprovanteExtrato(moment().format("YYYY-MM-DD HH:mm:ss"))
+            setDataAtualizacaoComprovanteExtratoView(moment().format("DD/MM/YYYY HH:mm:ss"))
+            setExibeBtnDownload(false)
+            setMsgErroExtensaoArquivo('')
+        }else {
+            reiniciaUploadExtrato()
+        }
+    };
+
+    const reiniciaUploadExtrato =()=>{
+
+        if(nomeComprovanteExtrato !== ""){
+            setBtnSalvarExtratoBancarioDisable(false);
+            setCheckSalvarExtratoBancario(false);
+            setClassBtnSalvarExtratoBancario("success");
+        }
+
+        setSelectedFile(null)
+        setDataAtualizacaoComprovanteExtrato('')
+        setDataAtualizacaoComprovanteExtratoView('')
+        setExibeBtnDownload(false)
+        setNomeComprovanteExtrato('')
+    }
+
+    const downloadComprovanteExtrato = useCallback(async ()=>{
+        try {
+            await getDownloadExtratoBancario(nomeComprovanteExtrato, observacaoUuid);
+            console.log("Download efetuado com sucesso");
+        }catch (e) {
+            console.log("Erro ao efetuar o download ", e.response);
+        }
+    }, [nomeComprovanteExtrato, observacaoUuid])
+
+    const [erroDataSaldo, setErroDataSaldo] = useState('')
+
+    const handleChangaDataSaldo = useCallback((name, value) => {
+        if (name === 'data_extrato'){
+            let hoje = moment(new Date());
+            let data_digitada = moment(value);
+            if (data_digitada > hoje){
+                setErroDataSaldo("Data do crédito não pode ser maior que a data de hoje")
+                setDataSaldoBancario(prevState => ({ ...prevState,  [name]: ''}));
+                return
+            }else {
+                setErroDataSaldo('')
+            }
+        }
+
+        setBtnSalvarExtratoBancarioDisable(false);
+        setCheckSalvarExtratoBancario(false);
+        setClassBtnSalvarExtratoBancario("success");
 
         setDataSaldoBancario({
-          data_extrato: observacao.data_extrato
-            ? parseLocalDate(observacao.data_extrato)
-            : null,
-          saldo_extrato: observacao.saldo_extrato
-            ? observacao.saldo_extrato
-            : null,
+            ...dataSaldoBancario,
+            [name]: value
         });
+    }, [dataSaldoBancario]);
 
-        setDataSaldoBancarioSolicitacaoEncerramento({
-          data_extrato: observacao.data_extrato ? observacao.data_extrato : "",
-          saldo_extrato: observacao.saldo_extrato
-            ? observacao.saldo_extrato
-            : 0,
-          possui_solicitacao_encerramento: true,
-          data_encerramento: observacao.data_encerramento
-            ? observacao.data_encerramento
-            : "",
-          saldo_encerramento: observacao.saldo_encerramento
-            ? observacao.saldo_encerramento
-            : 0,
-        });
+    const irParaAnaliseDre = async() => {
+        // Ao setar para false, quando a função a seguir setar o click do item do menu
+        // a pagina não ira automaticamente para a url do item
 
-        if (observacao.observacao_uuid) {
-          setObservacaoUuid(observacao.observacao_uuid);
+        await contextSideBar.setIrParaUrl(false)
+        SidebarLeftService.setItemActive("analise_dre")
 
-          setTextareaJustificativa(
-            observacao.observacao ? observacao.observacao : ""
-          );
-
-          setNomeComprovanteExtrato(
-            observacao.comprovante_extrato ? observacao.comprovante_extrato : ""
-          );
-          setDataAtualizacaoComprovanteExtrato(
-            moment(observacao.data_atualizacao_comprovante_extrato).format(
-              "YYYY-MM-DD HH:mm:ss"
-            )
-          );
-          setDataAtualizacaoComprovanteExtratoView(
-            moment(observacao.data_atualizacao_comprovante_extrato).format(
-              "DD/MM/YYYY HH:mm:ss"
-            )
-          );
-          if (observacao.comprovante_extrato && observacao.data_extrato) {
-            setExibeBtnDownload(true);
-          } else if (!observacao.comprovante_extrato) {
-            setExibeBtnDownload(false);
-          }
-        }
-      } else {
-        setObservacaoUuid(observacao.observacao_uuid);
-
-        setTextareaJustificativa(
-          observacao.observacao ? observacao.observacao : ""
-        );
-        setDataSaldoBancario({
-          data_extrato: observacao.data_extrato
-            ? parseLocalDate(observacao.data_extrato)
-            : null,
-          saldo_extrato: observacao.saldo_extrato
-            ? observacao.saldo_extrato
-            : null,
-        });
-        setNomeComprovanteExtrato(
-          observacao.comprovante_extrato ? observacao.comprovante_extrato : ""
-        );
-        setDataAtualizacaoComprovanteExtrato(
-          moment(observacao.data_atualizacao_comprovante_extrato).format(
-            "YYYY-MM-DD HH:mm:ss"
-          )
-        );
-        setDataAtualizacaoComprovanteExtratoView(
-          moment(observacao.data_atualizacao_comprovante_extrato).format(
-            "DD/MM/YYYY HH:mm:ss"
-          )
-        );
-        if (observacao.comprovante_extrato && observacao.data_extrato) {
-          setExibeBtnDownload(true);
-        } else if (!observacao.comprovante_extrato) {
-          setExibeBtnDownload(false);
-        }
-
-        setDataSaldoBancarioSolicitacaoEncerramento({});
-      }
+        // Necessário voltar o estado para true, para clicks nos itens do menu continuarem funcionando corretamente
+        contextSideBar.setIrParaUrl(true)
     }
-  };
-
-  const salvarJustificativa = async () => {
-    let payload;
-
-    payload = {
-      periodo_uuid: periodoConta.periodo,
-      conta_associacao_uuid: periodoConta.conta,
-      observacao: textareaJustificativa,
+    
+    const handleTransacoesConciliadas = async (ordenacao) => {
+        setLoadingConciliadas(true);
+        let transacoes_conciliadas = await getTransacoes(
+            periodoConta.periodo, 
+            periodoConta.conta, 
+            'True',
+            stateFiltros.filtrar_por_acao_CONCILIADO, 
+            ordenacao && ordenacao.ordenar_por_numero_do_documento ? ordenacao.ordenar_por_numero_do_documento : '',
+            ordenacao && ordenacao.ordenar_por_data_especificacao ? ordenacao.ordenar_por_data_especificacao : '',
+            ordenacao && ordenacao.ordenar_por_valor ? ordenacao.ordenar_por_valor : '',
+            ordenacao && ordenacao.ordenar_por_imposto ? ordenacao.ordenar_por_imposto : '',
+        );
+        setTransacoesConciliadas(transacoes_conciliadas);
+        setLoadingConciliadas(false);
     };
 
-    try {
-      await pathSalvarJustificativaPrestacaoDeConta(payload);
-      toastCustom.ToastCustomSuccess(
-        "Edição salva",
-        "A edição foi salva com sucesso!"
-      );
-      await carregaObservacoes();
-    } catch (e) {
-      console.log("Erro: ", e.message);
-    }
-  };
-
-  const salvarExtratoBancario = async () => {
-    setBtnSalvarExtratoBancarioDisable(true);
-    setCheckSalvarExtratoBancario(true);
-    setClassBtnSalvarExtratoBancario("secondary");
-
-    let payload;
-
-    payload = {
-      periodo_uuid: periodoConta.periodo,
-      conta_associacao_uuid: periodoConta.conta,
-      data_extrato: dataSaldoBancario.data_extrato
-        ? moment(dataSaldoBancario.data_extrato, "YYYY-MM-DD").format(
-            "YYYY-MM-DD"
-          )
-        : null,
-      saldo_extrato: dataSaldoBancario.saldo_extrato
-        ? trataNumericos(dataSaldoBancario.saldo_extrato)
-        : 0,
-      comprovante_extrato: selectedFile,
-      data_atualizacao_comprovante_extrato: dataAtualizacaoComprovanteExtrato
-        ? moment(
-            dataAtualizacaoComprovanteExtrato,
-            "YYYY-MM-DD HH:mm:ss"
-          ).format("YYYY-MM-DD HH:mm:ss")
-        : null,
-    };
-
-    try {
-      await pathExtratoBancarioPrestacaoDeConta(payload);
-      setShowModalSalvarDataSaldoExtrato(false);
-      verificaSePeriodoEstaAberto(periodoConta.periodo);
-      toastCustom.ToastCustomSuccess(
-        "Edição salva",
-        "A edição foi salva com sucesso!"
-      );
-      setDataAtualizacaoComprovanteExtrato("");
-      setDataAtualizacaoComprovanteExtratoView("");
-      setSelectedFile(null);
-      setMsgErroExtensaoArquivo("");
-      await carregaObservacoes();
-    } catch (e) {
-      console.log("Erro: ", e.message);
-    }
-  };
-  const checaPendenciaSaldoBancario = (statusPeriodo) => {
-    const pendenciaCadastral = statusPeriodo.pendencias_cadastrais;
-    const contaPendente =
-      pendenciaCadastral?.conciliacao_bancaria?.contas_pendentes?.includes(
-        periodoConta.conta
-      );
-
-    setPendenciaSaldoBancario(contaPendente ? true : false);
-  };
-
-  const verificaSePeriodoEstaAberto = async (periodoUuid) => {
-    if (periodosAssociacao) {
-      const periodo = periodosAssociacao.find((o) => o.uuid === periodoUuid);
-      if (periodo) {
-        const associacaoUuid = localStorage.getItem(ASSOCIACAO_UUID);
-        await getStatusPeriodoPorData(
-          associacaoUuid,
-          periodo.data_inicio_realizacao_despesas
-        )
-          .then((response) => {
-            checaPendenciaSaldoBancario(response);
-            const periodoBloqueado = response.prestacao_contas_status
-              ? response.prestacao_contas_status.periodo_bloqueado
-              : true;
-            setPeriodoFechado(periodoBloqueado);
-          })
-          .catch((error) => {
-            console.log(error);
-          });
-      }
-    }
-  };
-
-  // Tabela Valores Pendentes por Ação
-  const [valoresPendentes, setValoresPendentes] = useState({});
-
-  const carregaValoresPendentes = useCallback(async () => {
-    let valores_pendentes = await tabelaValoresPendentes(
-      periodoConta.periodo,
-      periodoConta.conta
-    );
-    setValoresPendentes(valores_pendentes);
-  }, [periodoConta.periodo, periodoConta.conta]);
-
-  useEffect(() => {
-    if (periodoConta.periodo && periodoConta.conta) {
-      carregaValoresPendentes();
-    }
-  }, [periodoConta.periodo, periodoConta.conta, carregaValoresPendentes]);
-
-  const valorTemplate = (valor) => {
-    let valor_formatado = Number(valor).toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
-    valor_formatado = valor_formatado.replace(/R/, "").replace(/\$/, "");
-    return valor_formatado;
-  };
-
-  // Transacoes Conciliadas e Não Conciliadas
-  const [transacoesConciliadas, setTransacoesConciliadas] = useState([]);
-  const [transacoesNaoConciliadas, setTransacoesNaoConciliadas] = useState([]);
-  const [checkboxTransacoes, setCheckboxTransacoes] = useState(false);
-  const [tabelasDespesa, setTabelasDespesa] = useState([]);
-
-  const carregaTransacoes = useCallback(async () => {
-    setLoading(true);
-    if (periodoConta.periodo && periodoConta.conta) {
-      handleTransacoesConciliadas();
-      handleTransacoesNaoConciliadas();
-    }
-    setLoading(false);
-  }, [periodoConta]);
-
-  useEffect(() => {
-    carregaTransacoes();
-  }, [carregaTransacoes]);
-
-  useEffect(() => {
-    const carregaTabelasDespesa = async () => {
-      const resp = await getDespesasTabelas();
-      setTabelasDespesa(resp);
-    };
-    carregaTabelasDespesa();
-  }, []);
-
-  const handleChangeCheckboxTransacoes = useCallback(
-    async (
-      event,
-      transacao_ou_rateio_uuid,
-      documento_mestre = null,
-      tipo_transacao
-    ) => {
-      setCheckboxTransacoes(event.target.checked);
-      if (event.target.checked) {
-        if (!documento_mestre) {
-          await conciliar(transacao_ou_rateio_uuid);
-        } else {
-          await patchConciliarDespesa(
-            periodoConta.periodo,
-            periodoConta.conta,
-            transacao_ou_rateio_uuid
-          );
-        }
-      } else if (!event.target.checked) {
-        if (!documento_mestre) {
-          await desconciliar(transacao_ou_rateio_uuid);
-        } else {
-          await patchDesconciliarDespesa(
-            periodoConta.conta,
-            transacao_ou_rateio_uuid
-          );
-        }
-      }
-      await carregaTransacoes();
-      await carregaValoresPendentes();
-    },
-    [
-      periodoConta,
-      carregaTransacoes,
-      conciliar,
-      desconciliar,
-      carregaValoresPendentes,
-    ]
-  );
-
-  // Filtros Transacoes
-  const [stateFiltros, setStateFiltros] = useState({});
-
-  const handleChangeFiltros = useCallback(
-    (name, value) => {
-      setStateFiltros({
-        ...stateFiltros,
-        [name]: value,
-      });
-    },
-    [stateFiltros]
-  );
-
-  // Data Saldo Bancário
-  const [dataSaldoBancario, setDataSaldoBancario] = useState({});
-  const [
-    dataSaldoBancarioSolicitacaoEncerramento,
-    setDataSaldoBancarioSolicitacaoEncerramento,
-  ] = useState({});
-  const [showModalSalvarDataSaldoExtrato, setShowModalSalvarDataSaldoExtrato] =
-    useState(false);
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [nomeComprovanteExtrato, setNomeComprovanteExtrato] = useState("");
-  const [
-    dataAtualizacaoComprovanteExtrato,
-    setDataAtualizacaoComprovanteExtrato,
-  ] = useState("");
-  const [
-    dataAtualizacaoComprovanteExtratoView,
-    setDataAtualizacaoComprovanteExtratoView,
-  ] = useState("");
-  const [exibeBtnDownload, setExibeBtnDownload] = useState(false);
-  const [msgErroExtensaoArquivo, setMsgErroExtensaoArquivo] = useState("");
-
-  const validaUploadExtrato = (event) => {
-    let ext = event.file.type;
-    let tamanho = event.file.size;
-    let array_extensoes = [
-      "image/jpeg",
-      "image/jpg",
-      "image/bmp",
-      "image/png",
-      "image/tif",
-      "application/pdf",
-    ];
-    if (tamanho <= 500395) {
-      let result = array_extensoes.filter((item) => ext.indexOf(item) > -1);
-      if (result <= 0) {
-        setMsgErroExtensaoArquivo(
-          `A extensão ${ext} não é permitida, tente novamente`
+    const handleTransacoesNaoConciliadas = async (ordenacao) => {
+        setLoadingNaoConciliadas(true);
+        let transacoes_nao_conciliadas = await getTransacoes(
+            periodoConta.periodo, 
+            periodoConta.conta, 
+            'False',
+            stateFiltros.filtrar_por_acao_NAO_CONCILIADO, 
+            ordenacao && ordenacao.ordenar_por_numero_do_documento ? ordenacao.ordenar_por_numero_do_documento : '',
+            ordenacao && ordenacao.ordenar_por_data_especificacao ? ordenacao.ordenar_por_data_especificacao : '',
+            ordenacao && ordenacao.ordenar_por_valor ? ordenacao.ordenar_por_valor : '',
+            ordenacao && ordenacao.ordenar_por_imposto ? ordenacao.ordenar_por_imposto : '',
         );
-        return false;
-      } else {
-        setMsgErroExtensaoArquivo("");
-        return true;
-      }
-    } else {
-      setMsgErroExtensaoArquivo(
-        "O tamanho do arquivo excede o limite de 500kb, tente novamente."
-      );
-      return false;
-    }
-  };
+        setTransacoesNaoConciliadas(transacoes_nao_conciliadas);
+        setLoadingNaoConciliadas(false);
+    };
 
-  const changeUploadExtrato = (event) => {
-    if (validaUploadExtrato(event)) {
-      setBtnSalvarExtratoBancarioDisable(false);
-      setCheckSalvarExtratoBancario(false);
-      setClassBtnSalvarExtratoBancario("success");
-      setSelectedFile(event.file);
-      setNomeComprovanteExtrato(event.file.name);
-      setDataAtualizacaoComprovanteExtrato(
-        moment().format("YYYY-MM-DD HH:mm:ss")
-      );
-      setDataAtualizacaoComprovanteExtratoView(
-        moment().format("DD/MM/YYYY HH:mm:ss")
-      );
-      setExibeBtnDownload(false);
-      setMsgErroExtensaoArquivo("");
-    } else {
-      reiniciaUploadExtrato();
-    }
-  };
-
-  const reiniciaUploadExtrato = () => {
-    if (nomeComprovanteExtrato !== "") {
-      setBtnSalvarExtratoBancarioDisable(false);
-      setCheckSalvarExtratoBancario(false);
-      setClassBtnSalvarExtratoBancario("success");
+    const onHandleCancelarModalSalvarDataSaldoExtrato = () => {
+        setShowModalSalvarDataSaldoExtrato(false);
+        // window.location.assign('/dados-das-contas-da-associacao')
     }
 
-    setSelectedFile(null);
-    setDataAtualizacaoComprovanteExtrato("");
-    setDataAtualizacaoComprovanteExtratoView("");
-    setExibeBtnDownload(false);
-    setNomeComprovanteExtrato("");
-  };
-
-  const downloadComprovanteExtrato = useCallback(async () => {
-    try {
-      await getDownloadExtratoBancario(nomeComprovanteExtrato, observacaoUuid);
-      console.log("Download efetuado com sucesso");
-    } catch (e) {
-      console.log("Erro ao efetuar o download ", e.response);
-    }
-  }, [nomeComprovanteExtrato, observacaoUuid]);
-
-  const [erroDataSaldo, setErroDataSaldo] = useState("");
-
-  const handleChangaDataSaldo = useCallback(
-    (name, value) => {
-      if (name === "data_extrato") {
-        let hoje = moment(new Date());
-        let data_digitada = moment(value);
-        if (data_digitada > hoje) {
-          setErroDataSaldo(
-            "Data do crédito não pode ser maior que a data de hoje"
-          );
-          setDataSaldoBancario((prevState) => ({ ...prevState, [name]: "" }));
-          return;
-        } else {
-          setErroDataSaldo("");
-        }
-      }
-
-      setBtnSalvarExtratoBancarioDisable(false);
-      setCheckSalvarExtratoBancario(false);
-      setClassBtnSalvarExtratoBancario("success");
-
-      setDataSaldoBancario({
-        ...dataSaldoBancario,
-        [name]: value,
-      });
-    },
-    [dataSaldoBancario]
-  );
-
-  const irParaAnaliseDre = async () => {
-    // Ao setar para false, quando a função a seguir setar o click do item do menu
-    // a pagina não ira automaticamente para a url do item
-
-    await contextSideBar.setIrParaUrl(false);
-    SidebarLeftService.setItemActive("analise_dre");
-
-    // Necessário voltar o estado para true, para clicks nos itens do menu continuarem funcionando corretamente
-    contextSideBar.setIrParaUrl(true);
-  };
-
-  const handleTransacoesConciliadas = async (ordenacao) => {
-    setLoadingConciliadas(true);
-    let transacoes_conciliadas = await getTransacoes(
-      periodoConta.periodo,
-      periodoConta.conta,
-      "True",
-      stateFiltros.filtrar_por_acao_CONCILIADO,
-      ordenacao && ordenacao.ordenar_por_numero_do_documento
-        ? ordenacao.ordenar_por_numero_do_documento
-        : "",
-      ordenacao && ordenacao.ordenar_por_data_especificacao
-        ? ordenacao.ordenar_por_data_especificacao
-        : "",
-      ordenacao && ordenacao.ordenar_por_valor
-        ? ordenacao.ordenar_por_valor
-        : "",
-      ordenacao && ordenacao.ordenar_por_imposto
-        ? ordenacao.ordenar_por_imposto
-        : ""
+    const justificativaObrigatoria = useMemo(
+      () =>
+        transacoesNaoConciliadas.length === 0 &&
+        valoresPendentes.saldo_posterior_total - dataSaldoBancario.saldo_extrato !== 0,
+      [dataSaldoBancario, valoresPendentes, transacoesNaoConciliadas]
     );
-    setTransacoesConciliadas(transacoes_conciliadas);
-    setLoadingConciliadas(false);
-  };
+    
+    return (
+        <>
+        <div className="detalhe-das-prestacoes-container mb-5 mt-5">
+            <div className="row">
+                <div className="col-12 d-flex bd-highlight mt-4">
+                    <div className="flex-grow-1 bd-highlight align-self-center detalhe-das-prestacoes-texto-cabecalho pl-0"><h3>Conciliação Bancária</h3></div>
 
-  const handleTransacoesNaoConciliadas = async (ordenacao) => {
-    setLoadingNaoConciliadas(true);
-    let transacoes_nao_conciliadas = await getTransacoes(
-      periodoConta.periodo,
-      periodoConta.conta,
-      "False",
-      stateFiltros.filtrar_por_acao_NAO_CONCILIADO,
-      ordenacao && ordenacao.ordenar_por_numero_do_documento
-        ? ordenacao.ordenar_por_numero_do_documento
-        : "",
-      ordenacao && ordenacao.ordenar_por_data_especificacao
-        ? ordenacao.ordenar_por_data_especificacao
-        : "",
-      ordenacao && ordenacao.ordenar_por_valor
-        ? ordenacao.ordenar_por_valor
-        : "",
-      ordenacao && ordenacao.ordenar_por_imposto
-        ? ordenacao.ordenar_por_imposto
-        : ""
-    );
-    setTransacoesNaoConciliadas(transacoes_nao_conciliadas);
-    setLoadingNaoConciliadas(false);
-  };
-
-  const onHandleCancelarModalSalvarDataSaldoExtrato = () => {
-    setShowModalSalvarDataSaldoExtrato(false);
-    // window.location.assign('/dados-das-contas-da-associacao')
-  };
-
-  const justificativaObrigatoria = useMemo(
-    () =>
-      transacoesNaoConciliadas.length === 0 &&
-      valoresPendentes.saldo_posterior_total -
-        dataSaldoBancario.saldo_extrato !==
-        0,
-    [dataSaldoBancario, valoresPendentes, transacoesNaoConciliadas]
-  );
-
-  return (
-    <>
-      <div className="detalhe-das-prestacoes-container mb-5 mt-5">
-        <div className="row">
-          <div className="col-12 d-flex bd-highlight mt-4">
-            <div className="flex-grow-1 bd-highlight align-self-center detalhe-das-prestacoes-texto-cabecalho pl-0">
-              <h3>Conciliação Bancária</h3>
-            </div>
-
-            {parametros &&
-              parametros.state &&
-              parametros.state &&
-              parametros.state &&
-              parametros.state.origem === "ir_para_conciliacao_bancaria" && (
-                <div className="bd-highlight detalhe-das-prestacoes-texto-cabecalho">
-                  <button
-                    className="btn btn-outline-success"
-                    onClick={() => {
-                      irParaAnaliseDre();
-                      navigate(
-                        `/consulta-detalhamento-analise-da-dre/${parametros.state.prestacaoDeContasUuid}/`,
-                        {
-                          state: {
-                            origem: "ir_para_conciliacao_bancaria",
-                            periodoFormatado:
-                              parametros &&
-                              parametros.state &&
-                              parametros.state.periodoFormatado
-                                ? parametros.state.periodoFormatado
-                                : "",
-                          },
-                        }
-                      );
-                    }}
-                  >
-                    Voltar para Análise DRE
-                  </button>
+                    {parametros && parametros.state && parametros.state && parametros.state && parametros.state.origem === 'ir_para_conciliacao_bancaria' &&
+                        <div className="bd-highlight detalhe-das-prestacoes-texto-cabecalho">
+                            <button
+                                className="btn btn-outline-success"
+                                onClick={() => {
+                                    irParaAnaliseDre();
+                                    navigate(`/consulta-detalhamento-analise-da-dre/${parametros.state.prestacaoDeContasUuid}/`, {
+                                        state: {
+                                            origem: 'ir_para_conciliacao_bancaria',
+                                            periodoFormatado: parametros && parametros.state && parametros.state.periodoFormatado ? parametros.state.periodoFormatado : ""
+                                        }
+                                    });
+                                }}
+                            >
+                                Voltar para Análise DRE
+                            </button>
+                        </div>
+                    }
                 </div>
-              )}
-          </div>
+            </div>
+            {loading ? (
+                    <Loading
+                        corGrafico="black"
+                        corFonte="dark"
+                        marginTop="0"
+                        marginBottom="0"
+                    />
+                ) :
+                <>
+                    <SelectPeriodoConta
+                        periodoConta={periodoConta}
+                        handleChangePeriodoConta={handleChangePeriodoConta}
+                        periodosAssociacao={periodosAssociacao}
+                        contasAssociacao={contasAssociacao}
+                    />
+
+                    {periodoConta.periodo && periodoConta.conta ? (
+                        <>
+                            <TopoComBotoes
+                                contaConciliacao={contaConciliacao}
+                                periodoFechado={periodoFechado}
+                                origem={origem}
+                            />
+
+                            <TabelaValoresPendentesPorAcao
+                                valoresPendentes={valoresPendentes}
+                                valorTemplate={valorTemplate}
+                            />
+
+                            <DataSaldoBancario
+                                valoresPendentes={valoresPendentes}
+                                dataSaldoBancario={dataSaldoBancario}
+                                handleChangaDataSaldo={handleChangaDataSaldo}
+                                periodoFechado={periodoFechado}
+                                nomeComprovanteExtrato={nomeComprovanteExtrato}
+                                dataAtualizacaoComprovanteExtrato={dataAtualizacaoComprovanteExtratoView}
+                                exibeBtnDownload={exibeBtnDownload}
+                                msgErroExtensaoArquivo={msgErroExtensaoArquivo}
+                                changeUploadExtrato={changeUploadExtrato}
+                                reiniciaUploadExtrato={reiniciaUploadExtrato}
+                                downloadComprovanteExtrato={downloadComprovanteExtrato}
+                                salvarExtratoBancario={salvarExtratoBancario}
+                                btnSalvarExtratoBancarioDisable={btnSalvarExtratoBancarioDisable}
+                                setBtnSalvarExtratoBancarioDisable={setBtnSalvarExtratoBancarioDisable}
+                                classBtnSalvarExtratoBancario={classBtnSalvarExtratoBancario}
+                                setClassBtnSalvarExtratoBancario={setClassBtnSalvarExtratoBancario}
+                                checkSalvarExtratoBancario={checkSalvarExtratoBancario}
+                                setCheckSalvarExtratoBancario={setCheckSalvarExtratoBancario}
+                                erroDataSaldo={erroDataSaldo}
+                                permiteEditarCamposExtrato={permiteEditarCamposExtrato}
+                                pendenciaSaldoBancario={pendenciaSaldoBancario}
+                                dataSaldoBancarioSolicitacaoEncerramento={dataSaldoBancarioSolicitacaoEncerramento}
+                                setShowModalSalvarDataSaldoExtrato={setShowModalSalvarDataSaldoExtrato}
+                            />
+
+                            <p className="detalhe-das-prestacoes-titulo-lancamentos mt-3 mb-3">Gastos pendentes de conciliação</p>
+                            <FiltrosTransacoes
+                                conciliado='NAO_CONCILIADO'
+                                stateFiltros={stateFiltros}
+                                tabelasDespesa={tabelasDespesa}
+                                handleChangeFiltros={handleChangeFiltros}
+                                handleSubmitFiltros={handleTransacoesNaoConciliadas}
+                            />
+
+                            <TabelaTransacoes
+                                transacoes={transacoesNaoConciliadas}
+                                checkboxTransacoes={checkboxTransacoes}
+                                periodoFechado={periodoFechado}
+                                handleChangeCheckboxTransacoes={handleChangeCheckboxTransacoes}
+                                tabelasDespesa={tabelasDespesa}
+                                showModalLegendaInformacao={showModalLegendaInformacao}
+                                setShowModalLegendaInformacao={setShowModalLegendaInformacao}
+                                handleCallbackOrdernar={handleTransacoesNaoConciliadas}
+                                loading={loadingNaoConciliadas}
+                                emptyListComponent={<p className="mt-2"><strong>Não existem gastos não conciliados...</strong></p>}
+                            />                            
+
+                            <p className="detalhe-das-prestacoes-titulo-lancamentos mt-5 mb-3">Gastos conciliados</p>
+                            <FiltrosTransacoes
+                                conciliado='CONCILIADO'
+                                stateFiltros={stateFiltros}
+                                tabelasDespesa={tabelasDespesa}
+                                handleChangeFiltros={handleChangeFiltros}
+                                handleSubmitFiltros={handleTransacoesConciliadas}
+                            />
+
+                            <TabelaTransacoes
+                                transacoes={transacoesConciliadas}
+                                checkboxTransacoes={checkboxTransacoes}
+                                periodoFechado={periodoFechado}
+                                handleChangeCheckboxTransacoes={handleChangeCheckboxTransacoes}
+                                tabelasDespesa={tabelasDespesa}
+                                showModalLegendaInformacao={showModalLegendaInformacao}
+                                setShowModalLegendaInformacao={setShowModalLegendaInformacao}
+                                handleCallbackOrdernar={handleTransacoesConciliadas}
+                                loading={loadingConciliadas}
+                                emptyListComponent={<p className="mt-2"><strong>Não existem gastos conciliados...</strong></p>}
+                            />                            
+
+                            <Justificativa
+                                justificativaObrigatoria={justificativaObrigatoria}
+                                textareaJustificativa={textareaJustificativa}
+                                handleChangeTextareaJustificativa={handleChangeTextareaJustificativa}
+                                periodoFechado={periodoFechado}
+                                btnSalvarJustificativaDisable={btnSalvarJustificativaDisable}
+                                setBtnJustificativaSalvarDisable={setBtnSalvarJustificativaDisable}
+                                checkSalvarJustificativa={checkSalvarJustificativa}
+                                setCheckSalvarJustificativa={setCheckSalvarJustificativa}
+                                salvarJustificativa={salvarJustificativa}
+                                classBtnSalvarJustificativa={classBtnSalvarJustificativa}
+                                setClassBtnSalvarJustificativa={setClassBtnSalvarJustificativa}
+
+                            />
+                        </>
+                    ):
+                        <MsgImgCentralizada
+                            texto='Selecione um período e uma conta acima para visualizar os demonstrativos'
+                            img={Img404}
+                        />
+                    }
+                </>
+            }
         </div>
-        {loading ? (
-          <Loading
-            corGrafico="black"
-            corFonte="dark"
-            marginTop="0"
-            marginBottom="0"
-          />
-        ) : (
-          <>
-            <SelectPeriodoConta
-              periodoConta={periodoConta}
-              handleChangePeriodoConta={handleChangePeriodoConta}
-              periodosAssociacao={periodosAssociacao}
-              contasAssociacao={contasAssociacao}
+
+        <section>
+            <ModalSalvarDataSaldoExtrato
+                show={showModalSalvarDataSaldoExtrato}
+                titulo="Salvar alterações."
+                texto='Os campos "data" e "saldo" foram alterados e podem não ser mais os mesmos cadastrados na solicitação de encerramento da conta. Confirma a alteração?'
+                segundoBotaoTexto="Confirmar"
+                segundoBotaoOnclick={salvarExtratoBancario}
+                segundoBotaoCss="success"
+                primeiroBotaoCss="outline-success"
+                primeiroBotaoTexto="Cancelar"
+                handleClose={onHandleCancelarModalSalvarDataSaldoExtrato}
+                primeiroBotaoOnclick={onHandleCancelarModalSalvarDataSaldoExtrato}
             />
+        </section>
 
-            {periodoConta.periodo && periodoConta.conta ? (
-              <>
-                <TopoComBotoes
-                  contaConciliacao={contaConciliacao}
-                  periodoFechado={periodoFechado}
-                  origem={origem}
-                />
-
-                <TabelaValoresPendentesPorAcao
-                  valoresPendentes={valoresPendentes}
-                  valorTemplate={valorTemplate}
-                />
-
-                <DataSaldoBancario
-                  valoresPendentes={valoresPendentes}
-                  dataSaldoBancario={dataSaldoBancario}
-                  handleChangaDataSaldo={handleChangaDataSaldo}
-                  periodoFechado={periodoFechado}
-                  nomeComprovanteExtrato={nomeComprovanteExtrato}
-                  dataAtualizacaoComprovanteExtrato={
-                    dataAtualizacaoComprovanteExtratoView
-                  }
-                  exibeBtnDownload={exibeBtnDownload}
-                  msgErroExtensaoArquivo={msgErroExtensaoArquivo}
-                  changeUploadExtrato={changeUploadExtrato}
-                  reiniciaUploadExtrato={reiniciaUploadExtrato}
-                  downloadComprovanteExtrato={downloadComprovanteExtrato}
-                  salvarExtratoBancario={salvarExtratoBancario}
-                  btnSalvarExtratoBancarioDisable={
-                    btnSalvarExtratoBancarioDisable
-                  }
-                  setBtnSalvarExtratoBancarioDisable={
-                    setBtnSalvarExtratoBancarioDisable
-                  }
-                  classBtnSalvarExtratoBancario={classBtnSalvarExtratoBancario}
-                  setClassBtnSalvarExtratoBancario={
-                    setClassBtnSalvarExtratoBancario
-                  }
-                  checkSalvarExtratoBancario={checkSalvarExtratoBancario}
-                  setCheckSalvarExtratoBancario={setCheckSalvarExtratoBancario}
-                  erroDataSaldo={erroDataSaldo}
-                  permiteEditarCamposExtrato={permiteEditarCamposExtrato}
-                  pendenciaSaldoBancario={pendenciaSaldoBancario}
-                  dataSaldoBancarioSolicitacaoEncerramento={
-                    dataSaldoBancarioSolicitacaoEncerramento
-                  }
-                  setShowModalSalvarDataSaldoExtrato={
-                    setShowModalSalvarDataSaldoExtrato
-                  }
-                />
-
-                <p className="detalhe-das-prestacoes-titulo-lancamentos mt-3 mb-3">
-                  Gastos pendentes de conciliação
-                </p>
-                <FiltrosTransacoes
-                  conciliado="NAO_CONCILIADO"
-                  stateFiltros={stateFiltros}
-                  tabelasDespesa={tabelasDespesa}
-                  handleChangeFiltros={handleChangeFiltros}
-                  handleSubmitFiltros={handleTransacoesNaoConciliadas}
-                />
-
-                <TabelaTransacoes
-                  transacoes={transacoesNaoConciliadas}
-                  checkboxTransacoes={checkboxTransacoes}
-                  periodoFechado={periodoFechado}
-                  handleChangeCheckboxTransacoes={
-                    handleChangeCheckboxTransacoes
-                  }
-                  tabelasDespesa={tabelasDespesa}
-                  showModalLegendaInformacao={showModalLegendaInformacao}
-                  setShowModalLegendaInformacao={setShowModalLegendaInformacao}
-                  handleCallbackOrdernar={handleTransacoesNaoConciliadas}
-                  loading={loadingNaoConciliadas}
-                  emptyListComponent={
-                    <p className="mt-2">
-                      <strong>Não existem gastos não conciliados...</strong>
-                    </p>
-                  }
-                />
-
-                <p className="detalhe-das-prestacoes-titulo-lancamentos mt-5 mb-3">
-                  Gastos conciliados
-                </p>
-                <FiltrosTransacoes
-                  conciliado="CONCILIADO"
-                  stateFiltros={stateFiltros}
-                  tabelasDespesa={tabelasDespesa}
-                  handleChangeFiltros={handleChangeFiltros}
-                  handleSubmitFiltros={handleTransacoesConciliadas}
-                />
-
-                <TabelaTransacoes
-                  transacoes={transacoesConciliadas}
-                  checkboxTransacoes={checkboxTransacoes}
-                  periodoFechado={periodoFechado}
-                  handleChangeCheckboxTransacoes={
-                    handleChangeCheckboxTransacoes
-                  }
-                  tabelasDespesa={tabelasDespesa}
-                  showModalLegendaInformacao={showModalLegendaInformacao}
-                  setShowModalLegendaInformacao={setShowModalLegendaInformacao}
-                  handleCallbackOrdernar={handleTransacoesConciliadas}
-                  loading={loadingConciliadas}
-                  emptyListComponent={
-                    <p className="mt-2">
-                      <strong>Não existem gastos conciliados...</strong>
-                    </p>
-                  }
-                />
-
-                <Justificativa
-                  justificativaObrigatoria={justificativaObrigatoria}
-                  textareaJustificativa={textareaJustificativa}
-                  handleChangeTextareaJustificativa={
-                    handleChangeTextareaJustificativa
-                  }
-                  periodoFechado={periodoFechado}
-                  btnSalvarJustificativaDisable={btnSalvarJustificativaDisable}
-                  setBtnJustificativaSalvarDisable={
-                    setBtnSalvarJustificativaDisable
-                  }
-                  checkSalvarJustificativa={checkSalvarJustificativa}
-                  setCheckSalvarJustificativa={setCheckSalvarJustificativa}
-                  salvarJustificativa={salvarJustificativa}
-                  classBtnSalvarJustificativa={classBtnSalvarJustificativa}
-                  setClassBtnSalvarJustificativa={
-                    setClassBtnSalvarJustificativa
-                  }
-                />
-              </>
-            ) : (
-              <MsgImgCentralizada
-                texto="Selecione um período e uma conta acima para visualizar os demonstrativos"
-                img={Img404}
-              />
-            )}
-          </>
-        )}
-      </div>
-
-      <section>
-        <ModalSalvarDataSaldoExtrato
-          show={showModalSalvarDataSaldoExtrato}
-          titulo="Salvar alterações."
-          texto='Os campos "data" e "saldo" foram alterados e podem não ser mais os mesmos cadastrados na solicitação de encerramento da conta. Confirma a alteração?'
-          segundoBotaoTexto="Confirmar"
-          segundoBotaoOnclick={salvarExtratoBancario}
-          segundoBotaoCss="success"
-          primeiroBotaoCss="outline-success"
-          primeiroBotaoTexto="Cancelar"
-          handleClose={onHandleCancelarModalSalvarDataSaldoExtrato}
-          primeiroBotaoOnclick={onHandleCancelarModalSalvarDataSaldoExtrato}
-        />
-      </section>
-    </>
-  );
+        </>
+    )
 };

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -220,7 +220,7 @@ export const DetalheDasPrestacoes = () => {
                 
                 setDataSaldoBancario({
                     data_extrato: observacao.data_extrato ? parseLocalDate(observacao.data_extrato) : null,
-                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : null,
+                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
                 })
 
                 setDataSaldoBancarioSolicitacaoEncerramento({
@@ -253,7 +253,7 @@ export const DetalheDasPrestacoes = () => {
                 setTextareaJustificativa(observacao.observacao ? observacao.observacao : '');
                 setDataSaldoBancario({
                     data_extrato: observacao.data_extrato ? parseLocalDate(observacao.data_extrato) : null,
-                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : null,
+                    saldo_extrato: observacao.saldo_extrato ? observacao.saldo_extrato : 0,
                 })
                 setNomeComprovanteExtrato(observacao.comprovante_extrato ? observacao.comprovante_extrato : '')
                 setDataAtualizacaoComprovanteExtrato(moment(observacao.data_atualizacao_comprovante_extrato).format("YYYY-MM-DD HH:mm:ss"))


### PR DESCRIPTION
Esse PR:

- Volta campos obrigatórios em conciliação bancária
- Torna campo de justificativa obrigatório condicionado as conciliações e diferença do saldo para pc.

[AB#129997](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/129997)