### PR TITLE
hotfix(147521): bloqueia botão Salvar no modal de ReceitaPrevistaPDDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.37.2",
+  "version": "9.37.3",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Paa/componentes/DetalhamentoAcoesPdde/ModalEdicaoReceitaPrevistaPdde.js
+++ b/src/componentes/escolas/Paa/componentes/DetalhamentoAcoesPdde/ModalEdicaoReceitaPrevistaPdde.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect } from "react";
+import React, { memo, useEffect, useMemo } from "react";
 import { Form, Row, Col, Flex, InputNumber, Spin } from "antd";
 import { ModalFormBodyText } from "../../../../Globais/ModalBootstrap";
 import { Icon } from "../../../../Globais/UI/Icon";
@@ -27,9 +27,12 @@ const ModalEdicaoReceitaPrevistaPDDE = ({ open, onClose, receitaPrevistaPDDE }) 
   const [form] = Form.useForm();
   const podeEditar = visoesService.getPermissoes(["custom_change_paa"]);
 
-  const isLoading = false;
   const { mutationPatch } = usePatchReceitaPrevistaPdde(onClose);
   const { mutationPost } = usePostReceitaPrevistaPdde(onClose);
+
+  const isLoading = useMemo(() => {
+    return mutationPatch.isPending || mutationPost.isPending
+  }, [mutationPatch, mutationPost]);
 
   Form.useWatch("saldo_capital", form);
   Form.useWatch("saldo_custeio", form);
@@ -113,9 +116,7 @@ const ModalEdicaoReceitaPrevistaPDDE = ({ open, onClose, receitaPrevistaPDDE }) 
       size="lg"
       bodyText={
         <Spin
-          spinning={
-            isLoading || mutationPatch.isPending
-          }
+          spinning={isLoading}
         >
           <Form
             form={form}
@@ -392,7 +393,7 @@ const ModalEdicaoReceitaPrevistaPDDE = ({ open, onClose, receitaPrevistaPDDE }) 
               <button 
                 type="submit" 
                 className={`btn ${podeEditar && (!receitaPrevistaPDDE || receitaPrevistaPDDE.aceita_livre_aplicacao || receitaPrevistaPDDE.aceita_capital || receitaPrevistaPDDE.aceita_custeio) ? "btn-success" : "btn-secondary"}`}
-                disabled={!podeEditar || (receitaPrevistaPDDE && !receitaPrevistaPDDE.aceita_livre_aplicacao && !receitaPrevistaPDDE.aceita_capital && !receitaPrevistaPDDE.aceita_custeio)}
+                disabled={isLoading || !podeEditar || (receitaPrevistaPDDE && !receitaPrevistaPDDE.aceita_livre_aplicacao && !receitaPrevistaPDDE.aceita_capital && !receitaPrevistaPDDE.aceita_custeio)}
               >
                 Salvar
               </button>

--- a/src/componentes/escolas/Paa/componentes/DetalhamentoAcoesPdde/__tests__/ModalEdicaoAcaoPdde.test.js
+++ b/src/componentes/escolas/Paa/componentes/DetalhamentoAcoesPdde/__tests__/ModalEdicaoAcaoPdde.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ModalEdicaoReceitaPrevistaPDDE from "../ModalEdicaoReceitaPrevistaPdde";
-import { usePatchReceitaPrevistaPdde } from '../hooks/usePatchReceitaPrevistaPdde';
-import { usePostReceitaPrevistaPdde } from '../hooks/usePostReceitaPrevistaPdde';
+import { usePatchReceitaPrevistaPdde } from "../hooks/usePatchReceitaPrevistaPdde";
+import { usePostReceitaPrevistaPdde } from "../hooks/usePostReceitaPrevistaPdde";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 jest.mock("../hooks/usePatchReceitaPrevistaPdde");
@@ -74,7 +74,7 @@ describe("ModalEdicaoAcaoPdde", () => {
     return render(
       <QueryClientProvider client={queryClient}>
         <ModalEdicaoReceitaPrevistaPDDE {...defaultProps} {...props} />
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
   };
 
@@ -82,7 +82,7 @@ describe("ModalEdicaoAcaoPdde", () => {
     it("renderiza o título com o nome do recurso", () => {
       renderComponent();
       expect(
-        screen.getByText(`Editar Recurso ${receitaPrevisaPdde.nome}`)
+        screen.getByText(`Editar Recurso ${receitaPrevisaPdde.nome}`),
       ).toBeInTheDocument();
     });
 
@@ -109,7 +109,7 @@ describe("ModalEdicaoAcaoPdde", () => {
     it("não exibe o modal quando open é false", () => {
       renderComponent({ open: false });
       expect(
-        screen.queryByText(`Editar Recurso ${receitaPrevisaPdde.nome}`)
+        screen.queryByText(`Editar Recurso ${receitaPrevisaPdde.nome}`),
       ).not.toBeInTheDocument();
     });
   });
@@ -211,22 +211,25 @@ describe("ModalEdicaoAcaoPdde", () => {
           uuid: receitaPrevisaPdde.receitas_previstas_pdde_valores.uuid,
           payload: {
             saldo_custeio: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_custeio
+              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_custeio,
             ),
             saldo_capital: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_capital
+              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_capital,
             ),
             saldo_livre: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_livre
+              receitaPrevisaPdde.receitas_previstas_pdde_valores.saldo_livre,
             ),
             previsao_valor_custeio: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.previsao_valor_custeio
+              receitaPrevisaPdde.receitas_previstas_pdde_valores
+                .previsao_valor_custeio,
             ),
             previsao_valor_capital: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.previsao_valor_capital
+              receitaPrevisaPdde.receitas_previstas_pdde_valores
+                .previsao_valor_capital,
             ),
             previsao_valor_livre: parseFloat(
-              receitaPrevisaPdde.receitas_previstas_pdde_valores.previsao_valor_livre
+              receitaPrevisaPdde.receitas_previstas_pdde_valores
+                .previsao_valor_livre,
             ),
           },
         });
@@ -294,6 +297,18 @@ describe("ModalEdicaoAcaoPdde", () => {
       });
 
       expect(mockMutatePatch).not.toHaveBeenCalled();
+    });
+
+    it("desabilita o botão Salvar enquanto está carregando (edição)", () => {
+      usePatchReceitaPrevistaPdde.mockReturnValue({
+        mutationPatch: { mutate: mockMutatePatch, isPending: true },
+      });
+
+      renderComponent();
+
+      const botaoSalvar = screen.getByText("Salvar");
+
+      expect(botaoSalvar).toBeDisabled();
     });
   });
 });


### PR DESCRIPTION
# O que este PR faz
- Evita múltiplos envios desabilitando botão Salvar durante loading no modal de ReceitaPrevistaPDDE

Referência Azure: [AB#147521](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/147521)