### PR TITLE
feat: :lipstick: Cria Card para Motivos de Reprovação de PC

### DIFF
--- a/src/componentes/sme/PainelParametrizacoes/index.js
+++ b/src/componentes/sme/PainelParametrizacoes/index.js
@@ -167,6 +167,12 @@ export const PainelParametrizacoes = () => {
             icone: IconeMotivosAprovacaoPcRessalva,
             permissoes: ['access_painel_parametrizacoes', 'change_painel_parametrizacoes'],
         },
+        {
+            parametro: 'Motivos de reprovação de PC',
+            url: 'parametro-motivos-reprovacao-pc',
+            icone: IconeMotivosAprovacaoPcRessalva,
+            permissoes: ['access_painel_parametrizacoes', 'change_painel_parametrizacoes'],
+        },
     ];
 
     const itensParametrizacaoPrestacaoContas = [

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/index.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export const ParametrizacoesMotivosReprovacaoPc = () => {
+    return (
+        <div>
+            <h1>Motivos de reprovação de PC</h1>
+            {/* Conteúdo da página */}
+        </div>
+    );
+}

--- a/src/rotas/index.js
+++ b/src/rotas/index.js
@@ -134,6 +134,7 @@ import { VisualizarAtividadesPrevistas } from "../componentes/escolas/Paa/Elabor
 import { EscolherRecursoPage } from "../paginas/SelecaoRecurso/EscolherRecursoPage";
 import { useRecursoSelecionadoContext } from "../context/RecursoSelecionado";
 import { FEATURE_FLAGS } from "../constantes/featureFlags";
+import { ParametrizacoesMotivosReprovacaoPc } from "../componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc";
 
 const routesConfig = [
   {
@@ -751,6 +752,12 @@ const routesConfig = [
     exact: true,
     path: "/parametro-motivos-pc-aprovada-ressalva",
     component: ParametrizacoesMotivosAprovacaoPcRessalva,
+    permissoes: ["access_painel_parametrizacoes", "change_painel_parametrizacoes"],
+  },
+    {
+    exact: true,
+    path: "/parametro-motivos-reprovacao-pc",
+    component: ParametrizacoesMotivosReprovacaoPc,
     permissoes: ["access_painel_parametrizacoes", "change_painel_parametrizacoes"],
   },
   {


### PR DESCRIPTION
Esse PR:

- Cria em Parâmetros SME Card para Motivos de Reprovação de PC

História: [AB#146628](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146628) e Tarefa: [AB#148554](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148554)