### PR TITLE
refac(147097): melhora busca referência utilizando serviço de notific...

### DIFF
--- a/src/context/Notificacoes/index.js
+++ b/src/context/Notificacoes/index.js
@@ -3,6 +3,7 @@ import {getQuantidadeNaoLidas, getRegistrosFalhaGeracaoPc} from "../../services/
 import {visoesService} from "../../services/visoes.service";
 import {ModalNotificaErroConcluirPC} from "../../componentes/Globais/ModalAntDesign/ModalNotificaErroConcluirPC";
 import {authService} from "../../services/auth.service";
+import { notificaDevolucaoPCStorageService } from "../../services/storages/NotificarDevolucao.storage.service";
 
 export const NotificacaoContext = createContext( {
     qtdeNotificacoesNaoLidas: '',
@@ -37,7 +38,9 @@ export const NotificacaoContextProvider = ({children}) => {
     const [registroFalhaGeracaoPc, setRegistroFalhaGeracaoPc] = useState([]);
 
     const deveExibirModalDevolucao = () => {
-        let storage = localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA");
+        const notificaDevolucao = notificaDevolucaoPCStorageService.retornaNotificarDevolucaoUnidadeRecursoSelecionado()
+
+        let storage = notificaDevolucao?.notificar_devolucao_referencia;
 
         if(storage === null || storage === "null"){
             return false;

--- a/src/paginas/PaginasContainer.js
+++ b/src/paginas/PaginasContainer.js
@@ -11,16 +11,18 @@ import { BarraMensagemFixaRecurso } from "../componentes/Globais/BarraMensagemFi
 import { BarraMensagemFixaProvider } from "../componentes/Globais/BarraMensagemFixa/context/BarraMensagemFixaProvider";
 import { FEATURE_FLAGS } from '../constantes/featureFlags';
 import { useRecursoSelecionadoContext } from "../context/RecursoSelecionado";
+import { notificaDevolucaoPCStorageService } from "../services/storages/NotificarDevolucao.storage.service";
 
 export const PaginasContainer = ({children}) => {
     const navigate = useNavigate();
     const sidebarStatus = useContext(SidebarContext);
     const notificacaoContext = useContext(NotificacaoContext);
     const { recursoSelecionado } = useRecursoSelecionadoContext();
+    const notificaDevolucao = notificaDevolucaoPCStorageService.retornaNotificarDevolucaoUnidadeRecursoSelecionado();
 
     const mensagem = (
         <span>
-            A prestação de contas {localStorage.getItem("NOTIFICAR_DEVOLUCAO_REFERENCIA")} foi devolvida para acertos pela DRE. <br/>
+            A prestação de contas {notificaDevolucao?.notificar_devolucao_referencia} foi devolvida para acertos pela DRE. <br/>
             <b>Recurso: {recursoSelecionado?.nome_exibicao}</b>
         </span>
     )


### PR DESCRIPTION
Este PR inclui:

- Melhora a busca do valor de notificar_devolucao_referencia, trocando a busca de "localStorage.getItem" para a utilização do serviço de notificação storage.

História: [AB#146625](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146625)
Tarefa: [AB#147097](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/147097)