### PR TITLE
fix(147705): Corrige campo de número de documento em acertos

### DIFF
--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -280,9 +280,14 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
       
 
     useEffect(() => {
-        if (despesaContext.initialValues.tipo_transacao && verbo_http === "PUT") {
-            aux.exibeDocumentoTransacao(despesaContext.initialValues.tipo_transacao.id, setCssEscondeDocumentoTransacao, setLabelDocumentoTransacao, despesasTabelas);
-            aux.exibeDocumentoTransacaoImpostoUseEffect(despesaContext.initialValues.despesas_impostos, setLabelDocumentoTransacaoImposto, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas);
+        const tipoTransacaoIni = despesaContext.initialValues.tipo_transacao;
+        const tipoTransacaoId =
+            tipoTransacaoIni != null
+                ? (typeof tipoTransacaoIni === "object" ? tipoTransacaoIni.id : tipoTransacaoIni)
+                : null;
+        if (tipoTransacaoId != null && verbo_http === "PUT") {
+            aux.exibeDocumentoTransacao(tipoTransacaoId, setCssEscondeDocumentoTransacao, setLabelDocumentoTransacao, despesasTabelas);
+            aux.exibeDocumentoTransacaoImpostoUseEffect(despesaContext.initialValues.despesas_impostos || [], setLabelDocumentoTransacaoImposto, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas);
         }
         if (despesaContext.initialValues.data_transacao && verbo_http === "PUT") {
             if(aux.origemAnaliseLancamento(parametroLocation)){
@@ -309,7 +314,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
         if (verbo_http === "PUT") {
             setObjetoParaComparacao(despesaContext.initialValues)
         }
-    }, [despesaContext.initialValues]);
+    }, [despesaContext.initialValues, despesasTabelas]);
 
     useEffect(() => {
         const carregaTabelasDespesas = async () => {

--- a/src/componentes/escolas/Despesas/metodosAuxiliares.js
+++ b/src/componentes/escolas/Despesas/metodosAuxiliares.js
@@ -125,7 +125,7 @@ const get_nome_razao_social = async (cpf_cnpj, setFieldValue, nome_fornecedor=""
 const exibeDocumentoTransacao = (valor, setCssEscondeDocumentoTransacao, setLabelDocumentoTransacao, despesasTabelas) => {
     if (valor && despesasTabelas && despesasTabelas.tipos_transacao){
         let exibe_documento_transacao =  despesasTabelas.tipos_transacao.find(element => element.id === Number(valor));
-        if (exibe_documento_transacao.tem_documento){
+        if (exibe_documento_transacao && exibe_documento_transacao.tem_documento){
             setCssEscondeDocumentoTransacao("");
             setLabelDocumentoTransacao(exibe_documento_transacao.nome);
         }else {
@@ -139,7 +139,7 @@ const exibeDocumentoTransacao = (valor, setCssEscondeDocumentoTransacao, setLabe
 const exibeDocumentoTransacaoImposto = (valor, setLabelDocumentoTransacao, labelDocumentoTransacaoImposto, setCssEscondeDocumentoTransacaoImposto, cssEscondeDocumentoTransacaoImposto, despesasTabelas, index) => {
     if(valor && despesasTabelas && despesasTabelas.tipos_transacao){
         let exibe_documento_transacao =  despesasTabelas.tipos_transacao.find(element => element.id === Number(valor));
-        if (exibe_documento_transacao.tem_documento){
+        if (exibe_documento_transacao && exibe_documento_transacao.tem_documento){
             setCssEscondeDocumentoTransacaoImposto({
                 ...cssEscondeDocumentoTransacaoImposto,
                 [index]: ""
@@ -168,7 +168,7 @@ const exibeDocumentoTransacaoImpostoUseEffect = (despesas_impostos, setLabelDocu
     despesas_impostos.map((despesa_imposto, index_imposto) => {
         if(despesa_imposto.tipo_transacao && despesasTabelas && despesasTabelas.tipos_transacao){
             let exibe_documento_transacao =  despesasTabelas.tipos_transacao.find(element => element.id === Number(despesa_imposto.tipo_transacao));
-            if(exibe_documento_transacao.tem_documento){
+            if (exibe_documento_transacao && exibe_documento_transacao.tem_documento){
                 setCssEscondeDocumentoTransacaoImposto(prevState => ([...prevState, ""]))
                 setLabelDocumentoTransacao(prevState => ([...prevState, exibe_documento_transacao.nome]))
             }


### PR DESCRIPTION
Esse PR:

- Corrigi uma condição de corrida em que o campo do número do cheque ficava oculto porque a visibilidade era calculada antes de carregar tipos_transacao, passando a recalcular quando as tabelas de despesa terminam de carregar.

História: [AB#147705](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/147705)