### PR TITLE
hotfix(146731): bloqueia duplicidade de documentos no paa

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.36.2",
+  "version": "9.36.3",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/RelSecaoTextos.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/RelSecaoTextos.test.js
@@ -61,7 +61,6 @@ describe('RelSecaoTextos', () => {
         render(<RelSecaoTextos {...props} />);
         await waitFor(() => {
             expect(screen.getByText('Texto fixo intro', { exact: false })).toBeInTheDocument();
-            expect(screen.getByText('Mensagem padrão intro', { exact: false })).toBeInTheDocument();
         })
     });
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/index.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/index.test.js
@@ -71,6 +71,7 @@ jest.mock("../hooks/usePostPaaGeracaoDocumento", () => ({
 
     return {
       mutate: mockMutateFinal,
+      mutateAsync: mockMutateFinal,
     };
   },
 }));
@@ -185,9 +186,7 @@ describe("Relatorios", () => {
 
   test("expande seção Plano Anual ao clicar no dropdown", () => {
     render(<Relatorios />);
-    const dropdownBtn = document.querySelector(
-      'button.btn-dropdown'
-    )
+    const dropdownBtn = document.querySelector("button.btn-dropdown");
     fireEvent.click(dropdownBtn);
 
     expect(screen.getByTestId("secao-introducao")).toBeInTheDocument();
@@ -197,7 +196,7 @@ describe("Relatorios", () => {
     render(<Relatorios />);
     fireEvent.click(screen.getByText("Visualizar prévia da ata"));
     expect(mockNavigate).toHaveBeenCalledWith(
-      "/relatorios-paa/visualizacao-da-ata-paa/paa-uuid-1"
+      "/relatorios-paa/visualizacao-da-ata-paa/paa-uuid-1",
     );
   });
 
@@ -211,9 +210,7 @@ describe("Relatorios", () => {
     render(<Relatorios />);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        "/paa-vigente-e-anteriores"
-      );
+      expect(mockNavigate).toHaveBeenCalledWith("/paa-vigente-e-anteriores");
     });
   });
 
@@ -250,9 +247,7 @@ describe("Relatorios", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.queryByText("Modal Prévia")
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Modal Prévia")).not.toBeInTheDocument();
     });
   });
 
@@ -263,16 +258,13 @@ describe("Relatorios", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Modal Confirmar")).toBeInTheDocument();
-    
-      fireEvent.click(screen.getByText("Fechar Confirmar"));
-    })
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText("Modal Confirmar")
-      ).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText("Fechar Confirmar"));
     });
 
+    await waitFor(() => {
+      expect(screen.queryByText("Modal Confirmar")).not.toBeInTheDocument();
+    });
   });
 
   test("fecha modal de pendências ao clicar em fechar", async () => {
@@ -284,18 +276,15 @@ describe("Relatorios", () => {
     });
 
     await waitFor(() => {
-
-      expect(
-        screen.getByText("Pendências encontradas")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Pendências encontradas")).toBeInTheDocument();
 
       fireEvent.click(screen.getByText("Fechar Pendencias"));
-    })
+    });
 
     await waitFor(() => {
       expect(
-        screen.queryByText("Pendências encontradas")
+        screen.queryByText("Pendências encontradas"),
       ).not.toBeInTheDocument();
-    })
+    });
   });
 });

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
@@ -79,6 +79,8 @@ const Relatorios = ({ initialExpandedSections }) => {
   const [openModalValidacoesGeracaoFinal, setOpenModalValidacoesGeracaoFinal] =
     useState(false);
 
+  const [gerandoDocFinal, setGerandoDocFinal] = useState(false);
+
   const {
     data: statusDocumento,
     isFetching: isLoadingStatusDocumento,
@@ -186,18 +188,27 @@ const Relatorios = ({ initialExpandedSections }) => {
   };
 
   const handleGerarDocumentoFinal = async (confirmar = 0) => {
-    if (!podeEditar) return;
+    if (!podeEditar) return;   
     setOpenModalConfirmarGeracaoFinal(false);
-    if (paaVigente?.uuid) {
-      mutationGerarDocumentoFinal.mutate({
-        uuid: paaVigente.uuid,
-        payload: { confirmar },
-      });
-    } else {
-      toastCustom.ToastCustomError(
-        "Erro!",
-        "PAA vigente não identificado para geração final.",
-      );
+  
+    try {
+        setGerandoDocFinal(true);
+        if (paaVigente?.uuid) {
+            await mutationGerarDocumentoFinal.mutateAsync({
+                uuid: paaVigente.uuid,
+                payload: { confirmar },
+            });
+         
+        } else {
+            toastCustom.ToastCustomError(
+                "Erro!",
+                "PAA vigente não identificado para geração final.",
+            );
+        }       
+    
+    } catch(err) {} 
+    finally {
+       setGerandoDocFinal(false);
     }
   };
 
@@ -366,6 +377,7 @@ const Relatorios = ({ initialExpandedSections }) => {
                 </Spin>
               </div>
             </div>
+            
             <div className="documento-actions">
               <Space>
                 <button
@@ -375,10 +387,10 @@ const Relatorios = ({ initialExpandedSections }) => {
                 >
                   Prévia
                 </button>
-
+               
                 <button
                   className="btn btn-success"
-                  disabled={botaoGeracaoFinalDesabilitado()}
+                  disabled={gerandoDocFinal || botaoGeracaoFinalDesabilitado()}
                   onClick={() => handleGerarDocumentoFinal(0)}
                 >
                   Gerar
@@ -468,13 +480,19 @@ const Relatorios = ({ initialExpandedSections }) => {
 
       <ModalConfirmaGeracaoFinal
         open={openModalConfirmarGeracaoFinal}
-        onClose={() => setOpenModalConfirmarGeracaoFinal(false)}
+        onClose={() => {
+            setGerandoDocFinal(false);
+            setOpenModalConfirmarGeracaoFinal(false);
+        }}
         onConfirm={() => handleGerarDocumentoFinal(1)}
       />
 
       <ModalInfoPendenciasGeracaoFinal
         open={openModalValidacoesGeracaoFinal}
-        onClose={() => setOpenModalValidacoesGeracaoFinal(false)}
+        onClose={() => {
+            setGerandoDocFinal(false);
+            setOpenModalValidacoesGeracaoFinal(false)
+        }}
         pendencias={pendenciasGeracaoFinal}
       />
     </div>


### PR DESCRIPTION
# O que este PR faz

-  desabilita botão de gerar documento final do paa quando está em processo de geração, evitando duplicidades.

Referência Azure: [AB#146731](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/146731)