### PR TITLE
Hotfix/133192 payload extrato bancario implementacao dayjs inves moment datepickerfield

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.21.1",
+  "version": "9.21.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/componentes/Globais/DatePickerField/index.js
+++ b/src/componentes/Globais/DatePickerField/index.js
@@ -4,7 +4,7 @@ import DatePicker, {registerLocale} from "react-datepicker";
 import 'react-datepicker/dist/react-datepicker.css';
 import { ptBR } from "date-fns/locale";
 import "./datePickerField.scss";
-import moment from "moment";
+import dayjs from "dayjs";
 
 registerLocale("pt", ptBR);
 
@@ -13,7 +13,7 @@ export const DatePickerField = ({ dataQa="", name, id, value, className="form-co
     const parseDate = (dateString) => {
         if (!dateString) return null;
         if (dateString instanceof Date) return dateString;
-        const date = moment(dateString, 'YYYY-MM-DD', true);
+        const date = dayjs(dateString, "YYYY-MM-DD", true); 
         return date.isValid() ? date.toDate() : null;
     };
 

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/__tests__/CadastroFormFormik.test.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/__tests__/CadastroFormFormik.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CadastroFormFormik } from "../CadastroFormFormik";
-import { act } from "@testing-library/react";
 
 // Mock dos serviços
 jest.mock("../../../../../services/visoes.service");

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/__tests__/index.test.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/__tests__/index.test.js
@@ -109,7 +109,6 @@ describe("DetalheDasPrestacoes", () => {
 
       renderComponent();
 
-      // 👇 Espera os efeitos dispararem
       await waitFor(() => {
         expect(localStorage.getItem('periodoConta')).toBe(ls);
         expect(receitaService.getTabelasReceita).toHaveBeenCalledTimes(1);

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/__tests__/index.test.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/__tests__/index.test.js
@@ -6,7 +6,9 @@ import * as associacaoService from "../../../../../services/escolas/Associacao.s
 import * as receitaService from "../../../../../services/escolas/Receitas.service";
 import { SidebarContext } from "../../../../../context/Sidebar";
 import { useParams, useLocation } from 'react-router-dom';
+import * as tabelaValoresPendentesService from "../../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
 
+jest.mock("../../../../../services/escolas/TabelaValoresPendentesPorAcao.service");
 jest.mock("../../../../../services/escolas/PrestacaoDeContas.service");
 jest.mock("../../../../../services/escolas/Receitas.service");
 jest.mock("../../../../../services/escolas/Associacao.service");
@@ -59,20 +61,23 @@ const renderComponent = () =>
 describe("DetalheDasPrestacoes", () => {
 
     beforeEach(() => {
-        localStorage.removeItem('ASSOCIACAO_UUID');
-        jest.clearAllMocks();
+      jest.clearAllMocks();
 
-        localStorage.setItem('ASSOCIACAO_UUID', 'associacao-uuid');
-        receitaService.getTabelasReceita.mockResolvedValue({ data: { acoes_associacao: [] } });
-        associacaoService.getContas.mockResolvedValue([{uuid: 'conta-uuid', conta: 'conta-nome', tipo_conta: {nome: 'conta-tipo'}}]);
-        prestacaoService.getObservacoes.mockResolvedValue({
-            possui_solicitacao_encerramento: true,
-            data_encerramento : '2025-07-05',
-            data_extrato : '2025-07-05',
-            saldo_extrato : 100,
-            saldo_encerramento : '2025-07-05',
-        });
-    })
+      localStorage.setItem('ASSOCIACAO_UUID', 'associacao-uuid');
+
+      receitaService.getTabelasReceita.mockResolvedValue({ data: { acoes_associacao: [] } });
+      associacaoService.getContas.mockResolvedValue([{ uuid: 'conta-uuid', conta: 'conta-nome', tipo_conta: { nome: 'conta-tipo' } }]);
+      prestacaoService.getObservacoes.mockResolvedValue({
+        possui_solicitacao_encerramento: true,
+        data_encerramento: '2025-07-05',
+        data_extrato: '2025-07-05',
+        saldo_extrato: 100,
+        saldo_encerramento: '2025-07-05',
+      });
+      prestacaoService.getStatusPeriodoPorData.mockResolvedValue({ prestacao_contas_status: { periodo_bloqueado: false } });
+      associacaoService.getPeriodosDePrestacaoDeContasDaAssociacao.mockResolvedValue([{ uuid: 'periodo-uuid' }]);
+      tabelaValoresPendentesService.tabelaValoresPendentes.mockResolvedValue([]);
+    });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -98,15 +103,19 @@ describe("DetalheDasPrestacoes", () => {
     });
 
     it("renderiza o componente e periodo_uuid SEM parâmetro de url (else if em getPeriodoConta())", async () => {
-        const ls = JSON.stringify({periodo: 'periodo-uuid', conta: 'conta-uuid'})
-        localStorage.setItem('periodoConta', ls);
-        useParams.mockReturnValue({ periodo_uuid: null });
+      const ls = JSON.stringify({ periodo: 'periodo-uuid', conta: 'conta-uuid' });
+      localStorage.setItem('periodoConta', ls);
+      useParams.mockReturnValue({ periodo_uuid: null });
 
-        renderComponent();
+      renderComponent();
+
+      // 👇 Espera os efeitos dispararem
+      await waitFor(() => {
         expect(localStorage.getItem('periodoConta')).toBe(ls);
         expect(receitaService.getTabelasReceita).toHaveBeenCalledTimes(1);
         expect(associacaoService.getContas).toHaveBeenCalledTimes(1);
         expect(prestacaoService.getObservacoes).toHaveBeenCalledTimes(1);
+      });
     });
 
     it("renderiza o componente e carregaObservacoes em (if(periodosAssociacao) em carregaObservacoes())", async () => {
@@ -195,15 +204,11 @@ describe("DetalheDasPrestacoes", () => {
 
         renderComponent();
 
-        const campoDataSaldo = await screen.findByLabelText(/Data/i)
-        const nova_data = '2025-07-05'
-        fireEvent.change(campoDataSaldo, { target: { value: nova_data } })
-        const dataEsperada = '04/07/2025' // considerando -03:00
-
+        const campoDataSaldo = await screen.findByLabelText(/Data/i);
+        fireEvent.change(campoDataSaldo, { target: { value: "05/07/2025" } });
         await waitFor(() => {
-            expect(campoDataSaldo).toHaveValue(dataEsperada);
+          expect(campoDataSaldo).toHaveValue("05/07/2025");
         });
-
         expect(useLocation).toHaveBeenCalled();
         expect(useParams).toHaveBeenCalled();
     });

--- a/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/DetalheDasPrestacoes/index.js
@@ -25,7 +25,6 @@ import Img404 from "../../../../assets/img/img-404.svg";
 import {ASSOCIACAO_UUID} from "../../../../services/auth.service";
 import {tabelaValoresPendentes} from "../../../../services/escolas/TabelaValoresPendentesPorAcao.service";
 import DataSaldoBancario from "./DataSaldoBancario";
-import {trataNumericos} from "../../../../utils/ValidacoesAdicionaisFormularios";
 import TabelaTransacoes from "./TabelaTransacoes";
 import {getDespesasTabelas} from "../../../../services/escolas/Despesas.service";
 import {FiltrosTransacoes} from "./FiltrosTransacoes";
@@ -33,6 +32,7 @@ import { SidebarLeftService } from "../../../../services/SideBarLeft.service";
 import { SidebarContext } from "../../../../context/Sidebar";
 import {toastCustom} from "../../../Globais/ToastCustom";
 import { ModalSalvarDataSaldoExtrato } from "../ModalSalvarDataSaldoExtrato";
+import {criarPayloadExtratoBancario} from "../../../../utils/PayloadExtratoBancario";
 
 export const DetalheDasPrestacoes = () => {
     let {periodo_uuid, conta_uuid} = useParams();
@@ -294,16 +294,12 @@ export const DetalheDasPrestacoes = () => {
         setCheckSalvarExtratoBancario(true);
         setClassBtnSalvarExtratoBancario("secondary");
 
-        let payload;
-
-        payload = {
-            "periodo_uuid": periodoConta.periodo,
-            "conta_associacao_uuid": periodoConta.conta,
-            "data_extrato": dataSaldoBancario.data_extrato ? moment(dataSaldoBancario.data_extrato, "YYYY-MM-DD").format("YYYY-MM-DD"): null,
-            "saldo_extrato": dataSaldoBancario.saldo_extrato ? trataNumericos(dataSaldoBancario.saldo_extrato) : 0,
-            "comprovante_extrato": selectedFile,
-            "data_atualizacao_comprovante_extrato": dataAtualizacaoComprovanteExtrato ? moment(dataAtualizacaoComprovanteExtrato, "YYYY-MM-DD HH:mm:ss").format("YYYY-MM-DD HH:mm:ss"): null,
-        }
+        const payload = criarPayloadExtratoBancario({
+            periodoConta,
+            dataSaldoBancario,
+            selectedFile,
+            dataAtualizacaoComprovanteExtrato,
+        });
 
         try {
             await pathExtratoBancarioPrestacaoDeConta(payload);

--- a/src/utils/PayloadExtratoBancario.js
+++ b/src/utils/PayloadExtratoBancario.js
@@ -1,0 +1,24 @@
+import dayjs from "dayjs";
+import { trataNumericos } from "./ValidacoesAdicionaisFormularios";
+
+export const criarPayloadExtratoBancario = ({
+  periodoConta,
+  dataSaldoBancario,
+  selectedFile,
+  dataAtualizacaoComprovanteExtrato
+}) => {
+  return {
+    periodo_uuid: periodoConta.periodo,
+    conta_associacao_uuid: periodoConta.conta,
+    data_extrato: dataSaldoBancario.data_extrato && dayjs(dataSaldoBancario.data_extrato).isValid()
+      ? dayjs(dataSaldoBancario.data_extrato).format("YYYY-MM-DD")
+      : null,
+    saldo_extrato: dataSaldoBancario.saldo_extrato
+      ? trataNumericos(dataSaldoBancario.saldo_extrato)
+      : 0,
+    comprovante_extrato: selectedFile,
+    data_atualizacao_comprovante_extrato: dataAtualizacaoComprovanteExtrato && dayjs(dataAtualizacaoComprovanteExtrato).isValid()
+      ? dayjs(dataAtualizacaoComprovanteExtrato).format("YYYY-MM-DD HH:mm:ss")
+      : null,
+  };
+};

--- a/src/utils/__tests__/PayloadExtratoBancario.test.js
+++ b/src/utils/__tests__/PayloadExtratoBancario.test.js
@@ -1,0 +1,39 @@
+import { criarPayloadExtratoBancario } from "../PayloadExtratoBancario";
+
+describe("criarPayloadExtratoBancario", () => {
+  it("deve criar payload correto com datas válidas", () => {
+    const payload = criarPayloadExtratoBancario({
+      periodoConta: { periodo: "p1", conta: "c1" },
+      dataSaldoBancario: { data_extrato: "2025-08-27", saldo_extrato: "1000" },
+      selectedFile: "arquivo.pdf",
+      dataAtualizacaoComprovanteExtrato: "2025-08-27 12:34:56"
+    });
+
+    expect(payload).toEqual({
+      periodo_uuid: "p1",
+      conta_associacao_uuid: "c1",
+      data_extrato: "2025-08-27",
+      saldo_extrato: 1000,
+      comprovante_extrato: "arquivo.pdf",
+      data_atualizacao_comprovante_extrato: "2025-08-27 12:34:56",
+    });
+  });
+
+  it("deve colocar null em datas inválidas", () => {
+    const payload = criarPayloadExtratoBancario({
+      periodoConta: { periodo: "p1", conta: "c1" },
+      dataSaldoBancario: { data_extrato: "Invalid date", saldo_extrato: null },
+      selectedFile: null,
+      dataAtualizacaoComprovanteExtrato: "Invalid date"
+    });
+
+    expect(payload).toEqual({
+      periodo_uuid: "p1",
+      conta_associacao_uuid: "c1",
+      data_extrato: null,
+      saldo_extrato: 0,
+      comprovante_extrato: null,
+      data_atualizacao_comprovante_extrato: null,
+    });
+  });
+});


### PR DESCRIPTION
hotfix(133192): remocao import act nao usado, substituicao moment por dayjs em datepickerfield, correcao payload extrato bancario para nao permitir data invalida