### PR TITLE
fix(145837): Ajusta urls solicitação acerto períodos anteriores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.35.2",
+  "version": "9.35.3",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDeLancamentos/DetalharAcertos/index.js
@@ -125,7 +125,7 @@ export const DetalharAcertos = () => {
             mounted = false;
         }
 
-    }, [verificaSeTemLancamentosDoTipoGasto, verificaSeEhRepasse])
+    }, [verificaSeTemLancamentosDoTipoGasto, verificaSeEhRepasse, aplicavelDespesasPeriodosAnteriores])
 
     useEffect(() => {
         let mounted = true;

--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDespesasPeriodosAnteriores/TabelaConferenciaDeLancamentos/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/ConferenciaDespesasPeriodosAnteriores/TabelaConferenciaDeLancamentos/index.js
@@ -253,7 +253,10 @@ const TabelaConferenciaDeLancamentos = ({
     const addDispatchRedireciona = (lancamentos) => {
         dispatch(limparDetalharAcertos())
         dispatch(addDetalharAcertos(lancamentos))
-        navigate(`/dre-detalhe-prestacao-de-contas-detalhar-acertos/${prestacaoDeContas.uuid}`, {replace: true})
+        navigate(
+            `/dre-detalhe-prestacao-de-contas-detalhar-acertos/${prestacaoDeContas.uuid}`,
+            {replace: true, state: {aplicavel_despesas_periodos_anteriores: true}}
+        )
     }
 
     const detalharAcertos = () => {

--- a/src/services/dres/PrestacaoDeContas.service.js
+++ b/src/services/dres/PrestacaoDeContas.service.js
@@ -239,7 +239,16 @@ export const getTiposDeAcertoLancamentos = async () => {
 };
 
 export const getTiposDeAcertoLancamentosAgrupadoCategoria = async (aplicavel_despesas_periodos_anteriores=null, is_repasse=null) => {
-    return (await api.get(`/api/tipos-acerto-lancamento/tabelas/${aplicavel_despesas_periodos_anteriores ? `?aplicavel_despesas_periodos_anteriores=${aplicavel_despesas_periodos_anteriores}` : ''}${is_repasse ? `?is_repasse=${is_repasse}` : ''}`, authHeader())).data
+    const params = new URLSearchParams();
+    if (aplicavel_despesas_periodos_anteriores) {
+        params.set('aplicavel_despesas_periodos_anteriores', String(aplicavel_despesas_periodos_anteriores));
+    }
+    if (is_repasse) {
+        params.set('is_repasse', String(is_repasse));
+    }
+    const query = params.toString();
+    const url = `/api/tipos-acerto-lancamento/tabelas/${query ? `?${query}` : ''}`;
+    return (await api.get(url, authHeader())).data;
 };
 
 export const getListaDeSolicitacaoDeAcertos = async (prestacao_de_contas_uuid, analise_lancamento_uuid) => {

--- a/src/services/dres/__tests__/PrestacaoDeContas.test.js
+++ b/src/services/dres/__tests__/PrestacaoDeContas.test.js
@@ -349,7 +349,7 @@ describe('Testes para funções de análise', () => {
         let aplicavel_despesas_periodos_anteriores='1234'
         let is_repasse=null
         const result = await getTiposDeAcertoLancamentosAgrupadoCategoria(aplicavel_despesas_periodos_anteriores, is_repasse);
-        const url = `/api/tipos-acerto-lancamento/tabelas/${aplicavel_despesas_periodos_anteriores ? `?aplicavel_despesas_periodos_anteriores=${aplicavel_despesas_periodos_anteriores}` : ''}${is_repasse ? `?is_repasse=${is_repasse}` : ''}`
+        const url = `/api/tipos-acerto-lancamento/tabelas/?aplicavel_despesas_periodos_anteriores=1234`
         expect(api.get).toHaveBeenCalledWith(url, authHeader())
         expect(result).toEqual(mockData);
     });


### PR DESCRIPTION
Esse PR:

- Ajusta urls de solicitação de acertos de períodos anteriores, para apenas permitir acertos de conciliação.

História: [AB#145837](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/145837)