### PR TITLE
Feature/144943 exibir tela escolha recurso

### DIFF
--- a/src/componentes/Globais/Cabecalho/__tests__/index.test.js
+++ b/src/componentes/Globais/Cabecalho/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { authService } from "../../../../services/auth.service";
 import { MemoryRouter } from 'react-router-dom';
 import {visoesService} from "../../../../services/visoes.service";
@@ -123,6 +123,32 @@ describe('Cabeçalho', () => {
         fireEvent.change(select, { target: { value: obj_unidade } });
         expect(visoesService.getItemUsuarioLogado).toHaveBeenCalledTimes(1);
         expect(mantemEstadoAnaliseDre.limpaAnaliseDreUsuarioLogado).toHaveBeenCalledTimes(1);
+
+    });
+
+    it('Deve chamar função para remover recurso selecionado', async () => {
+        jest.spyOn(Storage.prototype, 'removeItem')
+
+        useRecursoSelecionadoContext.mockReturnValue({ mostrarSelecionarRecursos: false });
+
+        renderComponent();
+        const obj_unidade = '{"uuid_unidade":"fake-uuid-2","uuid_associacao":"fake-uuid-2","nome_associacao":"Support Unit 2","unidade_tipo":"CEI","unidade_nome":"Unit 2","notificar_devolucao_referencia":true,"notificar_devolucao_pc_uuid":"fake-uuid-2","notificacao_uuid":"fake-uuid-2"}'
+        const select = screen.getByTestId('select-unidade');
+        fireEvent.change(select, { target: { value: obj_unidade } });
+        expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
+
+    });
+
+    it('Não deve chamar função para remover recurso selecionado', async () => {
+        jest.spyOn(Storage.prototype, 'removeItem')
+
+        useRecursoSelecionadoContext.mockReturnValue({ mostrarSelecionarRecursos: true });
+
+        renderComponent();
+        const obj_unidade = '{"uuid_unidade":"fake-uuid-2","uuid_associacao":"fake-uuid-2","nome_associacao":"Support Unit 2","unidade_tipo":"CEI","unidade_nome":"Unit 2","notificar_devolucao_referencia":true,"notificar_devolucao_pc_uuid":"fake-uuid-2","notificacao_uuid":"fake-uuid-2"}'
+        const select = screen.getByTestId('select-unidade');
+        fireEvent.change(select, { target: { value: obj_unidade } });
+        expect(localStorage.removeItem).not.toHaveBeenCalled();
 
     });
 

