### PR TITLE
feat(127468): Ação para duplicar Prioridade

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/BadgeCustom.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/BadgeCustom.js
@@ -1,0 +1,52 @@
+import { Badge, Button } from 'antd';
+
+const ButtonCustom = ({
+        buttonLabel='-',
+        buttonColor='#a4a4a4',
+        handleClick=()=>{}
+    }) => {
+    return (
+        <Button
+            variant="solid"
+            size="small"
+            style={
+                {
+                    backgroundColor: buttonColor,
+                    borderColor:'transparent',
+                    color:'white',
+                    fontSize: '11px',
+                    height: '18px'
+                }
+            }
+            onClick={handleClick}>
+            {buttonLabel}
+        </Button>
+    );
+};
+
+export const BadgeCustom = ({
+        badge=false,
+        buttonColor='#a4a4a4',
+        buttonLabel='',
+        handleClick=()=>{}
+    }) => {
+    return (
+        <>
+        {badge ?
+            <>
+                <Badge color="#cda910" count={'!'} size='small' offset={[-85, 0]}>
+                    <ButtonCustom
+                        buttonColor={buttonColor}
+                        buttonLabel={buttonLabel}
+                        handleClick={handleClick}/>
+                </Badge>
+            </>
+        :
+            <ButtonCustom
+                buttonColor={buttonColor}
+                buttonLabel={buttonLabel}
+                handleClick={handleClick}/>
+        }  
+        </>
+    );
+};

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
@@ -2,18 +2,16 @@ import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { IconButton } from "../../../../../Globais/UI/Button/IconButton";
 import { useState } from 'react';
-import { Button, Space } from 'antd';
+import { Space } from 'antd';
 import { formatMoneyBRL } from "../../../../../../utils/money";
+import { BadgeCustom } from './BadgeCustom';
 
 
-export const Tabela = ({ data, handleEditar }) => {
+export const Tabela = ({ data, handleEditar, handleDuplicar }) => {
     const [selectedItems, setSelectedItems] = useState([]);
 
     const handleExcluir = (rowData) => {
         // Implementar lógica de exclusão
-    }
-    const handleDuplicar = (rowData) => {
-        // Implementar lógica de duplicação
     }
 
     const handleSelectAll = (e) => {
@@ -72,18 +70,10 @@ export const Tabela = ({ data, handleEditar }) => {
                     <>
                         <div>{rowData.acao}</div>
                         {!rowData.prioridade &&
-                            <Button
-                                variant="solid"
-                                size="small"
-                                style={
-                                    {
-                                        backgroundColor:'#a4a4a4',
-                                        borderColor:'transparent',
-                                        color:'white',
-                                        fontSize: '11px',
-                                        height: 'auto'
-                                    }
-                                }>Não priorizado</Button>
+                            <BadgeCustom
+                                buttonColor='#a4a4a4'
+                                buttonLabel='Não priorizado'
+                            />
                         }
                     </>
                 )}
@@ -112,7 +102,18 @@ export const Tabela = ({ data, handleEditar }) => {
                 style={{ width: "120px", textAlign: "center" }}
                 bodyStyle={{ textAlign: 'center' }}
                 body={(rowData) => (
-                    <>{formatMoneyBRL(rowData.valor_total)}</>
+                    <>
+                        {!rowData.valor_total ?
+                            <BadgeCustom
+                                badge={true}
+                                buttonColor='#62a9ad'
+                                buttonLabel='Informar Valor'
+                                handleClick={() => handleEditar(rowData, true)}
+                            />
+                            :
+                            <>{formatMoneyBRL(rowData.valor_total)}</>
+                        }
+                    </>
                 )}
             />
             <Column
@@ -153,7 +154,7 @@ export const Tabela = ({ data, handleEditar }) => {
                             />
                         </Space>
                     );
-                 }}
+                }}
             />
         </DataTable>
     )

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/useGetPrioridades.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/useGetPrioridades.js
@@ -5,6 +5,7 @@ import { getPrioridades } from "../../../../../../../services/escolas/Paa.servic
 export const useGetPrioridades = (filtros, page) => {
   const {
     isLoading,
+    isFetching,
     isError,
     data = {},
     error,
@@ -26,5 +27,5 @@ export const useGetPrioridades = (filtros, page) => {
     acao: item?.acao_associacao_objeto?.nome || item?.acao_pdde_objeto?.nome || "Recurso Próprio",
     valor_total: parseFloat(item.valor_total)
   }));
-  return { isLoading, isError, prioridades: dadosProcessados, quantidade: data.count, error, refetch };
+  return { isLoading, isFetching, isError, prioridades: dadosProcessados, quantidade: data.count, error, refetch };
 };

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePatchPrioridade.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePatchPrioridade.js
@@ -13,7 +13,7 @@ export const usePatchPrioridade = (onClose) => {
       onClose && onClose();
     },
     onError: (e) => {
-      toastCustom.ToastCustomError("Houve um erro ao alterar a prioridade.");
+      toastCustom.ToastCustomError(e?.response?.data?.mensagem || "Houve um erro ao alterar a prioridade.");
     },
   });
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostPrioridade.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostPrioridade.js
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postPrioridade } from "../../../../../../../services/escolas/Paa.service";
+import { postPrioridade, postDuplicarPrioridade } from "../../../../../../../services/escolas/Paa.service";
 import { toastCustom } from "../../../../../../Globais/ToastCustom";
 
 export const usePostPrioridade = (onClose) => {
@@ -13,6 +13,22 @@ export const usePostPrioridade = (onClose) => {
     },
     onError: (e) => {
       toastCustom.ToastCustomError("Houve um erro ao criar a prioridade.");
+    },
+  });
+
+  return { mutationPost };
+};
+
+export const usePostDuplicarPrioridade = () => {
+  const queryClient = useQueryClient();
+  const mutationPost = useMutation({
+    mutationFn: ({ uuid }) => postDuplicarPrioridade(uuid),
+    onSuccess: () => {
+      toastCustom.ToastCustomSuccess("Prioridade duplicada com sucesso.");
+      queryClient.invalidateQueries(["prioridades"]);
+    },
+    onError: (e) => {
+      toastCustom.ToastCustomError(e?.response?.data?.mensagem || "Houve um erro ao duplicar prioridade.");
     },
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,11 @@ const antdTheme = {
     colorError: "rgba(184, 0, 0, 1)",
   },
   components: {
+    Alert: {
+      defaultPadding: '2px 4px',
+      withDescriptionIconSize: 18,
+      withDescriptionPadding: '3px 6px'
+    },
     Input: {
       controlHeight: 38,
     },

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -154,6 +154,10 @@ export const postPrioridade = async (payload) => {
   return (await api.post(`api/prioridades-paa/`, payload, authHeader())).data;
 }
 
+export const postDuplicarPrioridade = async (uuid) => {
+  return (await api.post(`api/prioridades-paa/${uuid}/duplicar/`, {}, authHeader())).data;
+}
+
 export const patchPrioridade = async (uuid, payload) => {
   return (await api.patch(`api/prioridades-paa/${uuid}/`, payload, authHeader())).data;
 }


### PR DESCRIPTION
Esse PR:

- Inclui um componente para reutilização em duas colunas na tabela (BadgeCustom)
- Hook de API de duplicação
- Adiciona a funcionalidade de duplicar uma prioridade na tabela
Os registros duplicados deve ser exibidos no topo da tabela

História [AB#127468](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/127468)