### PR TITLE
feature(134186): Regras de Importação de Prioridades do PAA

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalImportarPrioridades.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/ModalImportarPrioridades.js
@@ -1,12 +1,16 @@
 import { memo, useState, useMemo, useEffectseRef } from "react";
+import { useDispatch } from "react-redux";
 import { Form, Row, Col, Flex, Spin, Typography, Select } from 'antd';
 import { ModalFormBodyText } from "../../../../../Globais/ModalBootstrap";
 import { usePostImportarPrioridades } from "./hooks/usePostImportarPrioridades";
 import { importaPrioridadesValidationSchema } from "./validationSchema";
-
+import { CustomModalConfirm } from "../../../../../Globais/Modal/CustomModalConfirm";
+import { toastCustom } from "../../../../../Globais/ToastCustom";
 
 const ModalImportarPrioridades = ({ open, onClose, paas }) => {
   const [form] = Form.useForm();
+
+  const dispatch = useDispatch();
 
   const { mutationImportarPrioridades } = usePostImportarPrioridades(onClose);
 
@@ -28,7 +32,36 @@ const ModalImportarPrioridades = ({ open, onClose, paas }) => {
       const uuid_paa_atual = localStorage.getItem("PAA")
       const uuid_paa_anterior = values.uuid_paa_anterior
       
-      mutationImportarPrioridades.mutate({ uuid_paa_atual, uuid_paa_anterior});
+      mutationImportarPrioridades.mutate(
+        { uuid_paa_atual, uuid_paa_anterior, confirmar: 0},
+        {
+        onError: (e) => {
+          if (e?.response?.data?.confirmar) {
+            CustomModalConfirm({
+              dispatch,
+              title: "Confirma importação?",
+              message: e.response.data.confirmar,
+              cancelText: "Não",
+              confirmText: "Sim",
+              dataQa: "modal-confirmar-importar-prioridades",
+              isDanger: true,
+              onConfirm: () => {
+                mutationImportarPrioridades.mutate({
+                  uuid_paa_atual,
+                  uuid_paa_anterior,
+                  confirmar: 1,
+                });
+                onClose();
+              },
+            });
+          } else {
+            const mensagemDeErro = e?.response?.data?.mensagem || "Houve um erro ao importar prioridades.";
+            toastCustom.ToastCustomError(mensagemDeErro);
+            console.error(e)
+          }
+        },
+      }
+      );
       
     } catch (validationErrors) {
       if (validationErrors.inner) {

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/__tests__/ModalImportarPrioridades.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/__tests__/ModalImportarPrioridades.test.js
@@ -1,13 +1,27 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ModalImportarPrioridades from '../ModalImportarPrioridades';
 import { usePostImportarPrioridades } from '../hooks/usePostImportarPrioridades';
+import { toastCustom } from '../../../../../../Globais/ToastCustom';
+import { CustomModalConfirm } from "../../../../../../Globais/Modal/CustomModalConfirm";
 
+jest.mock("../../../../../../Globais/ToastCustom", () => ({
+  toastCustom: { ToastCustomError: jest.fn() },
+}));
 
 jest.mock('../hooks/usePostImportarPrioridades', () => ({
   usePostImportarPrioridades: jest.fn(),
+}));
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn()
+}));
+
+jest.mock("../../../../../../Globais/Modal/CustomModalConfirm", () => ({
+  CustomModalConfirm: jest.fn(),
 }));
 
 describe('ModalImportarPrioridades', () => {
@@ -15,8 +29,10 @@ describe('ModalImportarPrioridades', () => {
   let mockData;
   const mockOnClose = jest.fn();
   const mockMutate = jest.fn();
+  const mockDispatch = jest.fn();
 
   beforeEach(() => {
+    useDispatch.mockReturnValue(mockDispatch);
     localStorage.setItem("PAA", "uuid-atual-123");
     queryClient = new QueryClient({
       defaultOptions: {
@@ -105,24 +121,6 @@ describe('ModalImportarPrioridades', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it("faz submit válido e chama mutationImportarPrioridades.mutate", async () => {
-    const paas = mockData;
-
-    render(<ModalImportarPrioridades open={true} onClose={mockOnClose} paas={paas} />);
-
-    fireEvent.mouseDown(screen.getByRole("combobox"));
-    fireEvent.click(screen.getByText("2024 Teste Anterior"));
-
-    fireEvent.click(screen.getByRole("button", { name: /Importar/i }));
-
-    await waitFor(() => {
-      expect(mockMutate).toHaveBeenCalledWith({
-        uuid_paa_atual: "uuid-atual-123",
-        uuid_paa_anterior: mockData[0].uuid,
-      });
-    });
-  });
-
   it("exibe erros de validação quando o form é enviado vazio", async () => {
     render(<ModalImportarPrioridades open={true} onClose={mockOnClose} paas={[]} />);
 
@@ -130,6 +128,74 @@ describe('ModalImportarPrioridades', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/PAA anterior é obrigatório/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clica em Cancelar → chama onClose", () => {
+    const onClose = jest.fn();
+    render(<ModalImportarPrioridades open onClose={onClose} paas={[]} />);
+
+    fireEvent.click(screen.getByText(/Cancelar/i));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("trata erro sem confirmar → chama toastCustom", async () => {
+    mockMutate.mockImplementation((_, { onError }) => {
+      onError({ response: { data: { mensagem: "Erro ao importar" } } });
+    });
+
+    render(<ModalImportarPrioridades open onClose={jest.fn()} paas={mockData} />);
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("2024 Teste Anterior"));
+
+
+    fireEvent.click(screen.getByText("Importar"));
+
+    await waitFor(() => {
+      expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+        "Erro ao importar"
+      );
+    });
+  });
+
+  it("trata erro com confirmar → abre CustomModalConfirm exigindo a confirmação", async () => {
+    mockMutate.mockImplementation((_, { onError }) => {
+      onError({ response: { data: { confirmar: "Confirmação necessária" } } });
+    });
+
+    render(<ModalImportarPrioridades open onClose={jest.fn()} paas={mockData} />);
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("2024 Teste Anterior"));
+
+    fireEvent.click(screen.getByText("Importar"));
+
+    await waitFor(() => {
+      expect(CustomModalConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Confirma importação?",
+          message: "Confirmação necessária",
+        })
+      );
+    });
+  });
+
+  it("submete form com sucesso", async () => {
+    render(<ModalImportarPrioridades open onClose={jest.fn()} paas={mockData} />);
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("2024 Teste Anterior"));
+
+    fireEvent.click(screen.getByText("Importar"));
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith(
+        {
+          uuid_paa_atual: "uuid-atual-123",
+          uuid_paa_anterior: mockData[0].uuid,
+          confirmar: 0,
+        },
+        expect.any(Object)
+      );
     });
   });
 });

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/__tests__/index.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/__tests__/index.test.js
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useDispatch } from 'react-redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Prioridades from '../index';
 import { useGetPrioridadeTabelas } from '../hooks/useGetPrioridadeTabelas';
@@ -8,6 +9,10 @@ import { useGetTiposDespesaCusteio } from '../hooks/useGetTiposDespesaCusteio';
 // Mock dos hooks
 jest.mock('../hooks/useGetPrioridadeTabelas', () => ({
   useGetPrioridadeTabelas: jest.fn(),
+}));
+
+jest.mock("react-redux", () => ({
+  useDispatch: jest.fn()
 }));
 
 jest.mock('../hooks/useGetPrioridades', () => ({
@@ -42,11 +47,13 @@ jest.mock('../FormFiltros', () => ({
 
 // Mock do Tabela
 jest.mock('../Tabela', () => ({
-  Tabela: ({ data, handleEditar }) => (
+  Tabela: ({ data, handleEditar, handleDuplicar }) => (
     <div data-testid="tabela">
       {data?.map((item, index) => (
         <div key={item.uuid || index} data-testid={`row-${index}`}>
-          {item.acao || 'Ação'} <button data-testid={`btn-editar-${index}`} onClick={() => handleEditar()}>Editar</button>
+          {item.acao || 'Ação'}
+          <button data-testid={`btn-editar-${index}`} onClick={() => handleEditar()}>Editar</button>
+          <button data-testid={`btn-duplicar-${index}`} onClick={() => handleDuplicar(item.uuid)}>Duplicar</button>
         </div>
       ))}
     </div>
@@ -127,7 +134,10 @@ const renderWithQueryClient = (component) => {
 };
 
 describe('Prioridades', () => {
+  const mockDispatch = jest.fn();
+
   beforeEach(() => {
+    useDispatch.mockReturnValue(mockDispatch);
     window.matchMedia = jest.fn().mockImplementation((query) => ({
         matches: false,
         addListener: jest.fn(),
@@ -354,5 +364,23 @@ describe('Prioridades', () => {
     renderWithQueryClient(<Prioridades />);
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it("aciona edição e duplicação via tabela", () => {
+    const prioridades = mockPrioridades
+    useGetPrioridades.mockReturnValue({
+      isLoading: false,
+      prioridades: prioridades,
+      quantidade: prioridades.length,
+      refetch: jest.fn()
+    });
+    renderWithQueryClient(<Prioridades />);
+
+    const botaoEditar = screen.getByTestId('btn-editar-0');
+    const botaoDuplicar = screen.getByTestId('btn-duplicar-0');
+    fireEvent.click(botaoEditar);
+    expect(screen.getByTestId("modal-form")).toBeInTheDocument();
+
+    fireEvent.click(botaoDuplicar);
   });
 });

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostImportarPrioridades.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostImportarPrioridades.js
@@ -3,22 +3,16 @@ import { postImportarPrioridades } from "../../../../../../../services/escolas/P
 import { toastCustom } from "../../../../../../Globais/ToastCustom";
 
 export const usePostImportarPrioridades = (onClose) => {
-
   const queryClient = useQueryClient();
 
   const mutationImportarPrioridades = useMutation({
-    mutationFn: ({ uuid_paa_atual, uuid_paa_anterior }) => postImportarPrioridades(uuid_paa_atual, uuid_paa_anterior),
-    
+    mutationFn: ({ uuid_paa_atual, uuid_paa_anterior, confirmar }) => postImportarPrioridades(
+                                                                        uuid_paa_atual, uuid_paa_anterior, confirmar),
     onSuccess: (data) => {
-      toastCustom.ToastCustomSuccess(`Prioridades importadas com sucesso.`);
+      toastCustom.ToastCustomSuccess(data?.mensagem || `Prioridades importadas com sucesso.`);
       queryClient.invalidateQueries(["prioridades"]);
       queryClient.invalidateQueries(["prioridades-resumo"]);
       onClose && onClose();
-    },
-    onError: (e) => {
-      const mensagemDeErro = e?.response?.data?.mensagem || "Houve um erro ao importar prioridades.";
-      toastCustom.ToastCustomError(mensagemDeErro);
-      console.error(e)
     },
   });
 

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -870,6 +870,15 @@ const routesConfig = [
   },
   {
     exact: true,
+    path: "/parametro-tipos-receita",
+    component: TiposDeCredito,
+    permissoes: [
+      "access_painel_parametrizacoes",
+      "change_painel_parametrizacoes",
+    ],
+  },
+  {
+    exact: true,
     path: "/lista-situacao-patrimonial",
     component: SituacaoPatrimonialPage,
     permissoes: ["access_situacao_patrimonial"],

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -145,8 +145,10 @@ export const postAtivarAtualizacaoSaldoPAA = async (uuid) => {
   ).data;
 };
 
-export const postImportarPrioridades = async (uuid_paa_atual, uuid_paa_anterior) => {
-  return (await api.post(`api/paa/${uuid_paa_atual}/importar-prioridades/${uuid_paa_anterior}/`, {}, authHeader())).data;
+export const postImportarPrioridades = async (uuid_paa_atual, uuid_paa_anterior, confirmar=0) => {
+  return (await api.post(
+    `api/paa/${uuid_paa_atual}/importar-prioridades/${uuid_paa_anterior}/?confirmar=${confirmar}`,
+    {}, authHeader())).data;
 }
 
 // Prioridades


### PR DESCRIPTION
Esse PR:

- Adiciona Modal de Confirmação de Importação do PAA quando já existem prioridades(anteriormente importadas) no Paa Atual
- Validação quando há tentativa de importar as prioridades do mesmo PAA já importado
- Atualização e Inclusão de novos testes unitários sobre a feature
- Inclusão de parâmetro de confirmação no service endpoint

História [AB#134186](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/134186)