### PR TITLE
hotfix(134733): Adiciona categoria que não requer ata de retificação

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -96,24 +96,18 @@ export const GetComportamentoPorStatus = (
     };
 
     const podeReceberDevolvidaRetornada = () => {
-        if (prestacaoDeContas.tem_apenas_ajustes_externos) {
-            const resultado = TEMPERMISSAO && dataRecebimentoDevolutiva;
-            return resultado;
+        const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
+        if (naoRequerAta) {
+            return TEMPERMISSAO && dataRecebimentoDevolutiva;
         }
-        
-        const resultado = (
-            TEMPERMISSAO && 
-            dataRecebimentoDevolutiva && 
-            prestacaoDeContas.ata_retificacao_gerada
-        );
-        return resultado;
+        return TEMPERMISSAO && dataRecebimentoDevolutiva && prestacaoDeContas.ata_retificacao_gerada;
     };
 
 
     const tooltipReceberAposAcerto = () => {
         if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !dataRecebimentoDevolutiva){
             return "É necessário informar a data de recebimento para realizar o recebimento da Prestação de Contas."
-        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas.tem_apenas_ajustes_externos){
+        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata){
             return "É necessário efetuar a geração da ata de retificação para realizar o recebimento da Prestação de Contas."
         }
             

--- a/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
@@ -53,6 +53,7 @@ export function PendenciasRecebimento({ prestacaoDeContas }) {
 
   const handlePendencias = () => {
     let _pendencias = [];
+    const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
     if (
       prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.NAO_RECEBIDA &&
       !prestacaoDeContas.ata_aprensentacao_gerada
@@ -68,7 +69,7 @@ export function PendenciasRecebimento({ prestacaoDeContas }) {
 
     if (
       prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA &&
-      !prestacaoDeContas.tem_apenas_ajustes_externos &&
+      !naoRequerAta &&
       !prestacaoDeContas.ata_retificacao_gerada
     ) {
       _pendencias.push(


### PR DESCRIPTION
Esse PR:

- Adiciona um ajuste que permite o recebimento de PC após acerto quando possui apenas ajuste externo e/ou solicitação de esclarecimento.

História: AB#134733