--- a/src/componentes/Globais/Cabecalho/__tests__/index.test.js
+++ b/src/componentes/Globais/Cabecalho/__tests__/index.test.js
@@ -64,7 +64,7 @@ describe('Cabeçalho', () => {
         visoesService.getItemUsuarioLogado.mockReturnValue("James Bond");
         authService.isLoggedIn.mockReturnValue(true);
         visoesService.getDadosDoUsuarioLogado.mockReturnValue(mockDadosUsuarioLogado);
-        useRecursoSelecionadoContext.mockReturnValue({ isLoading: false });
+        useRecursoSelecionadoContext.mockReturnValue({ isLoading: false, clearRecursoNaSessao: jest.fn() });
     })
     const renderComponent = () => {
         return render(
@@ -123,32 +123,6 @@ describe('Cabeçalho', () => {
         fireEvent.change(select, { target: { value: obj_unidade } });
         expect(visoesService.getItemUsuarioLogado).toHaveBeenCalledTimes(1);
         expect(mantemEstadoAnaliseDre.limpaAnaliseDreUsuarioLogado).toHaveBeenCalledTimes(1);
-
-    });
-
-    it('Deve chamar função para remover recurso selecionado', async () => {
-        jest.spyOn(Storage.prototype, 'removeItem')
-
-        useRecursoSelecionadoContext.mockReturnValue({ mostrarSelecionarRecursos: false });
-
-        renderComponent();
-        const obj_unidade = '{"uuid_unidade":"fake-uuid-2","uuid_associacao":"fake-uuid-2","nome_associacao":"Support Unit 2","unidade_tipo":"CEI","unidade_nome":"Unit 2","notificar_devolucao_referencia":true,"notificar_devolucao_pc_uuid":"fake-uuid-2","notificacao_uuid":"fake-uuid-2"}'
-        const select = screen.getByTestId('select-unidade');
-        fireEvent.change(select, { target: { value: obj_unidade } });
-        expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
-
-    });
-
-    it('Não deve chamar função para remover recurso selecionado', async () => {
-        jest.spyOn(Storage.prototype, 'removeItem')
-
-        useRecursoSelecionadoContext.mockReturnValue({ mostrarSelecionarRecursos: true });
-
-        renderComponent();
-        const obj_unidade = '{"uuid_unidade":"fake-uuid-2","uuid_associacao":"fake-uuid-2","nome_associacao":"Support Unit 2","unidade_tipo":"CEI","unidade_nome":"Unit 2","notificar_devolucao_referencia":true,"notificar_devolucao_pc_uuid":"fake-uuid-2","notificacao_uuid":"fake-uuid-2"}'
-        const select = screen.getByTestId('select-unidade');
-        fireEvent.change(select, { target: { value: obj_unidade } });
-        expect(localStorage.removeItem).not.toHaveBeenCalled();
 
     });
 

--- a/src/componentes/Globais/Cabecalho/index.js
+++ b/src/componentes/Globais/Cabecalho/index.js
@@ -18,9 +18,11 @@ import { LogoSigEscola } from "../LogoSigEscola";
 
 export const Cabecalho = () => {
   const navigate = useNavigate();
-  const { isLoading, mostrarSelecionarRecursos } = useRecursoSelecionadoContext();
+  const { isLoading, clearRecursoNaSessao } = useRecursoSelecionadoContext();
 
   const logout = async () => {
+    clearRecursoNaSessao();
+
     await authService.logout();
   };
   let login_usuario = localStorage.getItem(USUARIO_LOGIN);
@@ -61,13 +63,6 @@ export const Cabecalho = () => {
       obj.notificacao_uuid,
     );
     meapcservice.limpaAnaliseDreUsuarioLogado(visoesService.getUsuarioLogin());
-    
-    // Ao trocar de unidade, se a unidade atual possuir apenas um recurso,
-    // a variável RECURSO_SELECIONADO é removida do localStorage, permitindo que 
-    // o usuário selecione um recurso na nova unidade, caso haja mais de um disponível.
-    if (!mostrarSelecionarRecursos) {
-        localStorage.removeItem(RECURSO_SELECIONADO)
-    }
   };
 
   const retornaVisaoConvertida = (

--- a/src/componentes/Globais/Cabecalho/index.js
+++ b/src/componentes/Globais/Cabecalho/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./cabecalho.scss";
-import { authService, USUARIO_LOGIN } from "../../../services/auth.service";
+import { authService, RECURSO_SELECIONADO, USUARIO_LOGIN } from "../../../services/auth.service";
 import { visoesService } from "../../../services/visoes.service";
 import { NotificacaoContext } from "../../../context/Notificacoes";
 import { CentralDeDownloadContext } from "../../../context/CentralDeDownloads";
@@ -18,7 +18,7 @@ import { LogoSigEscola } from "../LogoSigEscola";
 
 export const Cabecalho = () => {
   const navigate = useNavigate();
-  const { isLoading } = useRecursoSelecionadoContext();
+  const { isLoading, mostrarSelecionarRecursos } = useRecursoSelecionadoContext();
 
   const logout = async () => {
     await authService.logout();
@@ -61,6 +61,13 @@ export const Cabecalho = () => {
       obj.notificacao_uuid,
     );
     meapcservice.limpaAnaliseDreUsuarioLogado(visoesService.getUsuarioLogin());
+    
+    // Ao trocar de unidade, se a unidade atual possuir apenas um recurso,
+    // a variável RECURSO_SELECIONADO é removida do localStorage, permitindo que 
+    // o usuário selecione um recurso na nova unidade, caso haja mais de um disponível.
+    if (!mostrarSelecionarRecursos) {
+        localStorage.removeItem(RECURSO_SELECIONADO)
+    }
   };
 
   const retornaVisaoConvertida = (

--- a/src/hooks/Globais/__tests__/useRecursoSelecionado.test.js
+++ b/src/hooks/Globais/__tests__/useRecursoSelecionado.test.js
@@ -18,6 +18,7 @@ jest.mock("../../../services/auth.service", () => ({
 }));
 
 const STORAGE_KEY = "RECURSO_SELECIONADO";
+const RECURSO_EXIBIDO_NA_SESSAO = "RECURSO_EXIBIDO_NA_SESSAO";
 
 const recursoA = { uuid: "rec-a", nome: "Recurso A" };
 const recursoB = { uuid: "rec-b", nome: "Recurso B" };
@@ -353,6 +354,7 @@ describe("useRecursoSelecionado - mostrarOverlaySelecionarRecursos", () => {
 
   it("é false quando recursoSelecionado está definido", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(recursoA));
+    localStorage.setItem(RECURSO_EXIBIDO_NA_SESSAO, JSON.stringify(true));
     getRecursosPorUnidade.mockResolvedValue([recursoA, recursoB]);
 
     const { result } = renderHook(() =>

--- a/src/hooks/Globais/useRecursoSelecionado.js
+++ b/src/hooks/Globais/useRecursoSelecionado.js
@@ -10,6 +10,7 @@ import { authService } from "../../services/auth.service";
  */
 const useRecursoSelecionado = ({ visoesService }) => {
   const storageKey = "RECURSO_SELECIONADO";
+  const RECURSO_EXIBIDO_NA_SESSAO = "RECURSO_EXIBIDO_NA_SESSAO";
   const dadosUsuarioLogado = visoesService.getDadosDoUsuarioLogado();
 
   const [recursoSelecionado, setRecursoSelecionado] = useState(() => {
@@ -19,6 +20,14 @@ const useRecursoSelecionado = ({ visoesService }) => {
     } catch (error) {
       console.error("Erro ao carregar recurso do localStorage:", error);
       return null;
+    }
+  });
+  const [recursoSelecionadoNaSessao, setRecursoSelecionadoNaSessao] = useState(() => {
+    try {
+      const recursoExibido = localStorage.getItem(RECURSO_EXIBIDO_NA_SESSAO);
+      return recursoExibido ? JSON.parse(recursoExibido) : false;
+    } catch {
+      return false;
     }
   });
   const [recursos, setRecursos] = useState([]);
@@ -47,14 +56,16 @@ const useRecursoSelecionado = ({ visoesService }) => {
   }, [recursos]);
 
   const mostrarOverlaySelecionarRecursos = useMemo(() => {
-    return recursoSelecionado === null && recursos.length > 1;
+    return (recursoSelecionado === null && recursos.length > 1) || (!recursoSelecionadoNaSessao && recursos.length > 1);
   }, [recursoSelecionado, recursos]);
 
   const handleChangeRecurso = (recursoSelecionadoObj) => {
     try {
       setRecursoSelecionado(recursoSelecionadoObj);
+      setRecursoSelecionadoNaSessao(true);
       if (recursoSelecionadoObj) {
         localStorage.setItem(storageKey, JSON.stringify(recursoSelecionadoObj));
+        localStorage.setItem(RECURSO_EXIBIDO_NA_SESSAO, JSON.stringify(true));
         // TODO: Ao invés de limpar as informações do storage, tratar as informações por recurso selecionado
         // A separação de storage por recurso foi feita para a tela de conciliação apenas
         // Onde foi possível guardar informações do último período/conta na tela por recurso
@@ -62,6 +73,7 @@ const useRecursoSelecionado = ({ visoesService }) => {
         authService.limparStorageAoTrocarRecurso();
       } else {
         localStorage.removeItem(storageKey);
+        localStorage.removeItem(RECURSO_EXIBIDO_NA_SESSAO);
       }
 
       window.location.href = "/";
@@ -74,6 +86,11 @@ const useRecursoSelecionado = ({ visoesService }) => {
   const clearRecurso = () => {
     setRecursoSelecionado(null);
     localStorage.removeItem(storageKey);
+  };
+
+  const clearRecursoNaSessao = () => {
+    setRecursoSelecionadoNaSessao(false);
+    localStorage.removeItem(RECURSO_EXIBIDO_NA_SESSAO);
   };
 
   useEffect(() => {
@@ -131,6 +148,8 @@ const useRecursoSelecionado = ({ visoesService }) => {
     error,
     mostrarSelecionarRecursos,
     mostrarOverlaySelecionarRecursos,
+    setRecursoSelecionadoNaSessao,
+    clearRecursoNaSessao,
   };
 };
 

--- a/src/paginas/dres/Associacoes/DetalhesDaAssociacao/__tests__/index.test.js
+++ b/src/paginas/dres/Associacoes/DetalhesDaAssociacao/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React  from "react";
 import { MemoryRouter, useLocation, useParams } from "react-router-dom";
 import { DetalhesDaAssociacaoDrePage } from "../index";


### PR DESCRIPTION
Esta PR inclui:

- Adiciona uma nova variável no localStorage RECURSO_EXIBIDO_NA_SESSAO para controlar se o usuário selecionou um recurso em sua sessão;
- Corrige o teste que estava faltando o importe do 'screen' do https://github.com/testing-library;

História: [AB#144943](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/144943)
Tarefa: [AB#146049](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146049)