### PR TITLE
fix(145696):  Bloqueia botão gerar ata antes do paa final ser gerado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.35.1",
+  "version": "9.35.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
@@ -299,7 +299,7 @@ const Relatorios = ({ initialExpandedSections }) => {
     }
     if (!ataPaa?.uuid) return "Ata do PAA não encontrada.";
     if (!ataPaa?.completa) {
-      return "Preencha todos os dados obrigatórios da ata.";
+      return "Quando todos os dados estiverem preenchidos, a opção fica habilitada.";
     }
     return "";
   };

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
@@ -280,6 +280,32 @@ const Relatorios = ({ initialExpandedSections }) => {
     return validacoes.includes(true);
   };
 
+  const planoAnualDocumentoFinalGerado =
+    statusDocumento?.status === "CONCLUIDO" &&
+    statusDocumento?.versao === "FINAL";
+
+  const botaoGerarAtaDesabilitado = () => {
+    if (!podeEditar) return true;
+    if (!planoAnualDocumentoFinalGerado) return true;
+    if (!ataPaa?.uuid) return true;
+    if (!ataPaa?.completa) return true;
+    return false;
+  };
+
+  const mensagemTooltipGerarAta = () => {
+    if (!podeEditar) return "Sem permissão para gerar ata.";
+    if (!planoAnualDocumentoFinalGerado) {
+      return "Gere o Plano Anual antes de gerar a ata";
+    }
+    if (!ataPaa?.uuid) return "Ata do PAA não encontrada.";
+    if (!ataPaa?.completa) {
+      return "Preencha todos os dados obrigatórios da ata.";
+    }
+    return "";
+  };
+
+  const gerarAtaDisabled = botaoGerarAtaDesabilitado();
+
   return (
     <div className="relatorios-container">
       <div className="documentos-card">
@@ -411,19 +437,20 @@ const Relatorios = ({ initialExpandedSections }) => {
                 </button>
                 <button
                   className={`btn ${podeEditar ? "btn-success" : "btn-secondary"}`}
-                  disabled={!podeEditar}
-                  data-tooltip-content={
-                    !podeEditar
-                      ? "Sem permissão para gerar ata."
-                      : "Quando todos os dados estiverem preenchidos, a opção fica habilitada."
-                  }
-                  data-tooltip-id="tooltip-gerar-ata"
+                  type="button"
+                  disabled={gerarAtaDisabled}
+                  {...(gerarAtaDisabled && {
+                    "data-tooltip-content": mensagemTooltipGerarAta(),
+                    "data-tooltip-id": "tooltip-gerar-ata",
+                  })}
                 >
                   Gerar ata
                 </button>
               </Space>
             </div>
-            <ReactTooltip id="tooltip-gerar-ata" place="top" />
+            {gerarAtaDisabled && (
+              <ReactTooltip id="tooltip-gerar-ata" place="top" />
+            )}
           </div>
         </div>
       </div>

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/__tests__/index.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/__tests__/index.test.js
@@ -1,11 +1,14 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ElaborarNovoPlano } from '../index';
 import { iniciarAtaPaa } from '../../../../../../services/escolas/AtasPaa.service';
+import { visoesService } from '../../../../../../services/visoes.service';
 
 const mockUseLocation = jest.fn();
+const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => mockUseLocation(),
+  useNavigate: () => mockNavigate,
 }));
 
 jest.mock('../../../../../../paginas/PaginasContainer', () => ({
@@ -79,6 +82,12 @@ jest.mock('../../../../../../services/escolas/AtasPaa.service', () => ({
   iniciarAtaPaa: jest.fn(),
 }));
 
+jest.mock('../../../../../../services/visoes.service', () => ({
+  visoesService: {
+    getPermissoes: jest.fn(),
+  },
+}));
+
 const defaultLocation = { state: null, search: '' };
 
 describe('ElaborarNovoPlano', () => {
@@ -87,6 +96,7 @@ describe('ElaborarNovoPlano', () => {
     localStorage.clear();
     mockUseLocation.mockReturnValue(defaultLocation);
     iniciarAtaPaa.mockResolvedValue();
+    visoesService.getPermissoes.mockReturnValue(true);
   });
 
   describe('Renderização básica', () => {
@@ -298,6 +308,28 @@ describe('ElaborarNovoPlano', () => {
         'data-expanded',
         JSON.stringify(expandedSections)
       );
+    });
+  });
+
+  describe('Acesso à rota', () => {
+    it('redireciona para /paa quando não tem custom_change_paa nem PAA em andamento', async () => {
+      visoesService.getPermissoes.mockReturnValue(false);
+
+      render(<ElaborarNovoPlano />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/paa', { replace: true });
+      });
+    });
+
+    it('não redireciona sem custom_change_paa quando há PAA no localStorage (continuar elaboração)', () => {
+      visoesService.getPermissoes.mockReturnValue(false);
+      localStorage.setItem('PAA', 'uuid-continuar');
+
+      render(<ElaborarNovoPlano />);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(screen.getByTestId('paginas-container')).toBeInTheDocument();
     });
   });
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/index.js
@@ -7,11 +7,13 @@ import ReceitasPrevistas from './ReceitasPrevistas';
 import Prioridades from './Prioridades';
 import Relatorios from './Relatorios';
 import BarraTopoTitulo from './BarraTopoTitulo';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { iniciarAtaPaa } from '../../../../../services/escolas/AtasPaa.service';
+import { visoesService } from '../../../../../services/visoes.service';
 
 export const ElaborarNovoPlano = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const itemsBreadCrumb = [
     { label: 'Plano Anual de Atividades', url: '/paa' },
     { label: 'Elaborar novo plano', active: true },
@@ -48,6 +50,14 @@ export const ElaborarNovoPlano = () => {
     : null;
 
   useEffect(() => {
+    const temPermissaoIniciar = Boolean(
+      visoesService.getPermissoes(["custom_change_paa"])
+    );
+    const temPaaEmAndamento = Boolean(localStorage.getItem("PAA"));
+    if (!temPermissaoIniciar && !temPaaEmAndamento) {
+      navigate("/paa", { replace: true });
+      return;
+    }
     const paaUuid = localStorage.getItem("PAA");
     if (!paaUuid) {
       return;
@@ -55,7 +65,7 @@ export const ElaborarNovoPlano = () => {
     iniciarAtaPaa(paaUuid).catch((error) => {
       console.error("Erro ao iniciar ata do PAA:", error);
     });
-  }, []);
+  }, [navigate]);
 
   return (
     <PaginasContainer>

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/__tests__/index.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/__tests__/index.test.js
@@ -7,8 +7,15 @@ import { usePostPaa } from "../hooks/usePostPaa";
 import { getPaaVigente, getParametroPaa } from "../../../../../services/sme/Parametrizacoes.service";
 import { getStatusGeracaoDocumentoPaa } from "../../../../../services/escolas/Paa.service";
 import { ElaboracaoPaa } from '../index';
+import { visoesService } from '../../../../../services/visoes.service';
 
 jest.mock("../hooks/usePostPaa");
+
+jest.mock('../../../../../services/visoes.service', () => ({
+  visoesService: {
+    getPermissoes: jest.fn(),
+  },
+}));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -38,7 +45,7 @@ jest.mock('../EstruturaCompletaModeloPaa', () => ({
 
 const mockNavigate = jest.fn();
 let queryClient;
-const mockMutatePost = jest.fn();
+const mockMutateAsync = jest.fn();
 
 describe('ElaboracaoPaa Component', () => {
   beforeEach(() => {
@@ -54,16 +61,22 @@ describe('ElaboracaoPaa Component', () => {
       removeListener: jest.fn(),
     }));
 
+    mockMutateAsync.mockResolvedValue({ uuid: 'novo-uuid-paa' });
+
     usePostPaa.mockReturnValue({
-      mutationPost: { mutate: mockMutatePost, isPending: false },
+      mutationPost: { mutateAsync: mockMutateAsync, isPending: false },
     });
 
     require('react-router-dom').useNavigate.mockReturnValue(mockNavigate);
 
     jest.clearAllMocks();
 
+    visoesService.getPermissoes.mockReturnValue(true);
+
+    mockMutateAsync.mockResolvedValue({ uuid: 'novo-uuid-paa' });
+
     usePostPaa.mockReturnValue({
-      mutationPost: { mutate: mockMutatePost, isPending: false },
+      mutationPost: { mutateAsync: mockMutateAsync, isPending: false },
     });
     require('react-router-dom').useNavigate.mockReturnValue(mockNavigate);
   });
@@ -100,7 +113,72 @@ describe('ElaboracaoPaa Component', () => {
 
     fireEvent.click(screen.getByTestId('elaborar-paa-button'));
 
-    expect(mockMutatePost).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalled();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/elaborar-novo-paa');
+  });
+
+  it('desabilita o botão Elaborar novo PAA quando não há custom_change_paa e não existe PAA vigente', async () => {
+    visoesService.getPermissoes.mockReturnValue(false);
+    getTextosPaaUe.mockResolvedValue({
+      texto_pagina_paa_ue: 'Texto ABC',
+      introducao_do_paa_ue_1: '',
+      introducao_do_paa_ue_2: '',
+      conclusao_do_paa_ue_1: '',
+      conclusao_do_paa_ue_2: '',
+    });
+    getPaaVigente.mockRejectedValue(new Error('PAA não encontrado'));
+    getParametroPaa.mockResolvedValue({ detail: new Date().getMonth() + 1 });
+
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <ElaboracaoPaa />
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('elaborar-paa-button')).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId('elaborar-paa-button')).toBeDisabled();
+    expect(screen.getByTestId('elaborar-paa-button')).toHaveTextContent('Elaborar novo PAA');
+  });
+
+  it('habilita Continuar elaboração de PAA sem custom_change_paa quando já existe PAA vigente', async () => {
+    visoesService.getPermissoes.mockReturnValue(false);
+    getTextosPaaUe.mockResolvedValue({
+      texto_pagina_paa_ue: 'Texto ABC',
+      introducao_do_paa_ue_1: '',
+      introducao_do_paa_ue_2: '',
+      conclusao_do_paa_ue_1: '',
+      conclusao_do_paa_ue_2: '',
+    });
+    getPaaVigente.mockResolvedValue({ uuid: 'paa-existente' });
+    getStatusGeracaoDocumentoPaa.mockResolvedValue({ status: 'PENDENTE', versao: 'RASCUNHO' });
+    getParametroPaa.mockResolvedValue({ detail: new Date().getMonth() + 1 });
+
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <ElaboracaoPaa />
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('elaborar-paa-button')).toBeInTheDocument()
+    );
+
+    const btn = screen.getByTestId('elaborar-paa-button');
+    expect(btn).toBeEnabled();
+    expect(btn).toHaveTextContent('Continuar elaboração de PAA');
+
+    fireEvent.click(btn);
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/elaborar-novo-paa');
   });
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/index.js
@@ -9,10 +9,12 @@ import { usePostPaa } from "./hooks/usePostPaa";
 import { getPaaVigente, getParametroPaa } from "../../../../services/sme/Parametrizacoes.service";
 import { getStatusGeracaoDocumentoPaa } from "../../../../services/escolas/Paa.service";
 import { EstruturaCompletaModeloPaa } from './EstruturaCompletaModeloPaa';
+import { visoesService } from '../../../../services/visoes.service';
 
 export const ElaboracaoPaa = () => {
   const associacao_uuid = localStorage.getItem(ASSOCIACAO_UUID);
   const navigate = useNavigate();
+  const podeIniciarPaa = visoesService.getPermissoes(['custom_change_paa']);
 
   const [notValidPaa, setNotValidPaa] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -72,18 +74,23 @@ export const ElaboracaoPaa = () => {
     });
   }, []);
 
-  const handlePaa = () => {
+  const handlePaa = async () => {
     if (paaGerado) {
       return;
     }
-    if (notValidPaa){
-      const payload = {
-        associacao: associacao_uuid
+    if (notValidPaa) {
+      if (!podeIniciarPaa) {
+        return;
       }
-      mutationPost.mutate({payload: payload})
+      const payload = { associacao: associacao_uuid };
+      try {
+        await mutationPost.mutateAsync({ payload });
+      } catch {
+        return;
+      }
     }
     navigate('/elaborar-novo-paa');
-};
+  };
 
   return (
     <>
@@ -111,7 +118,11 @@ export const ElaboracaoPaa = () => {
                 className="btn btn-success mt-2 mr-5"
                 data-testid="elaborar-paa-button"
                 onClick={handlePaa}
-                disabled={!validMonthPaa || paaGerado}
+                disabled={
+                  !validMonthPaa ||
+                  paaGerado ||
+                  (notValidPaa && !podeIniciarPaa)
+                }
               >
                 {paaGerado
                   ? "Elaborar novo PAA"

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -829,7 +829,7 @@ const routesConfig = [
     exact: true,
     path: "/elaborar-novo-paa",
     component: ElaborarNovoPlano,
-    permissoes: ["access_paa", "custom_change_paa"],
+    permissoes: ["access_paa"],
     featureFlag: "paa",
   },
   {

--- a/src/services/__tests__/visoes.service.test.js
+++ b/src/services/__tests__/visoes.service.test.js
@@ -581,6 +581,8 @@ describe('Visoes Service', () => {
             localStorageMock.setItem('uuidAta', 'test');
             localStorageMock.setItem('prestacao_de_contas_nao_apresentada', 'test');
             localStorageMock.setItem(PERIODO_RELATORIO_CONSOLIDADO_DRE, 'test');
+            localStorageMock.setItem('PAA', 'uuid-paa-anterior');
+            localStorageMock.setItem('DADOS_PAA', '{"uuid":"uuid-paa-anterior"}');
 
             visoesService.alternaVisoes('DRE', 'dre1', 'dre1', 'DRE 1', 'DRE', 'DRE 1', null, null, null);
 
@@ -593,6 +595,8 @@ describe('Visoes Service', () => {
             expect(localStorageMock.getItem('uuidAta')).toBeNull();
             expect(localStorageMock.getItem('prestacao_de_contas_nao_apresentada')).toBeNull();
             expect(localStorageMock.getItem(PERIODO_RELATORIO_CONSOLIDADO_DRE)).toBeNull();
+            expect(localStorageMock.getItem('PAA')).toBeNull();
+            expect(localStorageMock.getItem('DADOS_PAA')).toBeNull();
         });
 
         it('Deve chamar salva_dados_ultimo_acesso com os parâmetros corretos', () => {

--- a/src/services/visoes.service.js
+++ b/src/services/visoes.service.js
@@ -522,6 +522,8 @@ const alternaVisoes = (visao, uuid_unidade, uuid_associacao, nome_associacao, un
         localStorage.removeItem('uuidAta');
         localStorage.removeItem('prestacao_de_contas_nao_apresentada');
         localStorage.removeItem(PERIODO_RELATORIO_CONSOLIDADO_DRE);
+        localStorage.removeItem('PAA');
+        localStorage.removeItem('DADOS_PAA');
 
         localStorage.setItem("NOTIFICAR_DEVOLUCAO_REFERENCIA", notificar_devolucao_referencia)
 


### PR DESCRIPTION
Esse PR:

- Bloqueia botão gerar ata antes do PAA final ser gerado;
- Remove do localstorage dados do PAA ao trocar de unidade;
- Adiciona permissão no botão de iniciar PAA.

História: [AB#145696](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/145696)