### PR TITLE
Feature/140950 parametrizacao periodos

### DIFF
--- a/src/componentes/Globais/ModalAntDesign/ModalConfirmarExclusao.js
+++ b/src/componentes/Globais/ModalAntDesign/ModalConfirmarExclusao.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import '../ModalAntDesign/modal-antdesign.scss';
+import { Modal } from 'antd';
+import IconeAvisoVermelho from "../../../assets/img/icone-modal-aviso-vermelho.svg"
+
+export const ModalConfirmarExclusao = (props) => {
+  return (
+    <div className="modal-ant-design">
+        <Modal 
+            open={props.open}
+            onOk={props.onOk}
+            okText={props.okText}
+            okButtonProps={{className: "btn-base-vermelho"}}
+            onCancel={props.onCancel}
+            cancelText={props.cancelText}
+            cancelButtonProps={{className: "btn-base-verde-outline"}}
+            wrapClassName={'modal-ant-design'}
+        >
+            <div className="row">
+                <div className="col-md-auto col-lg-12">
+                    <div className="text-center">
+                        <img src={IconeAvisoVermelho} alt="" className="img-fluid"/>
+                    </div>
+                </div>
+
+                <div className="col-md-auto col-lg-12 mt-3">
+                    <div className="text-center">
+                        <p className="title-modal-antdesign-aviso">{props.titulo}</p>
+                    </div>
+                    <div className="text-center mt-2">
+                        <p className="body-text-modal-antdesign-aviso">{props.bodyText}</p>
+                    </div>
+                </div>
+            </div>
+        </Modal>
+    </div>
+  );
+};

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/Filtros.js
@@ -8,10 +8,17 @@ export const Filtros = ({
 }) => {
     return (
         <>
+            <div className="mb-4">
+                <h4 className="font-weight-bold mb-0">Refine sua busca</h4>
+                <p>
+                    Utilize o filtro por referência para localizar períodos específicos e monitorar as datas de cada etapa do recurso selecionado.
+                </p>
+            </div>
+
             <form>
                 <div className="d-flex bd-highlight mt-2 mb-3">
-                    <div className="p-Y flex-grow-1 bd-highlight">
-                        <span className='mr-5'><label htmlFor="filtrar_por_referencia">Pesquisar</label></span>
+                    <div className="p-Y d-flex flex-column flex-grow-1 bd-highlight mr-4">
+                        <label htmlFor="filtrar_por_referencia">Filtre por referência</label>
                         <input
                             data-qa="input-filtro-referencia"
                             value={stateFiltros.filtrar_por_referencia}
@@ -19,13 +26,13 @@ export const Filtros = ({
                             name='filtrar_por_referencia'
                             id="filtrar_por_referencia"
                             type="text"
-                            className="form-control w-75"
+                            className="form-control"
                             placeholder='Busque por referência'
                             style={{display: 'inline-block'}}
                         />
 
                     </div>
-                    <div className="p-Y bd-highlight">
+                    <div className="d-flex align-items-end p-Y bd-highlight">
                         <button
                             data-qa="btn-limpar-filtros"
                             onClick={() => limpaFiltros()}
@@ -33,8 +40,7 @@ export const Filtros = ({
                             className="btn btn btn-outline-success mr-2">
                             Limpar
                         </button>
-                    </div>
-                    <div className="p-Y bd-highlight">
+                        
                         <button
                             data-qa="btn-filtrar"
                             onClick={handleSubmitFiltros}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/ModalFormPeriodos.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/ModalFormPeriodos.js
@@ -5,6 +5,7 @@ import {DatePickerField} from "../../../../Globais/DatePickerField";
 import {exibeDataPT_BR} from "../../../../../utils/ValidacoesAdicionaisFormularios";
 import {YupSignupSchemaPeriodos} from "./YupSignupSchemaPeriodos";
 import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import { useRecursoSelecionadoContext } from "../../../../../context/RecursoSelecionado";
 
 const ModalFormPeriodos = ({
     show, 
@@ -17,219 +18,251 @@ const ModalFormPeriodos = ({
     setErroDatasAtendemRegras, 
     setShowModalConfirmDeletePeriodo
 }) => {
-
+    const { recursos } = useRecursoSelecionadoContext()
+    
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
+
+    const readOnly = stateFormModal && !stateFormModal.editavel
 
     const bodyTextarea = () => {
         return (
-            <>
-                <Formik
-                    initialValues={stateFormModal}
-                    validationSchema={() => YupSignupSchemaPeriodos(deveValidarPeriodoAnterior)}
-                    validateOnBlur={true}
-                    enableReinitialize={true}
-                    onSubmit={onSubmit}
-                >
-                    {props => {
-                        const {
-                            values,
-                            setFieldValue,
-                        } = props;
-                        return(
-                            <form onSubmit={props.handleSubmit}>
-                                <div className='row'>
-                                    <div className='col-12'>
-                                        <p className='text-right mb-2'><strong>* Preenchimento obrigatório</strong></p>
-                                    </div>
-                                    <div className='col'>
+            <Formik
+                initialValues={stateFormModal}
+                validationSchema={() => YupSignupSchemaPeriodos(deveValidarPeriodoAnterior)}
+                validateOnBlur={true}
+                enableReinitialize={true}
+                onSubmit={onSubmit}
+            >
+                {props => {
+                    const {
+                        values,
+                        setFieldValue,
+                    } = props;
+
+                    return(
+                        <form onSubmit={props.handleSubmit}>
+                            <div className='row'>
+                                <div className='col-12'>
+                                    <p className='text-right mb-2'><strong>* Preenchimento obrigatório</strong></p>
+                                </div>
+
+                                <div className='col-12 mb-2'>
+                                    <label htmlFor="recurso">Recurso *</label>
+                                    <select
+                                        data-qa="input-recurso"
+                                        value={values.recurso ? values.recurso.uuid : ""}
+                                        disabled
+                                        name="recurso"
+                                        id="recurso"
+                                        className="form-control"
+                                        required
+                                    >
+                                        <option data-qa="option-recurso-vazio" value=''>Selecione um recurso</option>
+                                        {recursos?.map((recurso) =>
+                                            <option
+                                                data-qa={`option-recurso-${recurso.uuid}`}
+                                                key={recurso.uuid}
+                                                value={recurso.uuid}
+                                            >
+                                                {recurso.nome}
+                                            </option>
+                                        )}
+                                    </select>
+                                    {props.touched.recurso && props.errors.recurso && <span className="span_erro text-danger mt-1"> {props.errors.recurso} </span>}
+                                </div>
+
+                                <div className='col'>
                                     <div className="form-group">
-                                            <label htmlFor="referencia">Referencia *</label>
-                                            <input
-                                                data-qa="input-referencia"
-                                                type="text"
-                                                value={props.values.referencia}
-                                                name="referencia"
-                                                id="referencia"
-                                                className="form-control"
-                                                onChange={props.handleChange}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                            {props.touched.referencia && props.errors.referencia && <span className="span_erro text-danger mt-1"> {props.errors.referencia} </span>}
-                                        </div>
-                                    </div>
-                                    <div className='col'>
-                                        <div className="form-group">
-                                            <label htmlFor="data_prevista_repasse">Data prevista do repasse</label>
-                                            <DatePickerField
-                                                dataQa={"input-data-prevista-repasse"}
-                                                name="data_prevista_repasse"
-                                                id="data_prevista_repasse"
-                                                value={values.data_prevista_repasse != null ? values.data_prevista_repasse : ""}
-                                                onChange={setFieldValue}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                            {props.touched.data_prevista_repasse && props.errors.data_prevista_repasse && <span className="span_erro text-danger mt-1"> {props.errors.data_prevista_repasse} </span>}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className='row'>
-                                    <div className='col'>
-                                        <div className="form-group">
-                                            <label htmlFor="data_inicio_realizacao_despesas">Início realização de despesas *</label>
-                                            <DatePickerField
-                                                dataQa="input-data-inicio-realizacao-despesas"
-                                                name="data_inicio_realizacao_despesas"
-                                                id="data_inicio_realizacao_despesas"
-                                                value={values.data_inicio_realizacao_despesas != null ? values.data_inicio_realizacao_despesas : ""}
-                                                onChange={(name, value)=>{
-                                                    setFieldValue(name, value);
-                                                    setErroDatasAtendemRegras(false);
-                                                }}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                            {props.touched.data_inicio_realizacao_despesas && props.errors.data_inicio_realizacao_despesas && <span className="span_erro text-danger mt-1"> {props.errors.data_inicio_realizacao_despesas} </span>}
-                                        </div>
-                                    </div>
-                                    <div className='col'>
-                                        <div className="form-group">
-                                            <label htmlFor="data_fim_realizacao_despesas">Fim realização de despesas</label>
-                                            <DatePickerField
-                                                dataQa={"input-data-fim-realizacao-despesas"}
-                                                name="data_fim_realizacao_despesas"
-                                                id="data_fim_realizacao_despesas"
-                                                value={values.data_fim_realizacao_despesas != null ? values.data_fim_realizacao_despesas : ""}
-                                                onChange={setFieldValue}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                        </div>
+                                        <label htmlFor="referencia">Referencia *</label>
+                                        <input
+                                            data-qa="input-referencia"
+                                            type="text"
+                                            value={props.values.referencia}
+                                            name="referencia"
+                                            id="referencia"
+                                            className="form-control"
+                                            onChange={props.handleChange}
+                                            disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        />
+                                        {props.touched.referencia && props.errors.referencia && <span className="span_erro text-danger mt-1"> {props.errors.referencia} </span>}
                                     </div>
                                 </div>
 
-                                <div className='row'>
-                                    <div className='col'>
-                                        <div className="form-group">
-                                            <label htmlFor="data_inicio_prestacao_contas">Início prestação de contas</label>
-                                            <DatePickerField
-                                                dataQa={"input-data-inicio-prestacao-contas"}
-                                                name="data_inicio_prestacao_contas"
-                                                id="data_inicio_prestacao_contas"
-                                                value={values.data_inicio_prestacao_contas != null ? values.data_inicio_prestacao_contas : ""}
-                                                onChange={setFieldValue}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                            {props.touched.data_inicio_prestacao_contas && props.errors.data_inicio_prestacao_contas && <span className="span_erro text-danger mt-1"> {props.errors.data_inicio_prestacao_contas} </span>}
-                                        </div>
-                                    </div>
-                                    <div className='col'>
-                                        <div className="form-group">
-                                            <label htmlFor="data_fim_prestacao_contas">Fim prestação de contas</label>
-                                            <DatePickerField
-                                                dataQa={"input-data-fim-prestacao-contas"}
-                                                name="data_fim_prestacao_contas"
-                                                id="data_fim_prestacao_contas"
-                                                value={values.data_fim_prestacao_contas != null ? values.data_fim_prestacao_contas : ""}
-                                                onChange={setFieldValue}
-                                                disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            />
-                                            {props.touched.data_fim_prestacao_contas && props.errors.data_fim_prestacao_contas && <span className="span_erro text-danger mt-1"> {props.errors.data_fim_prestacao_contas} </span>}
-                                        </div>
+                                <div className='col'>
+                                    <div className="form-group">
+                                        <label htmlFor="data_prevista_repasse">Data prevista do repasse</label>
+                                        <DatePickerField
+                                            dataQa={"input-data-prevista-repasse"}
+                                            name="data_prevista_repasse"
+                                            id="data_prevista_repasse"
+                                            value={values.data_prevista_repasse != null ? values.data_prevista_repasse : ""}
+                                            onChange={setFieldValue}
+                                            disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        />
+                                        {props.touched.data_prevista_repasse && props.errors.data_prevista_repasse && <span className="span_erro text-danger mt-1"> {props.errors.data_prevista_repasse} </span>}
                                     </div>
                                 </div>
+                            </div>
 
-                                <div className='row'>
-                                    <div className='col'>
-                                        <label htmlFor="periodo_anterior">Período anterior {deveValidarPeriodoAnterior ? "*" : ""}</label>
-                                        <select
-                                            data-qa="input-periodo-anterior"
-                                            value={values.periodo_anterior ? values.periodo_anterior.uuid : ""}
-                                            onChange={(e)=>{
-                                                props.handleChange(e);
+                            <div className='row'>
+                                <div className='col'>
+                                    <div className="form-group">
+                                        <label htmlFor="data_inicio_realizacao_despesas">Início realização de despesas *</label>
+                                        <DatePickerField
+                                            dataQa="input-data-inicio-realizacao-despesas"
+                                            name="data_inicio_realizacao_despesas"
+                                            id="data_inicio_realizacao_despesas"
+                                            value={values.data_inicio_realizacao_despesas != null ? values.data_inicio_realizacao_despesas : ""}
+                                            onChange={(name, value)=>{
+                                                setFieldValue(name, value);
                                                 setErroDatasAtendemRegras(false);
                                             }}
                                             disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            name="periodo_anterior"
-                                            id="periodo_anterior"
-                                            className="form-control"
-                                        >
-                                            <option data-qa="option-periodo-anterior-vazio" value=''>Selecione um período</option>
-                                            {periodos && periodos.filter(element=> element.uuid !== values.uuid).map((periodo) =>
-                                                <option
-                                                    data-qa={`option-periodo-anterior-${periodo.uuid}`}
-                                                    key={periodo.uuid}
-                                                    value={periodo.uuid}>{`${periodo.referencia} - ${periodo.data_inicio_realizacao_despesas ? exibeDataPT_BR(periodo.data_inicio_realizacao_despesas) : "-"} até ${periodo.data_fim_realizacao_despesas ? exibeDataPT_BR(periodo.data_fim_realizacao_despesas) : "-"}`}
-                                                </option>
-                                            )}
-                                        </select>
-                                        {props.touched.periodo_anterior && props.errors.periodo_anterior && <span className="span_erro text-danger mt-1"> {props.errors.periodo_anterior} </span>}
+                                        />
+                                        {props.touched.data_inicio_realizacao_despesas && props.errors.data_inicio_realizacao_despesas && <span className="span_erro text-danger mt-1"> {props.errors.data_inicio_realizacao_despesas} </span>}
                                     </div>
                                 </div>
-                                {erroDatasAtendemRegras &&
-                                    <div className='row mt-2'>
-                                        <div className='col'>
-                                            <p><span className="span_erro text-danger mt-1" data-qa="span-erro-datas-atendem-regras"><strong>{erroDatasAtendemRegras}</strong></span></p>
-                                        </div>
+                                <div className='col'>
+                                    <div className="form-group">
+                                        <label htmlFor="data_fim_realizacao_despesas">Fim realização de despesas</label>
+                                        <DatePickerField
+                                            dataQa={"input-data-fim-realizacao-despesas"}
+                                            name="data_fim_realizacao_despesas"
+                                            id="data_fim_realizacao_despesas"
+                                            value={values.data_fim_realizacao_despesas != null ? values.data_fim_realizacao_despesas : ""}
+                                            onChange={setFieldValue}
+                                            disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        />
                                     </div>
-                                }
+                                </div>
+                            </div>
+
+                            <div className='row'>
+                                <div className='col'>
+                                    <div className="form-group">
+                                        <label htmlFor="data_inicio_prestacao_contas">Início prestação de contas</label>
+                                        <DatePickerField
+                                            dataQa={"input-data-inicio-prestacao-contas"}
+                                            name="data_inicio_prestacao_contas"
+                                            id="data_inicio_prestacao_contas"
+                                            value={values.data_inicio_prestacao_contas != null ? values.data_inicio_prestacao_contas : ""}
+                                            onChange={setFieldValue}
+                                            disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        />
+                                        {props.touched.data_inicio_prestacao_contas && props.errors.data_inicio_prestacao_contas && <span className="span_erro text-danger mt-1"> {props.errors.data_inicio_prestacao_contas} </span>}
+                                    </div>
+                                </div>
+                                <div className='col'>
+                                    <div className="form-group">
+                                        <label htmlFor="data_fim_prestacao_contas">Fim prestação de contas</label>
+                                        <DatePickerField
+                                            dataQa={"input-data-fim-prestacao-contas"}
+                                            name="data_fim_prestacao_contas"
+                                            id="data_fim_prestacao_contas"
+                                            value={values.data_fim_prestacao_contas != null ? values.data_fim_prestacao_contas : ""}
+                                            onChange={setFieldValue}
+                                            disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        />
+                                        {props.touched.data_fim_prestacao_contas && props.errors.data_fim_prestacao_contas && <span className="span_erro text-danger mt-1"> {props.errors.data_fim_prestacao_contas} </span>}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className='row'>
+                                <div className='col'>
+                                    <label htmlFor="periodo_anterior">Período anterior {deveValidarPeriodoAnterior ? "*" : ""}</label>
+                                    <select
+                                        data-qa="input-periodo-anterior"
+                                        value={values.periodo_anterior ? values.periodo_anterior.uuid : ""}
+                                        onChange={(e)=>{
+                                            props.handleChange(e);
+                                            setErroDatasAtendemRegras(false);
+                                        }}
+                                        disabled={!props.values.editavel || !TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        name="periodo_anterior"
+                                        id="periodo_anterior"
+                                        className="form-control"
+                                    >
+                                        <option data-qa="option-periodo-anterior-vazio" value=''>Selecione um período</option>
+                                        {periodos && periodos.filter(element=> element.uuid !== values.uuid).map((periodo) =>
+                                            <option
+                                                data-qa={`option-periodo-anterior-${periodo.uuid}`}
+                                                key={periodo.uuid}
+                                                value={periodo.uuid}>{`${periodo.referencia} - ${periodo.data_inicio_realizacao_despesas ? exibeDataPT_BR(periodo.data_inicio_realizacao_despesas) : "-"} até ${periodo.data_fim_realizacao_despesas ? exibeDataPT_BR(periodo.data_fim_realizacao_despesas) : "-"}`}
+                                            </option>
+                                        )}
+                                    </select>
+                                    {props.touched.periodo_anterior && props.errors.periodo_anterior && <span className="span_erro text-danger mt-1"> {props.errors.periodo_anterior} </span>}
+                                </div>
+                            </div>
+                            {erroDatasAtendemRegras &&
+                                <div className='row mt-2'>
+                                    <div className='col'>
+                                        <p><span className="span_erro text-danger mt-1" data-qa="span-erro-datas-atendem-regras"><strong>{erroDatasAtendemRegras}</strong></span></p>
+                                    </div>
+                                </div>
+                            }
+
+                            {
+                                values.id &&
                                 <div className='row mt-3'>
                                     <div className='col'>
-                                        <p className='mb-2'>Uuid</p>
-                                        <p className='mb-2'>{values.uuid}</p>
+                                        <p className='mb-2'>ID: {values.id}</p>
                                     </div>
-                                    {/* <div className='col'>
-                                        <p className='mb-2'>ID</p>
-                                        <p className='mb-2'>{values.id}</p>
-                                    </div> */}
                                 </div>
+                            }
 
-                                <div className="d-flex bd-highlight mt-2">
-                                    <div className="p-Y flex-grow-1 bd-highlight">
-                                        {values.operacao === 'edit' && values.editavel ? (
-                                            <button
-                                                data-qa="btn-apagar-periodo"
-                                                onClick={()=>setShowModalConfirmDeletePeriodo(true)}
-                                                type="button"
-                                                className="btn btn btn-danger mt-2 mr-2"
-                                                disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            >
-                                                Apagar
-                                            </button>
-                                        ): null}
-                                    </div>
+                            <div className="d-flex bd-highlight mt-2">
+                                <div className="p-Y flex-grow-1 bd-highlight">
+                                    {values.operacao === 'edit' && values.editavel ? (
+                                        <button
+                                            data-qa="btn-apagar-periodo"
+                                            onClick={()=> {
+                                                setShowModalConfirmDeletePeriodo({ open: true, periodo_uuid: values.uuid })
+                                                onHandleClose()
+                                            }}
+                                            type="button"
+                                            className="btn btn btn-danger mt-2 mr-2"
+                                            disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                        >
+                                            Excluir
+                                        </button>
+                                    ): null}
+                                </div>
+                                <div className="p-Y bd-highlight">
+                                    <button
+                                        data-qa="btn-cancelar"
+                                        onClick={onHandleClose}
+                                        type="button"
+                                        className={`btn btn${values.editavel ? '-outline-success' : '-success'} mt-2 mr-2`}
+                                    >
+                                        {values.editavel ? 'Cancelar' : 'Voltar'}
+                                    </button>
+                                </div>
+                                {values.operacao === 'create' || (values.operacao === 'edit' && values.editavel) ? (
                                     <div className="p-Y bd-highlight">
                                         <button
-                                            data-qa="btn-cancelar"
-                                            onClick={onHandleClose}
-                                            type="button"
-                                            className={`btn btn${values.editavel ? '-outline-success' : '-success'} mt-2 mr-2`}
+                                            data-qa="btn-salvar"
+                                            type="submit"
+                                            className="btn btn btn-success mt-2"
+                                            disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                         >
-                                            {values.editavel ? 'Cancelar' : 'Voltar'}
+                                            Salvar
                                         </button>
                                     </div>
-                                    {values.operacao === 'create' || (values.operacao === 'edit' && values.editavel) ? (
-                                        <div className="p-Y bd-highlight">
-                                            <button
-                                                data-qa="btn-salvar"
-                                                type="submit"
-                                                className="btn btn btn-success mt-2"
-                                                disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                            >
-                                                Salvar
-                                            </button>
-                                        </div>
-                                    ):null}
-                                </div>
-                            </form>
-                        );
-                    }}
-                </Formik>
-            </>
+                                ):null}
+                            </div>
+                        </form>
+                    );
+                }}
+            </Formik>
         )
     };
 
     return (
         <ModalFormBodyText
             show={show}
-            titulo={stateFormModal && !stateFormModal.editavel ? 'Visualizar período' : stateFormModal && stateFormModal.operacao === 'edit' ? 'Editar período' : 'Adicionar período'}
+            titulo={readOnly ? 'Visualizar período' : stateFormModal && stateFormModal.operacao === 'edit' ? 'Editar período' : 'Adicionar período'}
             onHide={onHandleClose}
             size='lg'
             bodyText={bodyTextarea()}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/Tabela.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/Tabela.js
@@ -2,14 +2,15 @@ import {memo, useCallback, useContext} from "react";
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import moment from "moment";
-import { EditIconButton, VisualizarIconButton} from "../../../../Globais/UI/Button";
+import { EditIconButton, IconButton, VisualizarIconButton} from "../../../../Globais/UI/Button";
 import { RecursosContext } from "../../componentes/AbasPorRecurso/context/Recursos";
 
 const Tabela = ({
     rowsPerPage, 
-    data, 
-    count,
-    handleOpenModalForm
+    data,
+    handleOpenModalForm,
+    handleOpenCreateModal,
+    tem_permissao_edicao_painel_parametrizacoes
 }) =>{
     const dataTemplate = useCallback((rowData, column) => {
         return (
@@ -37,8 +38,21 @@ const Tabela = ({
 
     return(
         <>
-        <p>Recurso selecionado: {selectedRecurso?.nome}</p>
-        <p>Exibindo <span data-qa="total-acoes" className='total-acoes'>{count}</span> períodos</p>        
+        <div className="d-flex justify-content-between align-items-end mb-3">
+            <div>
+                <h5 className="font-weight-bold">{selectedRecurso?.nome}</h5>
+                <p className="m-0">Confira abaixo os prazos de repasse e execução do {selectedRecurso?.nome_exibicao}.</p>
+            </div>
+
+            <IconButton
+                icon="faPlus"
+                iconProps={{ style: {fontSize: '15px', marginRight: "5", color:"#fff"} }}
+                label="Adicionar período"
+                onClick={() => handleOpenCreateModal(selectedRecurso)}
+                variant="success"
+                disabled={!tem_permissao_edicao_painel_parametrizacoes}
+            />
+        </div>
         <DataTable  
             value={data}
             rows={rowsPerPage}

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/YupSignupSchemaPeriodos.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/YupSignupSchemaPeriodos.js
@@ -2,11 +2,15 @@ import * as yup from "yup";
 
 export const YupSignupSchemaPeriodos = (deveValidarPeriodoAnterior) =>
     yup.object().shape({
+      recurso: yup.object({
+        uuid: yup.string().required("Recurso é obrigatório"),
+      }).required("Recurso é obrigatório"),
+
       referencia: yup.string().required("Referência é obrigatória"),
-  
+
       periodo_anterior: deveValidarPeriodoAnterior
-        ? yup.string().required("Período anterior é obrigatório")
-        : yup.string().nullable(),
+        ? yup.mixed().required("Período anterior é obrigatório")
+        : yup.mixed().nullable(),
   
       data_inicio_realizacao_despesas: yup
         .string()

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/Filtros.test.js
@@ -20,14 +20,14 @@ describe('Filtros', () => {
     });
 
     it('testa a as labels e botões', () => {
-        expect(screen.getByLabelText(/Pesquisar/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/Filtre por referência/i)).toBeInTheDocument();
         expect(screen.getByPlaceholderText(/Busque por referência/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /limpar/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /filtrar/i })).toBeInTheDocument();
     });
 
     it('testa a reatividade ao alterar o campo de filtro', async () => {
-        const input = screen.getByLabelText(/Pesquisar/i);
+        const input = screen.getByLabelText(/Filtre por referência/i);
         fireEvent.change(input, { target: { name: "filtrar_por_referencia", value: "2025.1" } });
         
         expect(propsMock.handleChangeFiltros).toHaveBeenCalled()
@@ -41,7 +41,7 @@ describe('Filtros', () => {
     });
 
     it('testa a chamada de Filtrar ao clicar em Filtrar', () => {
-        const input = screen.getByLabelText(/Pesquisar/i);
+        const input = screen.getByLabelText(/Filtre por referência/i);
         fireEvent.change(input, { target: { name: "filtrar_por_referencia", value: "Teste" } });
 
         const button = screen.getByRole('button', { name: /filtrar/i });

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/ModalFormPeriodos.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/ModalFormPeriodos.test.js
@@ -28,6 +28,7 @@ describe('ModalFormPeriodos Component', () => {
       uuid: "periodo-uuid-fake-1",
       editavel: true,
       operacao: 'edit',
+      recurso: {uuid: 'recurso-uuid-fake', nome: 'Recurso Fake'},
     },
     deveValidarPeriodoAnterior: true,
     erroDatasAtendemRegras: '',
@@ -121,7 +122,7 @@ describe('ModalFormPeriodos Component', () => {
       <ModalFormPeriodos {...initialProps} />
     );
 
-    fireEvent.click(screen.getByText(/Apagar/i));
+    fireEvent.click(screen.getByText(/Excluir/i));
     expect(mockSetShowModalConfirmDeletePeriodo).toHaveBeenCalled();
   });
 
@@ -164,7 +165,7 @@ describe('ModalFormPeriodos Component', () => {
     );
 
     const options = screen.getAllByRole("option");
-    expect(options.length).toBe(2);
+    expect(options.length).toBe(3); // 2 períodos + opção "Selecione um período"
 
     const option2024_3 = screen.getByRole("option", { name: "2024.3 - 01/09/2024 até 31/12/2024" });
     expect(option2024_3).toBeInTheDocument();

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/Tabela.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/Tabela.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import '@testing-library/jest-dom';
 import Tabela from "../Tabela";
+import { RecursosContext } from "../../../componentes/AbasPorRecurso/context/Recursos";
 
 describe("Tabela", () => {
     const mockHandleOpenModalForm = jest.fn();
@@ -33,14 +34,37 @@ describe("Tabela", () => {
         jest.clearAllMocks();
     });
 
+    const renderWithRecursosContext = (ui, contextValue = {}) => {
+        const defaultContextValue = {
+            selectedRecurso: {
+                nome: "PTRF Básico",
+                nome_exibicao: "PTRF Básico",
+            },
+            setSelectedRecurso: jest.fn(),
+            clickBtnEscolheOpcao: {},
+            setClickBtnEscolheOpcao: jest.fn(),
+            ...contextValue,
+        };
+
+        return render(
+            <RecursosContext.Provider value={defaultContextValue}>
+                {ui}
+            </RecursosContext.Provider>
+        );
+    };
+
     it("deve renderizar corretamente o número de períodos", () => {
-        render(<Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />);
+        renderWithRecursosContext(
+            <Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />
+        );
         
-        expect(screen.getByText((_, element) => element.textContent === `Exibindo ${mockData.length} períodos`)).toBeInTheDocument();
+        expect(screen.getByText("Confira abaixo os prazos de repasse e execução do PTRF Básico.")).toBeInTheDocument();
     });
 
     it("deve exibir os dados corretamente formatados", () => {
-        render(<Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />);
+        renderWithRecursosContext(
+            <Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />
+        );
 
         const headerNames = [
             "Referência",
@@ -60,7 +84,9 @@ describe("Tabela", () => {
     });
 
     it("deve chamar handleOpenModalForm ao clicar no botão de ação editar", () => {
-        render(<Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />);
+        renderWithRecursosContext(
+            <Tabela rowsPerPage={5} data={mockData} count={mockData.length} handleOpenModalForm={mockHandleOpenModalForm} />
+        );
 
         const actionButton = screen.getByRole("button", { name: /editar/i });
         fireEvent.click(actionButton);
@@ -70,7 +96,9 @@ describe("Tabela", () => {
     });
 
     it("deve chamar handleOpenModalForm ao clicar no botão de ação visualizar", () => {
-        render(<Tabela rowsPerPage={5} data={mockDataVisualizacao} count={mockDataVisualizacao.length} handleOpenModalForm={mockHandleOpenModalForm} />);
+        renderWithRecursosContext(
+            <Tabela rowsPerPage={5} data={mockDataVisualizacao} count={mockDataVisualizacao.length} handleOpenModalForm={mockHandleOpenModalForm} />
+        );
 
         const actionButton = screen.getByRole("button", { name: /visualizar/i });
         fireEvent.click(actionButton);

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/index.test.js
@@ -33,11 +33,12 @@ jest.mock("../../../componentes/AbasPorRecurso/context/Recursos", () => ({
 const mockSetShowModalConfirmDeletePeriodo = jest.fn();
 const mockHandleDelete = jest.fn();
 const mockSetShowModalInfoExclusaoNaoPermitida = jest.fn();
+const mockHandleCloseModalConfirmDeletePeriodo = jest.fn();
 
 jest.mock("../hooks/usePeriodos", () => ({
   usePeriodos: () => ({
     modalForm: { open: true, uuid: "123" },
-    showModalConfirmDeletePeriodo: true,
+    showModalConfirmDeletePeriodo: { open: true, periodo_uuid: "12345-uuid" },
     showModalInfoExclusaoNaoPermitida: true,
     erroDatasAtendemRegras: false,
     erroExclusaoNaoPermitida: "Não é possível excluir este período.",
@@ -57,6 +58,7 @@ jest.mock("../hooks/usePeriodos", () => ({
     setShowModalConfirmDeletePeriodo: mockSetShowModalConfirmDeletePeriodo,
     setShowModalInfoExclusaoNaoPermitida: mockSetShowModalInfoExclusaoNaoPermitida,
     setErroDatasAtendemRegras: jest.fn(),
+    handleCloseModalConfirmDeletePeriodo: mockHandleCloseModalConfirmDeletePeriodo
   }),
 }));
 
@@ -80,11 +82,6 @@ describe("Periodos", () => {
       expect(screen.getByText("Deseja realmente excluir este período?")).toBeInTheDocument();
       expect(screen.getByText("Cancelar")).toBeInTheDocument();
       expect(screen.getByText("Excluir")).toBeInTheDocument();
-  
-      // Verifica se o modal de exclusão não permitida está no documento
-      expect(screen.getByText("Exclusão não permitida")).toBeInTheDocument();
-      expect(screen.getByText("Não é possível excluir este período.")).toBeInTheDocument();
-      expect(screen.getByText("Fechar")).toBeInTheDocument();
     });
   
     it("deve fechar o modal de confirmação de exclusão ao clicar em 'Cancelar'", () => {
@@ -93,7 +90,7 @@ describe("Periodos", () => {
         const cancelButton = screen.getByText("Cancelar");
         fireEvent.click(cancelButton);
     
-        expect(mockSetShowModalConfirmDeletePeriodo).toHaveBeenCalledWith(false);
+        expect(mockHandleCloseModalConfirmDeletePeriodo).toHaveBeenCalled();
       });
   
     it("deve chamar a função de exclusão ao clicar em 'Excluir'", () => {
@@ -101,16 +98,8 @@ describe("Periodos", () => {
       const excluirButton = screen.getByText("Excluir");
       fireEvent.click(excluirButton);
   
-      expect(mockHandleDelete).toHaveBeenCalledWith("123");
-      expect(mockSetShowModalConfirmDeletePeriodo).toHaveBeenCalledWith(false);
-    });
-  
-    it("deve fechar o modal de exclusão não permitida ao clicar em 'Fechar'", () => {
-      render(<Periodos />);
-      const fecharButton = screen.getByText("Fechar");
-      fireEvent.click(fecharButton);
-  
-      expect(mockSetShowModalInfoExclusaoNaoPermitida).toHaveBeenCalledWith(false);
+      expect(mockHandleDelete).toHaveBeenCalledWith("12345-uuid");
+      expect(mockHandleCloseModalConfirmDeletePeriodo).toHaveBeenCalled();
     });
   });
   

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/useDeletePeriodo.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/useDeletePeriodo.test.js
@@ -58,14 +58,13 @@ describe("useDeletePeriodo", () => {
         const erro = { response: { data: { mensagem: "Exclusão não permitida." } } };
         deletePeriodo.mockRejectedValueOnce(erro);
 
-        const { result } = renderHook(() => useDeletePeriodo(setModalForm, setErroExclusaoNaoPermitida, setShowModalInfoExclusaoNaoPermitida), { wrapper });
+        const { result } = renderHook(() => useDeletePeriodo(setModalForm), { wrapper });
 
         await act(async () => {
             result.current.mutationDelete.mutate("uuid-teste");
         });
 
-        expect(setErroExclusaoNaoPermitida).toHaveBeenCalledWith("Exclusão não permitida.");
-        expect(setShowModalInfoExclusaoNaoPermitida).toHaveBeenCalledWith(true);
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith("Exclusão não permitida", "Exclusão não permitida.");
     });
 
     it("deve lidar com erro genérico na exclusão", async () => {

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/usePeriodos.test.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/__tests__/usePeriodos.test.js
@@ -94,6 +94,7 @@ describe("usePeriodos", () => {
                 data_fim_realizacao_despesas: "2023-01-31",
                 operacao: "create",
                 uuid: "",
+                recurso: { uuid: "fake-recurso-uuid" }
             });
         });
         
@@ -113,6 +114,7 @@ describe("usePeriodos", () => {
                 data_fim_realizacao_despesas: "2023-01-31",
                 operacao: "edit",
                 uuid: "fake-uuid",
+                recurso: { uuid: "fake-recurso-uuid" }
             });
         });
         
@@ -133,6 +135,7 @@ describe("usePeriodos", () => {
                 data_fim_realizacao_despesas: "2023-01-31",
                 operacao: "create",
                 uuid: "",
+                recurso: { uuid: "fake-recurso-uuid" }
             });
         });
 

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/useDeletePeriodo.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/useDeletePeriodo.js
@@ -3,9 +3,7 @@ import { deletePeriodo } from "../../../../../../services/sme/Parametrizacoes.se
 import { toastCustom } from "../../../../../Globais/ToastCustom";
 
 export const useDeletePeriodo = (
-    setModalForm,
-    setErroExclusaoNaoPermitida,
-    setShowModalInfoExclusaoNaoPermitida
+    setModalForm
 ) => {
     const queryClient = useQueryClient();
 
@@ -23,8 +21,7 @@ export const useDeletePeriodo = (
         },
         onError: (e) => {
             if (e.response && e.response.data && e.response.data.mensagem){
-                setErroExclusaoNaoPermitida(e.response.data.mensagem);
-                setShowModalInfoExclusaoNaoPermitida(true)
+                toastCustom.ToastCustomError("Exclusão não permitida", e.response.data.mensagem);
             } else {
                 toastCustom.ToastCustomError("Ops!", "Houve um erro ao tentar completar ação.");
             }

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/useGetPeriodos.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/useGetPeriodos.js
@@ -4,8 +4,14 @@ import { getTodosPeriodos } from "../../../../../../services/sme/Parametrizacoes
 
 export const useGetPeriodos = (filters) => {
     const { isFetching, isError, data = [], error, refetch } = useQuery({
-        queryKey: ['periodos'],
-        queryFn: ()=> getTodosPeriodos(filters.filtrar_por_referencia),
+        queryKey: ['periodos', filters.recurso_uuid],
+        queryFn: ()=> {
+            if (filters.is_required_recurso_uuid && !filters.recurso_uuid) {
+                return Promise.resolve([]);
+            }
+
+            return getTodosPeriodos(filters.filtrar_por_referencia, filters.recurso_uuid)
+        },
         keepPreviousData: true,
         staleTime: 5000, // 5 segundos
         refetchOnWindowFocus: true, // Caso saia da aba e voltar ele refaz a requisição

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/usePeriodos.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/hooks/usePeriodos.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import moment from "moment";
 import { usePatchPeriodo } from "./usePatchPeriodo";
 import { usePostPeriodo } from "./usePostPeriodo";
@@ -6,6 +6,7 @@ import { useGetPeriodos } from "./useGetPeriodos";
 import { useDeletePeriodo } from "./useDeletePeriodo";
 import { getDatasAtendemRegras } from "../../../../../../services/sme/Parametrizacoes.service";
 import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 
 const initialStateFormModal = {
     referencia: "",
@@ -21,23 +22,43 @@ const initialStateFormModal = {
     operacao: 'create',
     open: false
 };
-const initialStateFiltros = { filtrar_por_referencia: "" };
+
+const initialStateFiltros = {
+    filtrar_por_referencia: "",
+    is_required_recurso_uuid: true,
+    recurso_uuid: "",
+};
+
+const initialStateModalConfirmDeletePeriodo = {
+    open: false,
+    periodo_uuid: "",
+}
 
 export const usePeriodos = () => {
+    const { recursos } = useRecursoSelecionadoContext()
+    
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes();
     const [modalForm, setModalForm] = useState(initialStateFormModal);
     const [erroDatasAtendemRegras, setErroDatasAtendemRegras] = useState("");
     const [stateFiltros, setStateFiltros] = useState(initialStateFiltros);
-    const [showModalConfirmDeletePeriodo, setShowModalConfirmDeletePeriodo] = useState(false);
+    const [showModalConfirmDeletePeriodo, setShowModalConfirmDeletePeriodo] = useState(initialStateModalConfirmDeletePeriodo);
     const [showModalInfoExclusaoNaoPermitida, setShowModalInfoExclusaoNaoPermitida] = useState(false);
     const [erroExclusaoNaoPermitida, setErroExclusaoNaoPermitida] = useState("");
 
     const { mutationPatch } = usePatchPeriodo(setModalForm);
     const { mutationPost } = usePostPeriodo(setModalForm);
-    const { mutationDelete } = useDeletePeriodo(setModalForm, setErroExclusaoNaoPermitida, setShowModalInfoExclusaoNaoPermitida);
+    const { mutationDelete } = useDeletePeriodo(setModalForm);
     const { isLoading, data: results, count, refetch } = useGetPeriodos(stateFiltros);
 
-    const handleOpenCreateModal = () => setModalForm({ ...initialStateFormModal, open: true });
+    useEffect(() => {
+        const initialValueWithInitialRecurso = {...initialStateFiltros, recurso_uuid: recursos?.length > 0 ? recursos[0].uuid : '' }
+
+        setStateFiltros(initialValueWithInitialRecurso)
+    }, [recursos])
+
+    const handleOpenCreateModal = (recursoSelecionadoAba) => {
+        setModalForm({ ...initialStateFormModal, open: true, recurso: { uuid: recursoSelecionadoAba?.uuid } })
+    };
 
     const handleClose = () => setModalForm(initialStateFormModal);
 
@@ -45,16 +66,19 @@ export const usePeriodos = () => {
 
     const handleDelete = async (uuid) => mutationDelete.mutate(uuid);
 
+    const handleCloseModalConfirmDeletePeriodo = () => setShowModalConfirmDeletePeriodo(initialStateModalConfirmDeletePeriodo);
+
     const submit = (values) => {
         if (!values.uuid) {
             mutationPost.mutate({payload: values})
         } else {
-            mutationPatch.mutate({UUID: values.uuid, values: values})
+            mutationPatch.mutate({UUID: values.uuid, payload: values})
         }
     };
 
     const handleSubmitFormModal = async (values) => {
         const payload = {
+            recurso: values.recurso.uuid,
             uuid: values.uuid ? values.uuid : '',
             referencia: values.referencia,
             data_prevista_repasse: values.data_prevista_repasse ? moment(values.data_prevista_repasse).format("YYYY-MM-DD") : null,
@@ -62,7 +86,10 @@ export const usePeriodos = () => {
             data_fim_realizacao_despesas: values.data_fim_realizacao_despesas ? moment(values.data_fim_realizacao_despesas).format("YYYY-MM-DD") : null,
             data_inicio_prestacao_contas: values.data_inicio_prestacao_contas ? moment(values.data_inicio_prestacao_contas).format("YYYY-MM-DD") : null,
             data_fim_prestacao_contas: values.data_fim_prestacao_contas ? moment(values.data_fim_prestacao_contas).format("YYYY-MM-DD") : null,
-            periodo_anterior: values.periodo_anterior ? values.operacao === "create" ? values.periodo_anterior : values.periodo_anterior.uuid : ''
+            periodo_anterior: values.periodo_anterior
+                ? (typeof values.periodo_anterior === 'object' ? values.periodo_anterior.uuid : values.periodo_anterior)
+                : ''
+ 
         };
 
         let datas_atendem = await getDatasAtendemRegras(
@@ -70,14 +97,20 @@ export const usePeriodos = () => {
                 payload.data_fim_realizacao_despesas, 
                 payload.periodo_anterior, 
                 payload.uuid,
+                payload.recurso,
             );
         if (!datas_atendem.valido){
-            console.log(datas_atendem, datas_atendem.mensagem)
             setErroDatasAtendemRegras(datas_atendem.mensagem)
         } else {
             setErroDatasAtendemRegras("");
             submit(payload)
         }        
+    }
+
+    const handleLimparFiltros = () => {
+        setStateFiltros(prevState => ({...prevState, filtrar_por_referencia: "" }))
+
+        setTimeout(() => refetch(), 100);
     }
 
     return {
@@ -99,9 +132,10 @@ export const usePeriodos = () => {
         handleSubmitFormModal, 
         handleChangeFiltros: useCallback((name, value) => setStateFiltros((prev) => ({ ...prev, [name]: value })), []),
         handleSubmitFiltros: refetch, 
-        limpaFiltros: () => setStateFiltros(initialStateFiltros),
+        limpaFiltros: handleLimparFiltros,
         setShowModalConfirmDeletePeriodo, 
         setShowModalInfoExclusaoNaoPermitida,
-        setErroDatasAtendemRegras
+        setErroDatasAtendemRegras,
+        handleCloseModalConfirmDeletePeriodo
     };
 };

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/index.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/index.js
@@ -2,25 +2,20 @@ import { PaginasContainer } from "../../../../../paginas/PaginasContainer";
 import ModalFormPeriodos from "./ModalFormPeriodos";
 import { Filtros } from "./Filtros";
 import Tabela from "./Tabela";
-import { IconButton } from "../../../../Globais/UI/Button/IconButton";
 import Loading from "../../../../../utils/Loading";
-import { ModalBootstrap } from "../../../../Globais/ModalBootstrap";
 import { usePeriodos } from "./hooks/usePeriodos";
 import { AbasPorRecurso } from "../../componentes/AbasPorRecurso";
 import { RecursosProvider } from "../../componentes/AbasPorRecurso/context/Recursos";
+import { ModalConfirmarExclusao } from "../../../../Globais/ModalAntDesign/ModalConfirmarExclusao";
 
-export const Periodos = ()=>{
-    
+export const Periodos = () => {
     const {
         modalForm,
         showModalConfirmDeletePeriodo,
-        showModalInfoExclusaoNaoPermitida,
         erroDatasAtendemRegras,
-        erroExclusaoNaoPermitida,
         stateFiltros,
         isLoading,
         results,
-        count,
         TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES,
         handleOpenCreateModal,
         handleClose,
@@ -31,92 +26,72 @@ export const Periodos = ()=>{
         handleSubmitFiltros,
         limpaFiltros,
         setShowModalConfirmDeletePeriodo,
-        setShowModalInfoExclusaoNaoPermitida,
-        setErroDatasAtendemRegras
+        setErroDatasAtendemRegras,
+        handleCloseModalConfirmDeletePeriodo,
     } = usePeriodos();
     return(
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Períodos</h1>
-            {isLoading ? (
-                <div className="mt-5">
-                    <Loading
-                        corGrafico="black"
-                        corFonte="dark"
-                        marginTop="0"
-                        marginBottom="0"
+            <RecursosProvider>
+                <h1 className="titulo-itens-painel mt-5">Períodos</h1>
+                {isLoading ? (
+                    <div className="mt-5">
+                        <Loading
+                            corGrafico="black"
+                            corFonte="dark"
+                            marginTop="0"
+                            marginBottom="0"
+                        />
+                    </div>
+                ) : (
+                    <div className="page-content-inner">
+
+                    <Filtros
+                        stateFiltros={stateFiltros}
+                        handleChangeFiltros={handleChangeFiltros}
+                        handleSubmitFiltros={handleSubmitFiltros}
+                        limpaFiltros={limpaFiltros}
                     />
-                </div>
-            ) : (
-                <div className="page-content-inner">
 
-                <div className="d-flex  justify-content-end pb-4 mt-2">
-                    <IconButton
-                        icon="faPlus"
-                        iconProps={{ style: {fontSize: '15px', marginRight: "5", color:"#fff"} }}
-                        label="Adicionar período"
-                        onClick={handleOpenCreateModal}
-                        variant="success"
-                        disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                    
+                    <AbasPorRecurso
+                        handleChangeFiltros={handleChangeFiltros}
                     />
-                </div>
-
-                <Filtros
-                    stateFiltros={stateFiltros}
-                    handleChangeFiltros={handleChangeFiltros}
-                    handleSubmitFiltros={handleSubmitFiltros}
-                    limpaFiltros={limpaFiltros}
-                />
-
-                <RecursosProvider>
-                    <AbasPorRecurso />
 
                     <Tabela 
-                        rowsPerPage={20} 
-                        data={results} 
-                        count={count}
+                        rowsPerPage={10} 
+                        data={results}
                         handleOpenModalForm={handleOpenModalForm}
+                        handleOpenCreateModal={handleOpenCreateModal}
+                        tem_permissao_edicao_painel_parametrizacoes={TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                     />
-                </RecursosProvider>
 
-                <ModalFormPeriodos
-                    show={modalForm.open}
-                    stateFormModal={modalForm}
-                    onHandleClose={handleClose}
-                    onSubmit={handleSubmitFormModal}
-                    deveValidarPeriodoAnterior={results.length > 0 ? true : false}
-                    periodos={results}
-                    setErroDatasAtendemRegras={setErroDatasAtendemRegras}
-                    erroDatasAtendemRegras={erroDatasAtendemRegras}
-                    setShowModalConfirmDeletePeriodo={setShowModalConfirmDeletePeriodo}
-                />
+                    <ModalFormPeriodos
+                        show={modalForm.open}
+                        stateFormModal={modalForm}
+                        onHandleClose={handleClose}
+                        onSubmit={handleSubmitFormModal}
+                        deveValidarPeriodoAnterior={results.length > 1 ? true : false}
+                        periodos={results}
+                        setErroDatasAtendemRegras={setErroDatasAtendemRegras}
+                        erroDatasAtendemRegras={erroDatasAtendemRegras}
+                        setShowModalConfirmDeletePeriodo={setShowModalConfirmDeletePeriodo}
+                    />
 
-                <ModalBootstrap
-                    show={showModalConfirmDeletePeriodo}
-                    // onHide={() => setShowModalConfirmDeletePeriodo(false)}
-                    primeiroBotaoOnclick={() => setShowModalConfirmDeletePeriodo(false)}
-                    segundoBotaoOnclick={()=> {
-                        setShowModalConfirmDeletePeriodo(false)
-                        handleDelete(modalForm.uuid)
-                    }}
-                    titulo="Excluir Período"
-                    bodyText="<p>Deseja realmente excluir este período?</p>"
-                    primeiroBotaoTexto="Cancelar"
-                    primeiroBotaoCss="outline-success"
-                    segundoBotaoCss="danger"
-                    segundoBotaoTexto="Excluir"
-                />
-
-                <ModalBootstrap
-                    show={showModalInfoExclusaoNaoPermitida}
-                    // onHide={() => setShowModalInfoExclusaoNaoPermitida(false)}
-                    titulo="Exclusão não permitida"
-                    bodyText={`<p class="mb-0"> ${erroExclusaoNaoPermitida}</p>`}
-                    primeiroBotaoTexto="Fechar"
-                    primeiroBotaoCss="success"
-                    primeiroBotaoOnclick={() => setShowModalInfoExclusaoNaoPermitida(false)}
-                />
-            </div>
-            )}
+                    <ModalConfirmarExclusao
+                        open={showModalConfirmDeletePeriodo.open}
+                        onOk={()=> {
+                            handleDelete(showModalConfirmDeletePeriodo.periodo_uuid)
+                            handleCloseModalConfirmDeletePeriodo()
+                        }}
+                        okText="Excluir"
+                        onCancel={() => handleCloseModalConfirmDeletePeriodo()}
+                        cancelText="Cancelar"
+                        titulo="Excluir Período"
+                        bodyText="Deseja realmente excluir este período?"
+                    />
+                </div>
+                )}
+            </RecursosProvider>
         </PaginasContainer>
     )
 }

--- a/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/index.js
+++ b/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/index.js
@@ -1,13 +1,15 @@
 import React, { Fragment, useMemo, useRef, useEffect, useContext } from "react";
-import { useGetRecursos } from "./hooks/useGetRecursos";
 import { RecursosContext } from "./context/Recursos";
 import "../../../../../componentes/Globais/MenuInterno";
 import "../../../../../componentes/dres/Associacoes/associacoes.scss";
 import Loading from "../../../../../utils/Loading";
+import { useRecursoSelecionadoContext } from "../../../../../context/RecursoSelecionado";
 
-export const AbasPorRecurso = () => {
+export const AbasPorRecurso = ({
+    handleChangeFiltros,
+}) => {
     const { selectedRecurso, setSelectedRecurso, clickBtnEscolheOpcao, setClickBtnEscolheOpcao } = useContext(RecursosContext);
-    const { data: recursos, isLoading, isError, error } = useGetRecursos();
+    const { isLoading, recursos } = useRecursoSelecionadoContext();
     // Ref para garantir que a inicialização da aba ativa ocorra apenas uma vez
     const inicializado = useRef(false);
 
@@ -24,9 +26,25 @@ export const AbasPorRecurso = () => {
         }));
     }, [recursos]);
 
+    const filteredRecursoTabs = (recursoUUID) => {
+        handleChangeFiltros('recurso_uuid', recursoUUID);
+    }
+
+    const handleChangeTab = (tab_id) => {
+        // Ativa aba de recurso
+        setClickBtnEscolheOpcao({
+            [tab_id]: true,
+        });
+        // Atualiza o recurso selecionado no contexto
+        const recursoSelecionado = recursos.find(r => r.uuid === tab_id);
+        setSelectedRecurso(recursoSelecionado);
+
+        filteredRecursoTabs(recursoSelecionado ? recursoSelecionado.uuid : '');
+    }
+
     // Inicializa primeira aba como ativa - executa apenas uma vez com a primeira aba
     useEffect(() => {
-        if (recurso_tabs.length > 0 && !inicializado.current) {
+        if (recurso_tabs.length > 0 && !inicializado.current && !selectedRecurso) {
             const primeiroRecurso = recursos.find(r => r.uuid === recurso_tabs[0].id);
             setClickBtnEscolheOpcao({
                 [recurso_tabs[0].id]: true,
@@ -39,7 +57,7 @@ export const AbasPorRecurso = () => {
     // Sincroniza o recurso selecionado quando a aba ativa muda
     useEffect(() => {
         const abaAtivaId = Object.keys(clickBtnEscolheOpcao).find(key => clickBtnEscolheOpcao[key]);
-        if (abaAtivaId) {
+        if (abaAtivaId && !selectedRecurso) {
             const recursoAtivo = recursos.find(r => r.uuid === abaAtivaId);
             if (recursoAtivo) {
                 setSelectedRecurso(recursoAtivo);
@@ -60,46 +78,30 @@ export const AbasPorRecurso = () => {
         );
     }
 
-    if (isError) {
-        return (
-            <div className="alert alert-danger mt-3">
-                Erro ao carregar recursos: {error?.message || "Erro desconhecido"}
-            </div>
-        );
-    }
-
     if (recurso_tabs.length === 0) {
         return <div className="alert alert-info mt-3">Nenhum recurso disponível</div>;
     }
 
     return (
-        <nav className="nav mb-4 mt-2 menu-interno">
-            {recurso_tabs.map((tab, index) => {
+        <nav className="nav mt-2 menu-interno">
+            {recurso_tabs.map((tab) => {
                 return tab.permissao ? (
-                    <Fragment key={index}>
+                    <Fragment key={tab.id}>
                         <li>
-                        <a
-                            onClick={() => {
-                                // Ativa aba de recurso
-                                setClickBtnEscolheOpcao({
-                                    [tab.id]: true,
-                                });
-                                // Atualiza o recurso selecionado no contexto
-                                const recursoSelecionado = recursos.find(r => r.uuid === tab.id);
-                                setSelectedRecurso(recursoSelecionado);
-                            }}
-                            className={`nav-link btn-escolhe-aba ${
-                                clickBtnEscolheOpcao[tab.id] ? "btn-escolhe-aba-active" : ""
-                            }`}
-                            id={`nav-${tab.id}-tab`}
-                            data-toggle="tab"
-                            href={`#nav-${tab.id}`}
-                            role="tab"
-                            aria-controls={`nav-${tab.id}`}
-                            aria-selected={clickBtnEscolheOpcao[tab.id] ? "true" : "false"}
-                        >
-                            {tab.nome_exibicao}
-                        </a>
+                            <a
+                                onClick={() => handleChangeTab(tab.id)}
+                                className={`nav-link btn-escolhe-aba ${
+                                    clickBtnEscolheOpcao[tab.id] ? "btn-escolhe-aba-active" : ""
+                                }`}
+                                id={`nav-${tab.id}-tab`}
+                                data-toggle="tab"
+                                href={`#nav-${tab.id}`}
+                                role="tab"
+                                aria-controls={`nav-${tab.id}`}
+                                aria-selected={clickBtnEscolheOpcao[tab.id] ? "true" : "false"}
+                            >
+                                {tab.nome_exibicao}
+                            </a>
                         </li>
                     </Fragment>
                 ) : null;

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -511,8 +511,8 @@ export const validarDataDeEncerramento = async (
 };
 
 // Periodos
-export const getTodosPeriodos = async (referencia = "") => {
-  return (await api.get(`/api/periodos/?referencia=${referencia}`, authHeader()))
+export const getTodosPeriodos = async (referencia = "", recurso_uuid = "") => {
+  return (await api.get(`/api/periodos/?referencia=${referencia}&recurso_uuid=${recurso_uuid}`, authHeader()))
     .data;
 };
 export const getPeriodoPorReferencia = async (referencia) => {
@@ -523,7 +523,8 @@ export const getDatasAtendemRegras = async (
   data_inicio_realizacao_despesas,
   data_fim_realizacao_despesas,
   periodo_anterior_uuid,
-  periodo_uuid
+  periodo_uuid,
+  recurso_uuid,
 ) => {
   const queryParams = new URLSearchParams({
     data_inicio_realizacao_despesas,
@@ -537,6 +538,12 @@ export const getDatasAtendemRegras = async (
   }
   if (periodo_uuid) {
     queryParams.append("periodo_uuid", periodo_uuid);
+  }
+  if(recurso_uuid) {
+    queryParams.append(
+      "recurso_uuid",
+      recurso_uuid
+    );
   }
   return (
     await api.get(

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -867,7 +867,7 @@ describe('Testes para funções de análise', () => {
     test('getTodosPeriodos deve chamar a API corretamente sem referencia', async () => {
         api.get.mockResolvedValue({ data: mockData })
         const result = await getTodosPeriodos();
-        const url = `/api/periodos/?referencia=`
+        const url = `/api/periodos/?referencia=&recurso_uuid=`
         expect(api.get).toHaveBeenCalledWith(url, authHeader())
         expect(result).toEqual(mockData);
     });
@@ -876,7 +876,7 @@ describe('Testes para funções de análise', () => {
         api.get.mockResolvedValue({ data: mockData })
         const referencia = '2023'
         const result = await getTodosPeriodos(referencia);
-        const url = `/api/periodos/?referencia=${referencia}`
+        const url = `/api/periodos/?referencia=${referencia}&recurso_uuid=`
         expect(api.get).toHaveBeenCalledWith(url, authHeader())
         expect(result).toEqual(mockData);
     });


### PR DESCRIPTION
Este PR inclui:

- Ajusta a visualização da tabela de períodos por aba de recurso;
- Muda padinação para 10 por página;
- Ajusta modal de confirmação de exclusão de período;
- Ajusta mensagem de erro de excluir período para o toast;
- Remove a informação de uuid dos modais de formulário e detalhes;
- Mostra id no modal de detalhes e edição de período;
- Ajusta botão de limpar filtro por referência;
- Atualiza layout para de acordo com figma;
- Realiza ajustes nos testes unitários;

História: [AB#140950](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/140950)
Tarefa: [AB#146149](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146149)