### PR TITLE
feat(145740): Adiciona Etiqueta de Retificação

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/VisualizarPlanoOrcamentario.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/VisualizarPlanoOrcamentario.js
@@ -10,6 +10,7 @@ import { faEdit } from "@fortawesome/free-solid-svg-icons";
 import { formatMoneyBRL } from "../../../../../../../utils/money";
 import "./styles.scss";
 import { useGetPlanoOrcamentario } from "./hooks/useGetPlanoOrcamentario";
+import { TagRetificacao } from "../../../../componentes/TagRetificacao";
 
 const formatResumo = (
   valores,
@@ -113,6 +114,7 @@ const montarColunas = () => [
         }`}
       >
         {nome}
+        {linha?.historicos && <div><TagRetificacao /></div>}
       </span>
     ),
     width: 200,

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/__tests__/VisualizarPlanoOrcamentario.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/__tests__/VisualizarPlanoOrcamentario.test.js
@@ -13,22 +13,21 @@ jest.mock("../hooks/useGetPlanoOrcamentario", () => ({
   useGetPlanoOrcamentario: jest.fn(),
 }));
 
+let mockCapturedTabelaProps = [];
+
 jest.mock("../../components/RelatorioTabelaGrupo", () => ({
   __esModule: true,
-  RelatorioTabelaGrupo: ({ headerExtra }) => (
-    <div data-testid="relatorio-tabela-grupo">{headerExtra}</div>
-  ),
+  RelatorioTabelaGrupo: (props) => {
+    mockCapturedTabelaProps.push(props);
+    return <div data-testid="relatorio-tabela-grupo">{props.headerExtra}</div>;
+  },
 }));
 
 jest.mock(
   "../../components/RelatorioVisualizacao",
   () => ({
     __esModule: true,
-    RelatorioVisualizacao({
-      children,
-      headerActions,
-      onBack = () => {},
-    }) {
+    RelatorioVisualizacao({ children, headerActions, onBack = () => {} }) {
       return (
         <div>
           <div>{headerActions}</div>
@@ -42,32 +41,31 @@ jest.mock(
   })
 );
 
+jest.mock("../../../../../componentes/TagRetificacao", () => ({
+  TagRetificacao: () => <span data-testid="tag-retificacao" />,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: jest.fn().mockImplementation((query) => {
       const listeners = new Set();
-      const mql = {
+      return {
         matches: false,
         media: query,
         onchange: null,
-        addListener: jest.fn((callback) => {
-          listeners.add(callback);
-          callback({ matches: false });
+        addListener: jest.fn((cb) => {
+          listeners.add(cb);
+          cb({ matches: false });
         }),
-        removeListener: jest.fn((callback) => {
-          listeners.delete(callback);
+        removeListener: jest.fn((cb) => listeners.delete(cb)),
+        addEventListener: jest.fn((_, cb) => {
+          listeners.add(cb);
+          cb({ matches: false });
         }),
-        addEventListener: jest.fn((_, callback) => {
-          listeners.add(callback);
-          callback({ matches: false });
-        }),
-        removeEventListener: jest.fn((_, callback) => {
-          listeners.delete(callback);
-        }),
+        removeEventListener: jest.fn((_, cb) => listeners.delete(cb)),
         dispatchEvent: jest.fn(),
       };
-      return mql;
     }),
   });
 });
@@ -75,18 +73,18 @@ beforeAll(() => {
 describe("VisualizarPlanoOrcamentario", () => {
   const navigateMock = jest.fn();
 
+  const defaultSecoes = [
+    { key: "ptrf", titulo: "PTRF", linhas: [] },
+    { key: "pdde", titulo: "PDDE", linhas: [] },
+    { key: "outros_recursos", titulo: "Outros Recursos", linhas: [] },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCapturedTabelaProps = [];
     useNavigate.mockReturnValue(navigateMock);
-
     useGetPlanoOrcamentario.mockReturnValue({
-      data: {
-        secoes: [
-          { key: "ptrf", titulo: "PTRF", linhas: [] },
-          { key: "pdde", titulo: "PDDE", linhas: [] },
-          { key: "outros_recursos", titulo: "Outros Recursos", linhas: [] },
-        ],
-      },
+      data: { secoes: defaultSecoes },
       isLoading: false,
       isFetching: false,
       isError: false,
@@ -141,5 +139,365 @@ describe("VisualizarPlanoOrcamentario", () => {
       },
     });
   });
-});
 
+  it("redireciona para aba de relatórios ao clicar em Voltar", () => {
+    render(<VisualizarPlanoOrcamentario />);
+    fireEvent.click(screen.getByRole("button", { name: /voltar/i }));
+    expect(navigateMock).toHaveBeenCalledWith("/elaborar-novo-paa", {
+      state: {
+        activeTab: "relatorios",
+        expandedSections: {
+          planoAnual: true,
+          componentes: true,
+        },
+      },
+    });
+  });
+
+  it("não renderiza tabelas quando secoes está vazio", () => {
+    useGetPlanoOrcamentario.mockReturnValue({
+      data: { secoes: [] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+    render(<VisualizarPlanoOrcamentario />);
+    expect(screen.queryByTestId("relatorio-tabela-grupo")).not.toBeInTheDocument();
+  });
+
+  it("não renderiza tabelas quando data é undefined (isLoading=true)", () => {
+    useGetPlanoOrcamentario.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: false,
+      isError: false,
+    });
+    render(<VisualizarPlanoOrcamentario />);
+    expect(screen.queryByTestId("relatorio-tabela-grupo")).not.toBeInTheDocument();
+  });
+
+  it("isFetching=true cobre ramo carregando=true", () => {
+    useGetPlanoOrcamentario.mockReturnValue({
+      data: { secoes: defaultSecoes },
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    });
+    render(<VisualizarPlanoOrcamentario />);
+    expect(screen.getAllByTestId("relatorio-tabela-grupo").length).toBeGreaterThan(0);
+  });
+
+  it("renderiza seção sem ações (headerExtra null) para chave desconhecida", () => {
+    useGetPlanoOrcamentario.mockReturnValue({
+      data: { secoes: [{ key: "desconhecido", titulo: "Desconhecido", linhas: [] }] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+    render(<VisualizarPlanoOrcamentario />);
+    expect(mockCapturedTabelaProps[0].headerExtra).toBeNull();
+  });
+
+  describe("rowKey e rowClassName passados ao RelatorioTabelaGrupo", () => {
+    beforeEach(() => {
+      render(<VisualizarPlanoOrcamentario />);
+    });
+
+    it("rowKey retorna linha.key", () => {
+      const { rowKey } = mockCapturedTabelaProps[0];
+      expect(rowKey({ key: "abc-123" })).toBe("abc-123");
+      expect(rowKey({})).toBeUndefined();
+      expect(rowKey(null)).toBeUndefined();
+    });
+
+    it("rowClassName retorna classe de total para linha isTotal=true", () => {
+      const { rowClassName } = mockCapturedTabelaProps[0].tableProps;
+      expect(rowClassName({ isTotal: true })).toBe(
+        "relatorio-plano-orcamentario__table-total-row"
+      );
+    });
+
+    it("rowClassName retorna string vazia para linha normal", () => {
+      const { rowClassName } = mockCapturedTabelaProps[0].tableProps;
+      expect(rowClassName({ isTotal: false })).toBe("");
+      expect(rowClassName({})).toBe("");
+    });
+  });
+
+  describe("coluna Recursos (nome) — render", () => {
+    let col;
+
+    beforeEach(() => {
+      render(<VisualizarPlanoOrcamentario />);
+      col = mockCapturedTabelaProps[0].columns[0];
+    });
+
+    it("renderiza span sem classe total e sem TagRetificacao para linha normal", () => {
+      const { container } = render(
+        col.render("Nome Recurso", { isTotal: false, historicos: null })
+      );
+      const span = container.querySelector("span");
+      expect(span).toHaveClass("relatorio-plano-orcamentario__recurso");
+      expect(span).not.toHaveClass("relatorio-plano-orcamentario__recurso--total");
+      expect(container.querySelector("[data-testid='tag-retificacao']")).not.toBeInTheDocument();
+    });
+
+    it("renderiza span com classe total para linha isTotal=true", () => {
+      const { container } = render(col.render("Total", { isTotal: true }));
+      expect(container.querySelector("span")).toHaveClass(
+        "relatorio-plano-orcamentario__recurso--total"
+      );
+    });
+
+    it("renderiza TagRetificacao quando historicos é truthy", () => {
+      const { queryByTestId } = render(
+        col.render("Nome", { isTotal: false, historicos: [{ uuid: "1" }] })
+      );
+      expect(queryByTestId("tag-retificacao")).toBeInTheDocument();
+    });
+  });
+
+  describe("coluna receitas-despesas-legendas — render", () => {
+    let col;
+
+    beforeEach(() => {
+      render(<VisualizarPlanoOrcamentario />);
+      col = mockCapturedTabelaProps[0].columns[1];
+    });
+
+    it("retorna null para linha isTotal=true", () => {
+      expect(col.render(null, { isTotal: true })).toBeNull();
+    });
+
+    it("exibe todos os labels quando flags são undefined (padrão = exibir)", () => {
+      const { getByText } = render(col.render(null, {}));
+      expect(getByText("Custeio (R$)")).toBeInTheDocument();
+      expect(getByText("Capital (R$)")).toBeInTheDocument();
+      expect(getByText("Livre Aplicação (R$)")).toBeInTheDocument();
+    });
+
+    it("omite Custeio quando exibirCusteio=false", () => {
+      const { queryByText } = render(col.render(null, { exibirCusteio: false }));
+      expect(queryByText("Custeio (R$)")).not.toBeInTheDocument();
+      expect(queryByText("Capital (R$)")).toBeInTheDocument();
+    });
+
+    it("omite Capital quando exibirCapital=false", () => {
+      const { queryByText } = render(col.render(null, { exibirCapital: false }));
+      expect(queryByText("Capital (R$)")).not.toBeInTheDocument();
+      expect(queryByText("Custeio (R$)")).toBeInTheDocument();
+    });
+
+    it("omite Livre Aplicação quando exibirLivre=false", () => {
+      const { queryByText } = render(col.render(null, { exibirLivre: false }));
+      expect(queryByText("Livre Aplicação (R$)")).not.toBeInTheDocument();
+    });
+
+    it("retorna null quando todos os flags são false (sem labels)", () => {
+      const result = col.render(null, {
+        exibirCusteio: false,
+        exibirCapital: false,
+        exibirLivre: false,
+      });
+      expect(result).toBeNull();
+    });
+
+    it("trata linha null com segurança (exibe todos os labels)", () => {
+      const { getByText } = render(col.render(null, null));
+      expect(getByText("Custeio (R$)")).toBeInTheDocument();
+    });
+  });
+
+  describe("colunas Receitas / Despesas / Saldo — formatResumo e formatResumoTotal", () => {
+    let columns;
+    const valores = { custeio: 100, capital: 200, livre: 300, total: 600 };
+
+    beforeEach(() => {
+      render(<VisualizarPlanoOrcamentario />);
+      columns = mockCapturedTabelaProps[0].columns;
+    });
+
+    describe("coluna Receitas", () => {
+      it("usa formatResumoTotal para linha isTotal=true", () => {
+        const { container } = render(
+          columns[2].render({ total: 1000 }, { isTotal: true })
+        );
+        expect(
+          container.querySelector(".relatorio-plano-orcamentario__receitas--total")
+        ).toBeInTheDocument();
+      });
+
+      it("retorna null quando valores são null e isTotal=true", () => {
+        expect(columns[2].render(null, { isTotal: true })).toBeNull();
+      });
+
+      it("usa formatResumo com spans para linha normal", () => {
+        const { container } = render(
+          columns[2].render(valores, { isTotal: false, ocultarCusteioCapital: false })
+        );
+        expect(
+          container.querySelector(".relatorio-plano-orcamentario__receitas")
+        ).toBeInTheDocument();
+        expect(container.querySelectorAll("span").length).toBeGreaterThan(0);
+      });
+
+      it("retorna null quando receitas são null para linha normal", () => {
+        expect(
+          columns[2].render(null, { isTotal: false, ocultarCusteioCapital: false })
+        ).toBeNull();
+      });
+
+      it("exibe hífen para custeio e capital quando ocultarCusteioCapital=true", () => {
+        const { getAllByText } = render(
+          columns[2].render(valores, { isTotal: false, ocultarCusteioCapital: true })
+        );
+        expect(getAllByText("-").length).toBe(2);
+      });
+
+      it("omite custeio quando exibirCusteio=false", () => {
+        const jsx = columns[2].render(valores, {
+          isTotal: false,
+          ocultarCusteioCapital: false,
+          exibirCusteio: false,
+        });
+        const { container } = render(jsx);
+        expect(container.querySelectorAll("span").length).toBe(2);
+      });
+
+      it("retorna null quando todas as categorias são omitidas", () => {
+        const result = columns[2].render(valores, {
+          isTotal: false,
+          ocultarCusteioCapital: false,
+          exibirCusteio: false,
+          exibirCapital: false,
+          exibirLivre: false,
+        });
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("coluna Despesas", () => {
+      it("usa formatResumoTotal para linha isTotal=true", () => {
+        const { container } = render(
+          columns[3].render({ total: 500 }, { isTotal: true })
+        );
+        expect(
+          container.querySelector(".relatorio-plano-orcamentario__despesas--total")
+        ).toBeInTheDocument();
+      });
+
+      it("retorna null quando valores são null e isTotal=true", () => {
+        expect(columns[3].render(null, { isTotal: true })).toBeNull();
+      });
+
+      it("usa formatResumo com isDespesa=true para linha normal", () => {
+        const { container } = render(
+          columns[3].render(valores, { isTotal: false, ocultarCusteioCapital: false })
+        );
+        expect(
+          container.querySelector(".relatorio-plano-orcamentario__despesas")
+        ).toBeInTheDocument();
+      });
+
+      it("retorna null quando despesas são null para linha normal", () => {
+        expect(
+          columns[3].render(null, { isTotal: false, ocultarCusteioCapital: false })
+        ).toBeNull();
+      });
+
+      it("exibe hífen para livre quando isDespesa=true", () => {
+        const { getAllByText } = render(
+          columns[3].render(valores, { isTotal: false, ocultarCusteioCapital: false })
+        );
+        expect(getAllByText("-").length).toBeGreaterThanOrEqual(1);
+      });
+
+      it("omite capital quando exibirCapital=false", () => {
+        const jsx = columns[3].render(valores, {
+          isTotal: false,
+          ocultarCusteioCapital: false,
+          exibirCapital: false,
+        });
+        const { container } = render(jsx);
+        expect(container.querySelectorAll("span").length).toBe(2);
+      });
+    });
+
+    describe("coluna Saldo", () => {
+      it("usa formatResumoTotal para linha isTotal=true", () => {
+        const { container } = render(
+          columns[4].render({ total: 800 }, { isTotal: true })
+        );
+        expect(
+          container.querySelector(".relatorio-plano-orcamentario__saldos--total")
+        ).toBeInTheDocument();
+      });
+
+      it("retorna null quando valores são null e isTotal=true", () => {
+        expect(columns[4].render(null, { isTotal: true })).toBeNull();
+      });
+
+      it("usa formatResumo com wrapper strong para linha normal", () => {
+        const { container } = render(
+          columns[4].render(valores, { isTotal: false, ocultarCusteioCapital: false })
+        );
+        expect(container.querySelector("strong")).toBeInTheDocument();
+      });
+
+      it("retorna null quando saldos são null para linha normal", () => {
+        expect(
+          columns[4].render(null, { isTotal: false, ocultarCusteioCapital: false })
+        ).toBeNull();
+      });
+
+      it("omite custeio quando exibirCusteio=false (2 strong restantes)", () => {
+        const { container } = render(
+          columns[4].render(valores, {
+            isTotal: false,
+            exibirCusteio: false,
+            exibirLivre: true,
+          })
+        );
+        expect(container.querySelectorAll("strong").length).toBe(2);
+      });
+
+      it("omite capital quando exibirCapital=false (2 strong restantes)", () => {
+        const { container } = render(
+          columns[4].render(valores, {
+            isTotal: false,
+            exibirCapital: false,
+            exibirLivre: true,
+          })
+        );
+        expect(container.querySelectorAll("strong").length).toBe(2);
+      });
+
+      it("omite livre quando exibirLivre=false (2 strong restantes)", () => {
+        const { container } = render(
+          columns[4].render(valores, {
+            isTotal: false,
+            exibirLivre: false,
+          })
+        );
+        expect(container.querySelectorAll("strong").length).toBe(2);
+      });
+
+      it("retorna null quando todas as categorias são omitidas", () => {
+        const result = columns[4].render(valores, {
+          isTotal: false,
+          exibirCusteio: false,
+          exibirCapital: false,
+          exibirLivre: false,
+        });
+        expect(result).toBeNull();
+      });
+
+      it("exibe hífen para custeio e capital quando ocultarCusteioCapital=true", () => {
+        const { getAllByText } = render(
+          columns[4].render(valores, { isTotal: false, ocultarCusteioCapital: true })
+        );
+        expect(getAllByText("-").length).toBe(2);
+      });
+    });
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/index.js
@@ -6,7 +6,7 @@ import { PaaContext } from "../../componentes/PaaContext";
 export const ElaborarNovoPlano = () => {
   const paa_uuid_storage = localStorage.getItem('PAA');
 
-  const { data: paa, refetch } = useGetPaa(paa_uuid_storage);
+  const { data: paa, refetch, isFetching } = useGetPaa(paa_uuid_storage);
 
   const itemsBreadCrumb = useMemo(() => {
     return [
@@ -19,7 +19,7 @@ export const ElaborarNovoPlano = () => {
 
     return (
       // Provider para Paa, adiciona o (paa e refetch) de Paa Original
-      <PaaContext.Provider value={{ paa, refetch }}>
+      <PaaContext.Provider value={{ paa, refetch, isFetching }}>
         <PaaBase itemsBreadCrumb={itemsBreadCrumb} />
       </PaaContext.Provider>
     )

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/BotaoRetificarPaa.test.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/BotaoRetificarPaa.test.js
@@ -79,7 +79,7 @@ describe('BotaoRetificarPaa', () => {
         const paaEmRetificacao = { uuid: 'paa-uuid-123', status: 'EM_RETIFICACAO' };
         renderComponent(paaEmRetificacao);
 
-        fireEvent.click(screen.getByRole('button', { name: /retificar o paa/i }));
+        fireEvent.click(screen.getByRole('button', { name: /continuar retificação/i }));
 
         expect(mockNavigate).toHaveBeenCalledWith('/retificacao-paa/paa-uuid-123', {
             state: { origem: 'paa-vigente-e-anteriores' },

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/BotaoRetificarPaa/BotaoRetificarPaa.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/BotaoRetificarPaa/BotaoRetificarPaa.js
@@ -64,7 +64,7 @@ export const BotaoRetificarPaa = ({paa, statusDocumento}) => {
                     className="btn btn-outline-success"
                     onClick={handleAbrirModal}
                     style={{ fontWeight: 600, marginRight: '10px' }}>
-                    Retificar o PAA
+                    {paa.status === "EM_RETIFICACAO" ? 'Continuar Retificação' : 'Retificar o PAA'}
                 </button>
                 
                 <ModalRetificarPAA 

--- a/src/componentes/escolas/Paa/RetificacaoPaa/index.js
+++ b/src/componentes/escolas/Paa/RetificacaoPaa/index.js
@@ -9,7 +9,7 @@ import { PaaContext } from "../componentes/PaaContext";
 export const RetificacaoPaa = () => {
   const { uuid_paa } = useParams();
 
-  const { data: paa, refetch } = useGetPaaRetificacao(uuid_paa);
+  const { data: paa, refetch, isFetching } = useGetPaaRetificacao(uuid_paa);
 
   const itemsBreadCrumb = useMemo(() => {
     return [

--- a/src/componentes/escolas/Paa/componentes/ConteudoBase/index.js
+++ b/src/componentes/escolas/Paa/componentes/ConteudoBase/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import BreadcrumbComponent from "../../../../Globais/Breadcrumb";
 import TabSelector from "../../../../Globais/TabSelector";
 
@@ -18,6 +18,7 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
   const location = useLocation();
 
   const [activeTab, setActiveTab] = useState("prioridades");
+  const hasInitializedTab = useRef(false);
   const relatoriosInitialExpandedSections = location.state?.expandedSections;
   const fromPlanoAplicacao = Boolean(location.state?.fromPlanoAplicacao);
   const fromPlanoOrcamentario = Boolean(location.state?.fromPlanoOrcamentario);
@@ -83,14 +84,13 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
   }, [paa, navigate]);
 
   useEffect(() => {
-    const obterAbaInicial = () => {
-      const requestedTab = location.state?.activeTab;
-      return tabs.some((tab) => tab.id === requestedTab)
-        ? requestedTab
-        : tabs[0].id;
-    };
-    setActiveTab(obterAbaInicial());
-  }, [tabs]);
+    if (hasInitializedTab.current || tabs.length === 0) return;
+    hasInitializedTab.current = true;
+    const requestedTab = location.state?.activeTab;
+    setActiveTab(
+      tabs.some((tab) => tab.id === requestedTab) ? requestedTab : tabs[0].id,
+    );
+  }, [tabs, location.state?.activeTab]);
 
   useEffect(() => {
     const temPermissaoIniciar = Boolean(

--- a/src/componentes/escolas/Paa/componentes/DetalhamentoRecursosProprios/index.js
+++ b/src/componentes/escolas/Paa/componentes/DetalhamentoRecursosProprios/index.js
@@ -233,6 +233,7 @@ const DetalhamentoRecursosProprios = () => {
           style={{ width: "100%" }}
           value={rowData?.descricao}
           autoSize
+          maxLength={255}
           onChange={handleChange}
         />
       );

--- a/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/ModalConfirmarPararAtualizacaoSaldo.js
+++ b/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/ModalConfirmarPararAtualizacaoSaldo.js
@@ -50,6 +50,8 @@ const ModalConfirmaPararAtualizacaoSaldo = ({ open, onClose, check, paa, onSubmi
                 disabled: mutationPostAtivar.isPending ||
                           mutationPostDesativar.isPending
               }}
+            maskClosable={false}
+            keyboard={false}
             wrapClassName={'modal-ant-design'}
         >
           <Spin spinning={mutationPostAtivar.isPending || mutationPostDesativar.isPending }>

--- a/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/ReceitasPrevistasPTRF.js
+++ b/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/ReceitasPrevistasPTRF.js
@@ -14,7 +14,7 @@ import { usePaaContext } from "../PaaContext";
 const ReceitasPrevistasPTRF = () => {
   const queryClient = useQueryClient();
 
-  const { paa } = usePaaContext();
+  const { paa, refetch: refetchPaa, isFetching: isFetchingPaa } = usePaaContext();
 
   const [checkPararAtualizacaoSaldo, setValorCheckPararAtualizacaoSaldo] =
     useState(!!paa?.saldo_congelado_em);
@@ -62,8 +62,10 @@ const ReceitasPrevistasPTRF = () => {
   };
 
   const onSubmitParadaSaldo = async () => {
-    await recarregarAcoesAssociacoes();
-    await carregaPaa();
+    await Promise.all([
+      refetchReceitasPrevistas(),
+      refetchPaa(),
+    ]);
     setShowModalConfirmaPararAtualizacaoSaldo(false);
   };
 
@@ -94,7 +96,8 @@ const ReceitasPrevistasPTRF = () => {
                   disabled={
                     !visoesService.getPermissoes(["custom_change_paa"]) ||
                     isLoadingReceitasPrevistas ||
-                    isFetchingReceitasPrevistas
+                    isFetchingReceitasPrevistas ||
+                    isFetchingPaa
                   }
                 >
                   Parar atualizações do saldo
@@ -122,7 +125,12 @@ const ReceitasPrevistasPTRF = () => {
           onSubmitParadaSaldo={onSubmitParadaSaldo}
         />
         <Spin
-          spinning={isLoadingReceitasPrevistas || isFetchingReceitasPrevistas}
+          spinning={
+            isLoadingReceitasPrevistas ||
+            isFetchingReceitasPrevistas ||
+            isFetchingPaa ||
+            showModalConfirmaPararAtualizacaoSaldo
+          }
         >
           <TabelaReceitasPrevistas
             data={dataReceitasPrevistas}

--- a/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/hooks/usePararAtualizacaoSaldoPaa.js
+++ b/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/hooks/usePararAtualizacaoSaldoPaa.js
@@ -29,7 +29,9 @@ export const useDesativarSaldoPAA = (onSuccess, onError) => {
       onSuccess && onSuccess(data);
     },
     onError: (e) => {
-      toastCustom.ToastCustomError("Houve um erro ao desativar o saldo.");
+      toastCustom.ToastCustomError(
+      e?.response?.data?.mensagem ||  "Houve um erro ao desativar o saldo."
+      );
       onError && onError(e);
       console.error(e)
     },

--- a/src/componentes/escolas/Paa/componentes/TagRetificacao/__tests__/TagRetificacao.test.js
+++ b/src/componentes/escolas/Paa/componentes/TagRetificacao/__tests__/TagRetificacao.test.js
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { TagRetificacao } from "../index";
+
+jest.mock("antd", () => ({
+  Tag: ({ style, children }) => (
+    <span data-testid="tag-retificacao" style={style}>
+      {children}
+    </span>
+  ),
+}));
+
+describe("TagRetificacao", () => {
+  it("renderiza o texto 'Em retificação'", () => {
+    render(<TagRetificacao />);
+    expect(screen.getByText("Em retificação")).toBeInTheDocument();
+  });
+
+  it("aplica backgroundColor white", () => {
+    render(<TagRetificacao />);
+    const tag = screen.getByTestId("tag-retificacao");
+    expect(tag).toHaveStyle({ backgroundColor: "white" });
+  });
+
+  it("aplica color #01585E", () => {
+    render(<TagRetificacao />);
+    const tag = screen.getByTestId("tag-retificacao");
+    expect(tag).toHaveStyle({ color: "#01585E" });
+  });
+
+  it("aplica border 2px solid #01585E", () => {
+    render(<TagRetificacao />);
+    const tag = screen.getByTestId("tag-retificacao");
+    expect(tag).toHaveStyle({ border: "2px solid #01585E" });
+  });
+});

--- a/src/componentes/escolas/Paa/componentes/TagRetificacao/index.js
+++ b/src/componentes/escolas/Paa/componentes/TagRetificacao/index.js
@@ -1,0 +1,12 @@
+import { Tag } from "antd";
+
+export const TagRetificacao = () => {
+    const styleTag = {
+        backgroundColor: 'white',
+        color: '#01585E',
+        border: '2px solid #01585E'
+    }
+    return (
+        <Tag style={styleTag}>Em retificação</Tag>
+    )
+}

--- a/src/paginas/Login/LoginForm.js
+++ b/src/paginas/Login/LoginForm.js
@@ -88,11 +88,11 @@ export const LoginForm = ({redefinicaoDeSenha}) => {
                             <form onSubmit={props.handleSubmit}>
                                 <div className="form-group">
                                     <TooltipWrapper id="login" content={"Digite, sem ponto nem traço, </br>os 7 dígitos do RF para servidor,<br/> ou o CPF para usuário não servidor"}>
-                                        <label htmlFor="login">Usuário</label>
-                                        <FontAwesomeIcon
-                                            style={{fontSize: '18px', marginLeft: "3px", color:'#42474A'}}
-                                            icon={faQuestionCircle}
-                                        />
+                                        <label htmlFor="login">
+                                            Usuário <FontAwesomeIcon
+                                                        style={{fontSize: '18px', marginLeft: "3px", color:'#42474A'}}
+                                                        icon={faQuestionCircle}/>
+                                        </label>
                                     </TooltipWrapper>
                                     <input
                                         type="text"

--- a/src/paginas/LoginSuporte/form.js
+++ b/src/paginas/LoginSuporte/form.js
@@ -85,16 +85,18 @@ export const LoginSuporteForm = ({redefinicaoDeSenha}) => {
                         {props => (
                             <form onSubmit={props.handleSubmit}>
                                 <div className="form-group">
-                                    <label htmlFor="login">Usuário</label>
-                                    <span
-                                        data-tooltip-id="username-help"
-                                        data-tooltip-html='Digite, sem ponto nem traço, </br>os 7 dígitos do RF para servidor,<br/> ou o CPF para usuário não servidor'>
-                                        <FontAwesomeIcon
-                                            style={{fontSize: '18px', marginLeft: "3px", color:'#42474A'}}
-                                            icon={faQuestionCircle}
-                                        />
-                                    </span>
-                                    <ReactTooltip id="username-help" />
+                                    <label htmlFor="login">
+                                        Usuário
+                                        <span
+                                            data-tooltip-id="username-help"
+                                            data-tooltip-html='Digite, sem ponto nem traço, </br>os 7 dígitos do RF para servidor,<br/> ou o CPF para usuário não servidor'>
+                                            <FontAwesomeIcon
+                                                style={{fontSize: '18px', marginLeft: "3px", color:'#42474A'}}
+                                                icon={faQuestionCircle}
+                                            />
+                                        </span>
+                                        <ReactTooltip id="username-help" />
+                                    </label>
                                     <input
                                         data-testid="usuario-input"
                                         type="text"


### PR DESCRIPTION

Esse PR:

- Adiciona componente de Etique (Em retificação)
- Adiciona Etiqueta de Retificação no Plano Orçamentário (PAA-> Relatórios -> Componentes -> Plano Orçamentário)
- Atualiza label de Botão 'Retificar o PAA' para 'Continuar retificação' quando o PAA está em retificação

- Ajustes adicionais:
  - adiciona isFetching ao Context de PAA
  - Limita quantidade de caracteres(255) na descrição de Fonte de Recursos em Receitas de Recurso Próprio para evitar conflito com backend
  - adiciona ao toast de Error(do hook Parar Atualizações do Saldo) o response.mensagem para obtenção de mensagem do backend
  - Ajusta quebra de linha no ícone da label Usuário na tela de login (Login SME e Login Suporte)
  

História [AB#145740](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145740)
