### PR TITLE
hotfix(134733): Adiciona categoria que não requer ata de retificação v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.23.2",
+  "version": "9.23.3",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/GetComportamentoPorStatus.js
@@ -96,7 +96,7 @@ export const GetComportamentoPorStatus = (
     };
 
     const podeReceberDevolvidaRetornada = () => {
-        const naoRequerAta = prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata;
+        const naoRequerAta = prestacaoDeContas.possui_apenas_categorias_que_nao_requerem_ata;
         if (naoRequerAta) {
             return TEMPERMISSAO && dataRecebimentoDevolutiva;
         }
@@ -107,7 +107,7 @@ export const GetComportamentoPorStatus = (
     const tooltipReceberAposAcerto = () => {
         if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !dataRecebimentoDevolutiva){
             return "É necessário informar a data de recebimento para realizar o recebimento da Prestação de Contas."
-        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas?.possui_apenas_categorias_que_nao_requerem_ata){
+        } else if(prestacaoDeContas && prestacaoDeContas.status === STATUS_PRESTACAO_CONTA.DEVOLVIDA_RETORNADA && !prestacaoDeContas.ata_retificacao_gerada && !prestacaoDeContas.possui_apenas_categorias_que_nao_requerem_ata){
             return "É necessário efetuar a geração da ata de retificação para realizar o recebimento da Prestação de Contas."
         }
             


### PR DESCRIPTION
Esse PR:

- Adiciona um ajuste que permite o recebimento de PC após acerto quando possui apenas ajuste externo e/ou solicitação de esclarecimento.

História: AB#134733