### PR TITLE
feature(129382): Ajuste para o campo de referência no título PAA

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/__tests__/index.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/__tests__/index.test.js
@@ -33,7 +33,7 @@ describe("BarraTopoTitulo", () => {
     localStorage.setItem(
       "DADOS_PAA",
       JSON.stringify({
-        periodo_paa_objeto: { data_inicial: "2025-01-15" },
+        periodo_paa_objeto: { referencia: "Teste Referência" },
       })
     );
 
@@ -44,7 +44,7 @@ describe("BarraTopoTitulo", () => {
     );
 
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
-      "Plano Anual 01/2025"
+      "Plano Anual Teste Referência"
     );
   });
 
@@ -59,7 +59,7 @@ describe("BarraTopoTitulo", () => {
     localStorage.setItem(
       "DADOS_PAA",
       JSON.stringify({
-        periodo_paa_objeto: { data_inicial: "2026-05-01" },
+        periodo_paa_objeto: { referencia: "Teste Referência" },
       })
     );
     fireEvent(
@@ -67,13 +67,13 @@ describe("BarraTopoTitulo", () => {
       new StorageEvent("storage", {
         key: "DADOS_PAA",
         newValue: JSON.stringify({
-          periodo_paa_objeto: { data_inicial: "2026-05-01" },
+          periodo_paa_objeto: { referencia: "Teste Referência" },
         }),
       })
     );
 
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
-      "Plano Anual 05/2026"
+      "Plano Anual Teste Referência"
     );
   });
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/index.js
@@ -13,11 +13,7 @@ const BarraTopoTitulo = () => {
 
   const headerPaaReferencia = useCallback(() => {
     // retornar o texto completo(com referência de período) do header
-    return `Plano Anual ${
-      paa?.periodo_paa_objeto?.data_inicial
-        ? dayjs(paa.periodo_paa_objeto.data_inicial).format("MM/YYYY")
-        : ""
-    }`;
+    return `Plano Anual ${paa?.periodo_paa_objeto?.referencia}`;
   }, [paa]);
 
   useEffect(() => {


### PR DESCRIPTION
Esse PR:

Ajusta o título do PAA para o campo `referencia` da classe

História [AB#129382](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/129382)