### PR TITLE
feature(132467): Importação de Prioridades sobre um PAA anterior

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/BarraTopoTitulo/index.js
@@ -35,7 +35,7 @@ const BarraTopoTitulo = () => {
         <h2>{headerPaaReferencia()}</h2>
       </div>
       <div className="p-2 bd-highlight">
-        <button className="btn btn-outline-success" onClick={() => navigate('/paa')}>Voltar</button>
+        <button className="btn btn-outline-success btn-sm" onClick={() => navigate('/paa')}>Voltar</button>
       </div>
     </div>
   );

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalFormAdicionarPrioridade.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalFormAdicionarPrioridade.js
@@ -437,10 +437,11 @@ const ModalFormAdicionarPrioridade = ({ open, onClose, tabelas, formModal, focus
               >
                 Cancelar
               </button>
-
-              <button type="submit" className="btn btn btn-success">
-                Salvar
-              </button>
+              <Spin spinning={mutationPatch.isPending || mutationPost.isPending}>
+                <button type="submit" className="btn btn btn-success">
+                  Salvar
+                </button>
+              </Spin>
             </Flex>
           </Form>
         </Spin>

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalImportarPrioridades.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalImportarPrioridades.js
@@ -1,0 +1,110 @@
+import { memo, useState, useMemo, useEffectseRef } from "react";
+import { Form, Row, Col, Flex, Spin, Typography, Select } from 'antd';
+import { ModalFormBodyText } from "../../../../../Globais/ModalBootstrap";
+import { usePostImportarPrioridades } from "./hooks/usePostImportarPrioridades";
+import { importaPrioridadesValidationSchema } from "./validationSchema";
+
+
+const ModalImportarPrioridades = ({ open, onClose, paas }) => {
+  const [form] = Form.useForm();
+
+  const { mutationImportarPrioridades } = usePostImportarPrioridades(onClose);
+
+  const isLoading = false;
+  const initialValues = {
+    uuid_paa_anterior: undefined,
+  }
+
+  const paasOptions = Array.isArray(paas) ? paas.map(item => ({
+    value: item.uuid,
+    label: item?.periodo_paa_objeto?.referencia
+  })) : [];
+
+  const onSubmit = async (values) => {
+    try {
+      const validationSchema = importaPrioridadesValidationSchema();
+      await validationSchema.validate(values, { abortEarly: false });
+
+      const uuid_paa_atual = localStorage.getItem("PAA")
+      const uuid_paa_anterior = values.uuid_paa_anterior
+      
+      mutationImportarPrioridades.mutate({ uuid_paa_atual, uuid_paa_anterior});
+      
+    } catch (validationErrors) {
+      if (validationErrors.inner) {
+        const errors = {};
+        validationErrors.inner.forEach(error => {
+          errors[error.path] = error.message;
+        });
+        const errorKeys = Object.keys(errors);
+        form.setFields(
+          Array.isArray(errorKeys) ? errorKeys.map(key => ({
+            name: key,
+            errors: [errors[key]]
+          })) : []
+        );
+      }
+    }
+  };
+  
+  return (
+    <ModalFormBodyText
+      show={open}
+      onHide={onClose}
+      titulo={`Importar PAAs anteriores`}
+      // size="lg"
+      bodyText={
+        <Spin spinning={ isLoading }>
+          <Form
+            form={form}
+            onFinish={onSubmit}
+            initialValues={initialValues}
+            role="form"
+            className="p-2"
+            >
+            <Typography.Text>
+                Selecione o ano em que deseja importar os dados para o PAA atual.
+            </Typography.Text>
+            <Row gutter={[16, 8]} className="mt-3">
+              <Col md={24}>
+                <Form.Item
+                  label="Ano:"
+                  name="uuid_paa_anterior"
+                  labelCol={{ span: 24 }}
+                  style={{ marginBottom: 3 }}>
+                  <Select
+                    placeholder="Selecione um PAA"
+                    style={{ width: "100%" }}
+                    options={paasOptions}
+                    onChange={() => form.setFields([{ name: 'uuid_paa_anterior', errors: [] }])}
+                  />
+                </Form.Item>
+              </Col>
+            </Row>
+
+            <Flex gap={16} justify="end" className="mt-3">
+              <Spin spinning={mutationImportarPrioridades.isPending}>
+                <button
+                  type="button"
+                  className="btn btn-outline-success btn-sm"
+                  onClick={onClose}
+                >
+                  Cancelar
+                </button>
+              </Spin>
+              <Spin spinning={mutationImportarPrioridades.isPending}>
+                <button
+                  type="submit"
+                  className="btn btn btn-success btn-sm">
+                  Importar
+                </button>
+              </Spin>
+            </Flex>
+          </Form>
+        </Spin>
+      }
+    />
+  );
+};
+
+export default memo(ModalImportarPrioridades);

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/Tabela.js
@@ -66,7 +66,8 @@ export const Tabela = forwardRef(({ data, handleEditar, handleDuplicar, handleEx
             <Column 
                 header={
                     <input 
-                        type="checkbox" 
+                        type="checkbox"
+                        className='seletor-header'
                         checked={isAllSelected}
                         ref={(input) => {
                             if (input) input.indeterminate = isIndeterminate;
@@ -81,6 +82,7 @@ export const Tabela = forwardRef(({ data, handleEditar, handleDuplicar, handleEx
                     
                     return (
                         <input 
+                            className='seletor-individual'
                             type="checkbox" 
                             checked={isChecked}
                             onChange={() => handleSelectItem(rowData.uuid)}

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/useGetPAAsAnteriores.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/useGetPAAsAnteriores.js
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPAAsAnteriores } from "../../../../../../../services/sme/Parametrizacoes.service";
+
+export const useGetPAAsAnteriores = () => {
+  const {
+    isFetching,
+    isError,
+    data = {},
+    error,
+    refetch,
+  } = useQuery(["paas-anteriores"], () => getPAAsAnteriores(), {
+    keepPreviousData: true,
+    staleTime: 5000, // 5 segundos
+    refetchOnWindowFocus: true, // Caso saia da aba e voltar ele refaz a requisição
+    enabled: true,
+  });
+
+  return { isFetching, isError, paas_anteriores: data, error, refetch };
+};

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostImportarPrioridades.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostImportarPrioridades.js
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postImportarPrioridades } from "../../../../../../../services/escolas/Paa.service";
+import { toastCustom } from "../../../../../../Globais/ToastCustom";
+
+export const usePostImportarPrioridades = (onClose) => {
+
+  const queryClient = useQueryClient();
+
+  const mutationImportarPrioridades = useMutation({
+    mutationFn: ({ uuid_paa_atual, uuid_paa_anterior }) => postImportarPrioridades(uuid_paa_atual, uuid_paa_anterior),
+    
+    onSuccess: (data) => {
+      toastCustom.ToastCustomSuccess(`Prioridades importadas com sucesso.`);
+      queryClient.invalidateQueries(["prioridades"]);
+      queryClient.invalidateQueries(["prioridades-resumo"]);
+      onClose && onClose();
+    },
+    onError: (e) => {
+      const mensagemDeErro = e?.response?.data?.mensagem || "Houve um erro ao importar prioridades.";
+      toastCustom.ToastCustomError(mensagemDeErro);
+      console.error(e)
+    },
+  });
+
+  return { mutationImportarPrioridades };
+};

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/index.js
@@ -3,6 +3,7 @@ import { Flex, Button, Spin, Alert, Typography } from 'antd';
 import { Paginator } from "primereact/paginator";
 import ModalFormAdicionarPrioridade from './ModalFormAdicionarPrioridade';
 import { useGetPrioridadeTabelas } from "./hooks/useGetPrioridadeTabelas";
+import { useGetPAAsAnteriores } from "./hooks/useGetPAAsAnteriores";
 import { useGetPrioridades } from "./hooks/useGetPrioridades";
 import { usePostDuplicarPrioridade } from "./hooks/usePostPrioridade";
 import { useDeletePrioridade } from "./hooks/useDeletePrioridade";
@@ -14,6 +15,7 @@ import { ModalConfirmarExclusao } from "../../../../../sme/Parametrizacoes/compo
 import Img404 from "../../../../../../assets/img/img-404.svg";
 import { Tabela } from './Tabela';
 import { Resumo } from './Resumo';
+import ModalImportarPrioridades from './ModalImportarPrioridades';
 
 
 const filtroInicial = {
@@ -36,6 +38,10 @@ const Prioridades = () => {
   const { prioridadesTabelas, recursos, tipos_aplicacao } = useGetPrioridadeTabelas();
   const { tipos_despesa_custeio } = useGetTiposDespesaCusteio();
   const { isFetching: isLoadingPrioridades, prioridades, quantidade, refetch } = useGetPrioridades(filtros, currentPage);
+
+  // PAA`s Anteriores
+  const [modalImportarPrioridades, setModalImportarPrioridades] = useState({ open: false, paas: [] });
+  const { paas_anteriores, isFetching: isLoadingPAAsAnteriores } = useGetPAAsAnteriores();
   
   const { mutationDelete } = useDeletePrioridade(() => setModalExclusao({ open: false, item: null, tipo: 'individual' }));
   const { mutationDeleteEmLote } = useDeletePrioridadesEmLote(() => {
@@ -76,7 +82,11 @@ const Prioridades = () => {
     setFirstPage(0);
   };
 
-  const abrirModal = async () => {
+  const abrirModalImportarPAAsAnteriores = async () => {
+    setModalImportarPrioridades({ open: true, paas: paas_anteriores });
+  };
+
+  const abrirModalNovaPrioridade = async () => {
     setModalForm({ open: true, tabelas: dadosTabelas, formModal: null });
   };
 
@@ -104,6 +114,7 @@ const Prioridades = () => {
     } else {
       mutationDeleteEmLote.mutate({ payload: modalExclusao.item });
     }
+    onFiltrar();
   };
 
   const existePrioridadesSemValor = () => {
@@ -119,11 +130,22 @@ const Prioridades = () => {
             Registro de prioridades
         </Typography.Title>
 
-        <Button
-          type="primary"
-          onClick={abrirModal}>
-          Adicionar nova prioridade
-        </Button>
+        <Flex>
+          <Spin spinning={isLoadingPAAsAnteriores}>
+            <button
+              className="btn btn-outline-success btn-sm mx-2"
+              onClick={abrirModalImportarPAAsAnteriores}
+              type="button">
+                Importar PAAs anteriores
+            </button>
+          </Spin>
+          <button
+              className="btn btn-success btn-sm"
+              onClick={abrirModalNovaPrioridade}
+              type="button">
+              Adicionar prioridade
+          </button>
+        </Flex>
       </Flex>
 
       {/* Bloco de filtros com 7 selects */}
@@ -195,6 +217,16 @@ const Prioridades = () => {
             tabelas: null,
             formModal: null,
             focusValor: false })}
+        />
+      )}
+
+      {modalImportarPrioridades.open && (
+        <ModalImportarPrioridades
+          open={modalImportarPrioridades.open}
+          paas={modalImportarPrioridades.paas}
+          onClose={() => setModalImportarPrioridades({
+            open: false,
+            paas: []})}
         />
       )}
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/validationSchema.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/validationSchema.js
@@ -38,4 +38,12 @@ export const createValidationSchema = (selectedRecurso, selectedTipoAplicacao) =
   }
 
   return schema;
+};
+
+export const importaPrioridadesValidationSchema = () => {
+  let schema = Yup.object().shape({
+    uuid_paa_anterior: Yup.string().required('PAA anterior é obrigatório'),
+  });
+
+  return schema;
 }; 

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -137,6 +137,10 @@ export const postAtivarAtualizacaoSaldoPAA = async (uuid) => {
   ).data;
 };
 
+export const postImportarPrioridades = async (uuid_paa_atual, uuid_paa_anterior) => {
+  return (await api.post(`api/paa/${uuid_paa_atual}/importar-prioridades/${uuid_paa_anterior}/`, {}, authHeader())).data;
+}
+
 // Prioridades
 export const getPrioridadesTabelas = async () => {
   return (await api.get(`api/prioridades-paa/tabelas/`, authHeader())).data;

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -245,6 +245,11 @@ export const getPaaVigente = async (associacao_uuid) => {
   const result = await api.get(`/api/associacoes/${associacao_uuid}/paa-vigente/`, authHeader());
   return result
 };
+
+export const getPAAsAnteriores = async () => {
+  return (await api.get(`/api/paa/${localStorage.getItem('PAA')}/paas-anteriores/`, authHeader())).data;
+};
+
 export const getParametroPaa = async () => {
   return (await api.get(`/api/parametros-paa/mes-elaboracao-paa/`, authHeader())).data;
 };


### PR DESCRIPTION
Esse PR:

Adiciona:
- Modal de seleção de PAA Anterior para importação de Prioridades
- hook e service API de Get para PAAs Anteriores
- hook e service API de Post para Importar Prioridades
- Adiciona loading nos botões de Salvar Prioridades (evitar duplicidades de cliques)
- Validação de Formulário para o campo de PAA Anterior ao importar prioridades

História AB#132467