### PR TITLE
feat(145671): Inclusão de recurso nos relatórios e histórico de contas encerradas de associações.

### DIFF
--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/TabelaContasEncerradas/index.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/TabelaContasEncerradas/index.js
@@ -25,6 +25,7 @@ export const TabelaContasEncerradas = ({
             paginatorTemplate="PrevPageLink PageLinks NextPageLink"
             autoLayout={true}
         >
+            <Column field="nome_exibicao_recurso" header="Recurso"/>
             <Column field="tipo_conta.nome" header="Tipo de Conta"/>
             <Column field="banco_nome" header="Banco" />
             <Column field="agencia" header="Agência" />

--- a/src/componentes/escolas/Associacao/DadosDasContas/TabelaContasEncerradas/index.js
+++ b/src/componentes/escolas/Associacao/DadosDasContas/TabelaContasEncerradas/index.js
@@ -27,6 +27,7 @@ export const TabelaContasEncerradas = ({
                         paginatorTemplate="PrevPageLink PageLinks NextPageLink"
                         autoLayout={true}
                     >
+                        <Column field="nome_exibicao_recurso" header="Recurso"/>
                         <Column field="tipo_conta.nome" header="Tipo de Conta"/>
                         <Column field="banco_nome" header="Banco"/>
                         <Column field="agencia" header="Agência"/>

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TextoDinamicoSuperior/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/TextoDinamicoSuperior/index.js
@@ -10,7 +10,7 @@ export const TextoDinamicoSuperior = ({dadosAta, retornaDadosAtaFormatado, prest
     let textoPauta = ''
     let textoObjeto = ''
     if (dadosAta.tipo_ata === 'RETIFICACAO') {
-        textoPauta = ` Retificação da Prestação de Contas do PTRF e suas ações agregadas, 
+        textoPauta = ` Retificação da Prestação de Contas do ${recursoSelecionado?.nome} e suas ações agregadas, 
         do período de ${retornaDadosAtaFormatado("periodo.data_inicio_realizacao_despesas")} a 
         ${retornaDadosAtaFormatado("periodo.data_fim_realizacao_despesas")}, 
         referente ao ${retornaDadosAtaFormatado("periodo.referencia")}.`

--- a/src/paginas/dres/Associacoes/DetalhesDaAssociacao/__tests__/index.test.js
+++ b/src/paginas/dres/Associacoes/DetalhesDaAssociacao/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React  from "react";
 import { MemoryRouter, useLocation, useParams } from "react-router-dom";
 import { DetalhesDaAssociacaoDrePage } from "../index";


### PR DESCRIPTION
Este PR inclui:

- Inclusão de coluna recurso na tabela de contas encerradas (Dados das contas - UE);
- Inclusão de coluna recurso na tabela de contas encerradas (Dados da associação -> Contas da associação - DRE);
- Correção de erro de importação em um teste unitário;
- Validação de testes unitários;

História: [AB#145671](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145671)
Tarefa: [AB#146038](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146038)