### PR TITLE
fix(147097): Corrige a exibição modal devolução de pc devolução

### DIFF
--- a/src/context/Notificacoes/index.js
+++ b/src/context/Notificacoes/index.js
@@ -42,7 +42,7 @@ export const NotificacaoContextProvider = ({children}) => {
 
         let storage = notificaDevolucao?.notificar_devolucao_referencia;
 
-        if(storage === null || storage === "null"){
+        if(!storage || storage === null || storage === "null"){
             return false;
         }
         else {


### PR DESCRIPTION
Este PR inclui:

- Corrige exibição de modal de devolução de pc quando a unidade não tem devolução informada.

História: [AB#146625](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146625)
Tarefa: [AB#147097](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/147097)