### PR TITLE
feat(143915): Altera header de requisições de upload de arquivo de carga - Hom

### DIFF
--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -7,6 +7,12 @@ const authHeader = ()=>({
     "Content-Type": "application/json",
   },
 });
+const authHeaderArquivos = ()=>({
+  headers: {
+    Authorization: `JWT ${localStorage.getItem(TOKEN_ALIAS)}`,
+    "Content-Type": "multipart/form-data",
+  },
+});
 
 // ***** Cargas Associacoes *****
 export const getTabelaArquivosDeCarga = async () => {
@@ -42,7 +48,7 @@ export const postCreateArquivoDeCarga = async (payload) => {
   if (payload.tipo_de_conta) {
     formData.append("tipo_de_conta", payload.tipo_de_conta);
   }
-  return (await api.post(`/api/arquivos/`, formData, authHeader())).data;
+  return (await api.post(`/api/arquivos/`, formData, authHeaderArquivos())).data;
 };
 export const patchAlterarArquivoDeCarga = async (
   uuid_arquivo_de_carga,
@@ -65,7 +71,7 @@ export const patchAlterarArquivoDeCarga = async (
     await api.patch(
       `/api/arquivos/${uuid_arquivo_de_carga}/`,
       formData,
-      authHeader()
+      authHeaderArquivos()
     )
   ).data;
 };

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -188,6 +188,14 @@ describe('Testes para funções de análise', () => {
             }
         };
     };
+    const authHeaderArquivos = () => {
+        return {
+            headers: {
+                'Authorization': `JWT ${mockToken}`,
+                'Content-Type': 'multipart/form-data'
+            }
+        };
+    };
 
     test('getTabelaArquivosDeCarga  deve chamar a API corretamente', async () => {
         api.get.mockResolvedValue({ data: mockData })
@@ -236,7 +244,7 @@ describe('Testes para funções de análise', () => {
         expect(api.post).toHaveBeenCalledWith(
             `/api/arquivos/`,
             formData,
-            authHeader()
+            authHeaderArquivos()
         )
         expect(result).toEqual(mockData);
     });
@@ -265,7 +273,7 @@ describe('Testes para funções de análise', () => {
         expect(api.patch).toHaveBeenCalledWith(
             `/api/arquivos/${uuid_arquivo_de_carga}/`,
             formData,
-            authHeader()
+            authHeaderArquivos()
         )
         expect(result).toEqual(mockData);
     });


### PR DESCRIPTION

Esse PR:

- Altera cabeçalho de requisição de upload de arquivo de carga para o formato multipart/form-data

História [AB#143915](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/143915)
