### PR TITLE
hotfix(134733): Ata retificação e ajustes externos e encerramento conta

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -96,18 +96,24 @@ export const GetComportamentoPorStatus = (
     };
 
     const podeReceberDevolvidaRetornada = () => {
-        return (
+        if (prestacaoDeContas.tem_apenas_ajustes_externos) {
+            const resultado = TEMPERMISSAO && dataRecebimentoDevolutiva;
+            return resultado;
+        }
+        
+        const resultado = (
             TEMPERMISSAO && 
             dataRecebimentoDevolutiva && 
             prestacaoDeContas.ata_retificacao_gerada
-        )
+        );
+        return resultado;
     };
 
 
     const tooltipReceberAposAcerto = () => {
         if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !dataRecebimentoDevolutiva){
             return "É necessário informar a data de recebimento para realizar o recebimento da Prestação de Contas."
-        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada){
+        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas.tem_apenas_ajustes_externos){
             return "É necessário efetuar a geração da ata de retificação para realizar o recebimento da Prestação de Contas."
         }
             

--- a/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
@@ -68,6 +68,7 @@ export function PendenciasRecebimento({ prestacaoDeContas }) {
 
     if (
       prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA &&
+      !prestacaoDeContas.tem_apenas_ajustes_externos &&
       !prestacaoDeContas.ata_retificacao_gerada
     ) {
       _pendencias.push(

--- a/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/CardSaldoEncerramentoConta.js
+++ b/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/CardSaldoEncerramentoConta.js
@@ -3,6 +3,7 @@ import {DatePickerField} from "../../../../Globais/DatePickerField";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faExclamationCircle, faTimesCircle} from "@fortawesome/free-solid-svg-icons";
 import { Tooltip as ReactTooltip } from "react-tooltip";
+import { visoesService } from "../../../../../services/visoes.service";
 
 export const CardSaldoEncerramentoConta = ({
     index, 
@@ -78,7 +79,7 @@ export const CardSaldoEncerramentoConta = ({
                                     </label>
                                     
                                     <DatePickerField
-                                        disabled={!conta.habilitar_solicitar_encerramento}
+                                        disabled={!conta.habilitar_solicitar_encerramento || !visoesService.getPermissoes(['change_associacao'])}
                                         value={dataEncerramento}
                                         onChange={(name, value) => setDataEncerramento(value)}
                                         name='data_extrato'
@@ -95,50 +96,51 @@ export const CardSaldoEncerramentoConta = ({
                                 </div>                                                             
                             </div>
 
-                            <div className="col-6 d-flex flex-wrap justify-content-end mt-5">
-                                {conta.habilitar_solicitar_encerramento && (
-                                    <div data-html={true} data-tooltip-content="Essa solicitação deve ser feita à DRE, após o encerramento da conta no banco e, caso validada, inativará a referida conta para eventos futuros no sistema."
-                                        className="mb-3">
+                            {visoesService.getPermissoes(['change_associacao']) &&
+                                <div className="col-6 d-flex flex-wrap justify-content-end mt-5">
+                                    {conta.habilitar_solicitar_encerramento && (
+                                        <div data-html={true} data-tooltip-content="Essa solicitação deve ser feita à DRE, após o encerramento da conta no banco e, caso validada, inativará a referida conta para eventos futuros no sistema."
+                                            className="mb-3">
+                                            <button 
+                                                type="button"
+                                                className="btn btn-base-verde-outline"
+                                                onClick={() => handleOpenModalConfirmEncerramentoConta(conta, dataEncerramento, index)}
+                                            >
+                                                <FontAwesomeIcon
+                                                    className="icon-btn-base-verde-outline"
+                                                    icon={faTimesCircle}
+                                                />
+                                                Solicitar encerramento da conta
+                                            </button>
+                                        </div>
+                                    )}
+                                    
+                                    {conta.solicitacao_encerramento && conta.solicitacao_encerramento.status === statusSolicitacao.PENDENTE  && (
                                         <button 
                                             type="button"
-                                            className="btn btn-base-verde-outline"
-                                            onClick={() => handleOpenModalConfirmEncerramentoConta(conta, dataEncerramento, index)}
+                                            className="btn btn-base-vermelho-outline"
+                                            onClick={() => handleCancelarEncerramento(conta.solicitacao_encerramento)}
                                         >
                                             <FontAwesomeIcon
-                                                className="icon-btn-base-verde-outline"
+                                                className="icon-btn-base-vermelho-outline"
                                                 icon={faTimesCircle}
                                             />
-                                            Solicitar encerramento da conta
+                                            Cancelar solicitação de encerramento
                                         </button>
-                                    </div>
-                                )}
-                                
-                                {conta.solicitacao_encerramento && conta.solicitacao_encerramento.status === statusSolicitacao.PENDENTE  && (
-                                    <button 
-                                        type="button"
-                                        className="btn btn-base-vermelho-outline"
-                                        onClick={() => handleCancelarEncerramento(conta.solicitacao_encerramento)}
-                                    >
-                                        <FontAwesomeIcon
-                                            className="icon-btn-base-vermelho-outline"
-                                            icon={faTimesCircle}
-                                        />
-                                        Cancelar solicitação de encerramento
-                                    </button>
-                                )}                                   
+                                    )}                                   
 
-                                {conta.solicitacao_encerramento && conta.solicitacao_encerramento.status === statusSolicitacao.REJEITADA  && (
-                                    <div className="ml-3">
-                                        <button 
-                                            type="button"
-                                            className="btn btn-base-verde"
-                                            onClick={() => handleOpenModalMotivoRejeicaoEncerramento(conta.solicitacao_encerramento)}
-                                        >
-                                            Ver motivo da negativa
-                                        </button>
-                                    </div>
-                                )}                                
-                            </div>
+                                    {conta.solicitacao_encerramento && conta.solicitacao_encerramento.status === statusSolicitacao.REJEITADA  && (
+                                        <div className="ml-3">
+                                            <button 
+                                                type="button"
+                                                className="btn btn-base-verde"
+                                                onClick={() => handleOpenModalMotivoRejeicaoEncerramento(conta.solicitacao_encerramento)}
+                                            >
+                                                Ver motivo da negativa
+                                            </button>
+                                        </div>
+                                    )}                                
+                            </div>}
                         </>
                     }
                 </div>

--- a/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/__tests__/CardSaldoEncerramentoConta.test.js
+++ b/src/componentes/escolas/Associacao/DadosDasContas/FormDadosDasContas/__tests__/CardSaldoEncerramentoConta.test.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { within } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { CardSaldoEncerramentoConta } from "../CardSaldoEncerramentoConta";
+
+jest.mock("../../../../../../services/visoes.service", () => ({
+  visoesService: {
+    getPermissoes: jest.fn(),
+  },
+}));
+
+const { visoesService } = require("../../../../../../services/visoes.service");
+
+function setupComponent(overrides = {}) {
+  const props = {
+    index: 0,
+    conta: {
+      tipo_conta: { permite_inativacao: true },
+      saldo_atual_conta: 0,
+      habilitar_solicitar_encerramento: true,
+      solicitacao_encerramento: null,
+    },
+    handleOpenModalConfirmEncerramentoConta: jest.fn(),
+    handleOpenModalMotivoRejeicaoEncerramento: jest.fn(),
+    handleCancelarEncerramento: jest.fn(),
+    errosDataEncerramentoConta: [],
+    inicioPeriodo: new Date("2024-01-01"),
+    ...overrides,
+  };
+
+  return render(<CardSaldoEncerramentoConta {...props} />);
+}
+
+test("respeita permissao change_associacao: desabilita data e oculta acoes quando sem permissao; habilita e exibe quando tem permissao", async () => {
+  const user = userEvent.setup();
+
+  // Sem permissao -> campo data desabilitado e botoes nao aparecem
+  visoesService.getPermissoes.mockReturnValue(false);
+  const renderNoPerm = setupComponent();
+
+  const dateInputNoPerm = within(renderNoPerm.container).getByRole("textbox");
+  expect(dateInputNoPerm).toBeDisabled();
+  expect(within(renderNoPerm.container).queryByRole("button", { name: /Solicitar encerramento da conta/i })).not.toBeInTheDocument();
+
+  // Com permissao -> campo habilitado e botoes aparecem
+  visoesService.getPermissoes.mockReturnValue(true);
+  const renderWithPerm = setupComponent();
+
+  const dateInputWithPerm = within(renderWithPerm.container).getByRole("textbox");
+  expect(dateInputWithPerm).not.toBeDisabled();
+  expect(within(renderWithPerm.container).getByRole("button", { name: /Solicitar encerramento da conta/i })).toBeInTheDocument();
+
+  await user.click(within(renderWithPerm.container).getByRole("button", { name: /Solicitar encerramento da conta/i }));
+});

--- a/src/services/escolas/Despesas.service.js
+++ b/src/services/escolas/Despesas.service.js
@@ -17,13 +17,15 @@ export const deleteDespesa = async (uuid) => {
 
 export const getDespesasTabelas = async (associacao_uuid = null) => {
   const uuid_associacao = getUuidAssociacao();
+  const uuid = associacao_uuid || uuid_associacao;
+  
+  if (!uuid) {
+    return null;
+  }
+  
   return (
     await api.get(
-      `api/despesas/tabelas/?associacao_uuid=${
-        associacao_uuid
-          ? associacao_uuid
-          : uuid_associacao
-      }`,
+      `api/despesas/tabelas/?associacao_uuid=${uuid}`,
       authHeader()
     )
   ).data;


### PR DESCRIPTION
Esse hotfix:

- Remove a obrigatoriedade de ter ata de retificação quando é uma devolução com apenas ajuste externo.
- Adiciona permissão de editar dados de associação na funcionalidade de solicitar encerramento de conta.

História: AB#134733 AB#134682