### PR TITLE
hotfix(134733): Ajuste no recebimento após acerto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.23.1",
+  "version": "9.23.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.23.2",
+  "version": "9.23.3",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -96,7 +96,7 @@ export const GetComportamentoPorStatus = (
     };
 
     const podeReceberDevolvidaRetornada = () => {
-        const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
+        const naoRequerAta = prestacaoDeContas.possui_apenas_categorias_que_nao_requerem_ata;
         if (naoRequerAta) {
             return TEMPERMISSAO && dataRecebimentoDevolutiva;
         }
@@ -107,7 +107,7 @@ export const GetComportamentoPorStatus = (
     const tooltipReceberAposAcerto = () => {
         if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !dataRecebimentoDevolutiva){
             return "É necessário informar a data de recebimento para realizar o recebimento da Prestação de Contas."
-        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata){
+        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas.possui_apenas_categorias_que_nao_requerem_ata){
             return "É necessário efetuar a geração da ata de retificação para realizar o recebimento da Prestação de Contas."
         }
             

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -96,24 +96,18 @@ export const GetComportamentoPorStatus = (
     };
 
     const podeReceberDevolvidaRetornada = () => {
-        if (prestacaoDeContas.tem_apenas_ajustes_externos) {
-            const resultado = TEMPERMISSAO && dataRecebimentoDevolutiva;
-            return resultado;
+        const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
+        if (naoRequerAta) {
+            return TEMPERMISSAO && dataRecebimentoDevolutiva;
         }
-        
-        const resultado = (
-            TEMPERMISSAO && 
-            dataRecebimentoDevolutiva && 
-            prestacaoDeContas.ata_retificacao_gerada
-        );
-        return resultado;
+        return TEMPERMISSAO && dataRecebimentoDevolutiva && prestacaoDeContas.ata_retificacao_gerada;
     };
 
 
     const tooltipReceberAposAcerto = () => {
         if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !dataRecebimentoDevolutiva){
             return "É necessário informar a data de recebimento para realizar o recebimento da Prestação de Contas."
-        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas.tem_apenas_ajustes_externos){
+        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata){
             return "É necessário efetuar a geração da ata de retificação para realizar o recebimento da Prestação de Contas."
         }
             

--- a/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/PendenciasRecebimento/index.js
@@ -53,6 +53,7 @@ export function PendenciasRecebimento({ prestacaoDeContas }) {
 
   const handlePendencias = () => {
     let _pendencias = [];
+    const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
     if (
       prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.NAO_RECEBIDA &&
       !prestacaoDeContas.ata_aprensentacao_gerada
@@ -68,7 +69,7 @@ export function PendenciasRecebimento({ prestacaoDeContas }) {
 
     if (
       prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA &&
-      !prestacaoDeContas.tem_apenas_ajustes_externos &&
+      !naoRequerAta &&
       !prestacaoDeContas.ata_retificacao_gerada
     ) {
       _pendencias.push(


### PR DESCRIPTION
Esse PR:

- Adiciona um ajustes que permitem o recebimento de PCs após acerto sem ata de retificação apenas quando possui ajuste externo, solicitação de esclarecimento e acertos não realizados.

História: AB#134733