### PR TITLE
feat(146627): Parametrizações: Motivos de aprovação de PC com ressalvas por recurso.

### DIFF
--- a/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
+++ b/src/componentes/dres/PrestacaoDeContas/DetalhePrestacaoDeContas/index.js
@@ -35,11 +35,14 @@ import {ModalAlterarSEI} from "../../../Globais/ModalAntDesign/modalAlterarSEI"
 import {ModalNaoPodeVoltarParaAnalise} from "../ModalNaoPodeVoltarParaAnalise";
 import { getPeriodoPorUuid } from "../../../../services/sme/Parametrizacoes.service";
 import IconeAvisoVermelho from "../../../../assets/img/icone-modal-aviso-vermelho.svg"
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
 
 require("ordinal-pt-br");
 
 export const DetalhePrestacaoDeContas = () =>{
     let {prestacao_conta_uuid} = useParams();
+
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
 
     const { hash } = useLocation();
 
@@ -181,19 +184,19 @@ export const DetalhePrestacaoDeContas = () =>{
 
     useEffect(() => {
         const carregaMotivosAprovadoComRessalva = async () => {
-            const resp = await getMotivosAprovadoComRessalva();
+            const resp = await getMotivosAprovadoComRessalva(recursoSelecionado?.uuid);
             setMotivosAprovadoComRessalva(resp);
         };
         carregaMotivosAprovadoComRessalva();
-    }, []);
+    }, [recursoSelecionado]);
 
     useEffect(() => {
         const carregaMotivosReprovacao = async () => {
-            const resp = await getMotivosReprovacao();
+            const resp = await getMotivosReprovacao(recursoSelecionado?.uuid);
             setMotivosReprovacao(resp);
         };
         carregaMotivosReprovacao();
-    }, []);
+    }, [recursoSelecionado]);
 
     useEffect(() => {
         const retornaPeriodo = async () => {

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/YupSchemaMotivosAprovacaoPcRessalva.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/YupSchemaMotivosAprovacaoPcRessalva.js
@@ -2,4 +2,5 @@ import * as yup from "yup";
 
 export const YupSchemaMotivosAprovacaoPcRessalva  = yup.object().shape({
     motivo: yup.string().required("Motivo é obrigatório."),
+    recurso: yup.string().required("Recurso é obrigatório.")
 });

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Filtros.test.js
@@ -2,13 +2,23 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Filtros } from '../components/Filtros';
 import { MotivosAprovacaoPcRessalvaContext } from '../context/MotivosAprovacaoPcRessalva';
+import { useAbasPorRecursoContext } from '../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext';
 import '@testing-library/jest-dom';
+
+jest.mock('../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext', () => ({
+  useAbasPorRecursoContext: jest.fn(),
+}));
 
 describe('Filtros', () => {
   const mockSetFilter = jest.fn();
   const mockSetCurrentPage = jest.fn();
   const mockSetFirstPage = jest.fn();
   const initialFilter = { motivo: '' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAbasPorRecursoContext.mockReturnValue({ selectedRecurso: { uuid: "123", nome: "Recurso Test" } });
+  });
 
   const renderComponent = () => {
     return render(
@@ -25,36 +35,32 @@ describe('Filtros', () => {
     );
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   test('Deve renderizar os elementos corretamente', () => {
     renderComponent();
 
     expect(screen.getByLabelText('Filtrar por motivo de aprovação de PC com ressalvas')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Busque por motivo')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Limpar' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filtrar' })).toBeInTheDocument();
   });
 
   test('Deve atualizar o estado do filtro quando o input muda', () => {
     renderComponent();
-    const input = screen.getByPlaceholderText('Busque por motivo');
+    const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
     expect(input.value).toBe('Teste');
   });
 
   test('Deve chamar setFilter, setCurrentPage e setFirstPage com os valores corretos quando o botão "Filtrar" é clicado', () => {
     renderComponent();
-    const input = screen.getByPlaceholderText('Busque por motivo');
+    const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
 
     const filtrarButton = screen.getByRole('button', { name: 'Filtrar' });
     fireEvent.click(filtrarButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: 'Teste' });
+    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: 'Teste', recurso: '123' });
     expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
     expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
     expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
@@ -63,14 +69,14 @@ describe('Filtros', () => {
 
   test('Deve chamar setFilter, setCurrentPage e setFirstPage com o valor inicial quando o botão "Limpar" é clicado', () => {
     renderComponent();
-    const input = screen.getByPlaceholderText('Busque por motivo');
+    const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
 
     const limparButton = screen.getByRole('button', { name: 'Limpar' });
     fireEvent.click(limparButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith(initialFilter);
+    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: '', recurso: '123' });
     expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
     expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
     expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
@@ -81,7 +87,7 @@ describe('Filtros', () => {
   test("Verifica se as classes estão corretas", () => {
         renderComponent()
         const divPrincipal = screen.getByRole('button', { name: 'Filtrar' }).parentElement.parentElement
-        const input = screen.getByPlaceholderText('Busque por motivo')
+        const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas')
         const form = input.parentElement
 
         expect(divPrincipal).toHaveClass('d-flex')

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Lista.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Lista.test.js
@@ -48,8 +48,12 @@ const contexto = {
   setBloquearBtnSalvarForm: jest.fn(),
   handleEditFormModal: jest.fn(),
   handleExcluirMotivo: jest.fn(),
+  showModalConfirmacaoExclusao: { open: false, uuid: '' },
+  setShowModalConfirmacaoExclusao: jest.fn(),
+  stateFormModal: {},
+  showModalForm: false,
 }
-const itemMock = { id: 1, motivo: "Motivo 1", uuid: "123" }
+const itemMock = { id: 1, motivo: "Motivo 1", uuid: "123", recurso: "" }
 
 describe("Lista", () => {
   beforeEach(() => {

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/ModalForm.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/ModalForm.test.js
@@ -4,11 +4,21 @@ import { ModalForm } from "../components/ModalForm";
 import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
 import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
 import { useGetMotivosAprovacaoPcRessalva } from "../hooks/useGetMotivosAprovacaoPcRessalva";
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
 
 jest.mock("../hooks/useGetMotivosAprovacaoPcRessalva");
 
 jest.mock("../../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes", () => ({
   RetornaSeTemPermissaoEdicaoPainelParametrizacoes: jest.fn(),
+}));
+
+jest.mock("../../../../../../context/RecursoSelecionado", () => ({
+  useRecursoSelecionadoContext: jest.fn(),
+}));
+
+jest.mock("../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext", () => ({
+  useAbasPorRecursoContext: jest.fn(),
 }));
 
 const contexto = {
@@ -18,13 +28,16 @@ const contexto = {
   setBloquearBtnSalvarForm: jest.fn(),
   handleEditFormModal: jest.fn(),
   setShowModalConfirmacaoExclusao: jest.fn(),
+  showModalConfirmacaoExclusao: { open: false, uuid: '' },
+  stateFormModal: {},
 }
 
 const mockEdit = {
   motivo: "Nome do motivo",
   id: 1,
   uuid: "12345",
-  operacao: "edit"
+  operacao: "edit",
+  recurso: "abc"
 };
 
 const mockCreate = { 
@@ -32,12 +45,15 @@ const mockCreate = {
   id: null,
   uuid: null,
   operacao: "create",
+  recurso: "abc"
 };
 
 describe("Componente ModalForm", () => {
   beforeEach(() => {
     RetornaSeTemPermissaoEdicaoPainelParametrizacoes.mockReturnValue(true);
     useGetMotivosAprovacaoPcRessalva.mockReturnValue({ isLoading: false, data: [], count: 0 });
+    useRecursoSelecionadoContext.mockReturnValue({ recursos: [], isLoading: false });
+    useAbasPorRecursoContext.mockReturnValue({ selectedRecurso: { uuid: "12345", nome: "Recurso Test" } });
   });
 
   it("Renderiza a Modal quando a operação é Cadastro e Permissão True", () => {
@@ -65,7 +81,7 @@ describe("Componente ModalForm", () => {
 
     render(
       <MotivosAprovacaoPcRessalvaContext.Provider value={{
-        showModalForm: true,
+        ...contexto,
         stateFormModal: mockCreate
       }}>
         <ModalForm />
@@ -129,7 +145,7 @@ describe("Componente ModalForm", () => {
       </MotivosAprovacaoPcRessalvaContext.Provider>
     )
     const saveButton = screen.getByRole("button", { name: "Salvar" });
-    fireEvent.submit(saveButton);
+    fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(contexto.handleEditFormModal).toHaveBeenCalledTimes(1);
@@ -164,7 +180,10 @@ describe("Componente ModalForm", () => {
     const button = screen.getByRole('button', { name: /Excluir/i });
     fireEvent.click(button);
 
-    expect(contexto.setShowModalConfirmacaoExclusao).toHaveBeenCalledWith(true);
+    expect(contexto.setShowModalConfirmacaoExclusao).toHaveBeenCalledWith({
+      "open": true,
+      "uuid": "12345",
+    });
   });
 
   it("Lancar erro ao tentar salvar motivo vazio", async () => {

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/index.test.js
@@ -28,6 +28,10 @@ jest.mock("../components/ExibicaoQuantidade", () => ({
     ExibicaoQuantidade: () => <div data-testid="exibicao-quantidade">ExibicaoQuantidade</div>,
 }));
 
+jest.mock("../../../componentes/AbasPorRecurso", () => ({
+    AbasPorRecurso: () => <div data-testid="abas-por-recurso">AbasPorRecurso</div>,
+}));
+
 describe('ParametrizacoesMotivosAprovacaoPcRessalva', () => {
     const renderComponent = () => {
         return render(
@@ -48,9 +52,10 @@ describe('ParametrizacoesMotivosAprovacaoPcRessalva', () => {
         expect(screen.getByTestId('paginas-container')).toBeInTheDocument();
         expect(screen.getByTestId('topo-com-botoes')).toBeInTheDocument();
         expect(screen.getByTestId('filtros')).toBeInTheDocument();
+        expect(screen.getByTestId('abas-por-recurso')).toBeInTheDocument();
         expect(screen.getByTestId('lista')).toBeInTheDocument();
         expect(screen.getByTestId('paginacao')).toBeInTheDocument();
-        expect(screen.getByTestId('exibicao-quantidade')).toBeInTheDocument();
+        // expect(screen.getByTestId('exibicao-quantidade')).toBeInTheDocument();
         
     });
 

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Filtros.js
@@ -1,33 +1,53 @@
-import React, {useContext, useState} from "react";
+import React, {useContext, useState, useEffect} from "react";
 import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
 
 export const Filtros = () => {
 
     const {setFilter, initialFilter, setCurrentPage, setFirstPage} = useContext(MotivosAprovacaoPcRessalvaContext)
-    const [formFilter, setFormFilter] = useState(initialFilter);
+    const { selectedRecurso } = useAbasPorRecursoContext();
+    const [formFilter, setFormFilter] = useState({...initialFilter, recurso: selectedRecurso ? selectedRecurso.uuid : ''});
+
+    // Atualiza o formFilter quando o recurso selecionado muda
+    useEffect(() => {
+        setFormFilter(prevFilter => ({
+            ...prevFilter,
+            recurso: selectedRecurso ? selectedRecurso.uuid : ''
+        }));
+    }, [selectedRecurso]);
 
     const handleChangeFormFilter = (name, value) => {
         setFormFilter({
             ...formFilter,
-            [name]: value
+            [name]: value,
         });
     };
 
     const handleSubmitFormFilter = () => {
         setCurrentPage(1)
         setFirstPage(0)
-        setFilter(formFilter);
+        setFilter({
+            ...formFilter,
+            recurso: selectedRecurso ? selectedRecurso.uuid : ''
+        });
     };
 
     const clearFilter = () => {
         setCurrentPage(1)
         setFirstPage(0)
-        setFormFilter(initialFilter);
-        setFilter(initialFilter);
+        const resetFormFilter = {...initialFilter, recurso: selectedRecurso ? selectedRecurso.uuid : ''};
+        setFormFilter(resetFormFilter);
+        setFilter(resetFormFilter);
     };
     
     return (
         <>
+            <div className="mb-4">
+                <h4 className="font-weight-bold mb-0">Refine sua busca</h4>
+                <p>
+                    Utilize o filtro por referência para localizar motivos de aprovação com ressalvas específicos.
+                </p>
+            </div>
             <div className="d-flex bd-highlight align-items-end mt-2">
                 <div className="p-2 flex-grow-1 bd-highlight">
                     <form>
@@ -39,7 +59,7 @@ export const Filtros = () => {
                             id="motivo"
                             type="text"
                             className="form-control"
-                            placeholder='Busque por motivo'
+                            placeholder='Digite o motivo de aprovação de PC com ressalvas'
                         />
                     </form>
                 </div>

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Lista.js
@@ -11,14 +11,14 @@ import { usePostMotivoAprovacaoPcRessalva } from '../hooks/usePostMotivoAprovaca
 import { usePatchMotivoAprovacaoPcRessalva } from '../hooks/usePatchMotivoAprovacaoPcRessalva';
 import { useDeleteMotivoAprovacaoPcRessalva } from '../hooks/useDeleteMotivoAprovacaoPcRessalva';
 import { ModalForm } from "./ModalForm";
-import { ModalConfirmacaoExclusao } from "./ModalConfirmacaoExclusao";
 import {MsgImgCentralizada} from "../../../../../Globais/Mensagens/MsgImgCentralizada";
 import Img404 from "../../../../../../assets/img/img-404.svg";
 import { EditIconButton } from "../../../../../Globais/UI/Button";
+import { ModalConfirmarExclusao } from "../../../../../Globais/ModalAntDesign/ModalConfirmarExclusao";
 
 export const Lista = () => {
 
-  const { setShowModalForm, stateFormModal, setStateFormModal, setBloquearBtnSalvarForm } = useContext(MotivosAprovacaoPcRessalvaContext)
+  const { showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao, setShowModalForm, stateFormModal, setStateFormModal, setBloquearBtnSalvarForm } = useContext(MotivosAprovacaoPcRessalvaContext)
   const { isLoading, data } = useGetMotivosAprovacaoPcRessalva()
   const { mutationPost } = usePostMotivoAprovacaoPcRessalva()
   const { mutationPatch } = usePatchMotivoAprovacaoPcRessalva()
@@ -41,6 +41,7 @@ export const Lista = () => {
         motivo: rowData.motivo,
         uuid: rowData.uuid,
         id: rowData.id,
+        recurso: rowData.recurso ? rowData.recurso : '',
     });
     setShowModalForm(true)
   };
@@ -50,6 +51,7 @@ export const Lista = () => {
     setBloquearBtnSalvarForm(true)
     let payload = {
         motivo: values.motivo,
+        recurso: values.recurso,
     };
 
     if (!values.uuid) {
@@ -111,8 +113,17 @@ export const Lista = () => {
             />
         </section>
         <section>
-            <ModalConfirmacaoExclusao
-                handleExcluirMotivo={handleExcluirMotivo}
+            <ModalConfirmarExclusao
+                open={showModalConfirmacaoExclusao.open}
+                onOk={()=> {
+                    handleExcluirMotivo(showModalConfirmacaoExclusao.uuid)
+                    setShowModalConfirmacaoExclusao({open: false, uuid: ''})
+                }}
+                okText="Excluir"
+                onCancel={()=> setShowModalConfirmacaoExclusao({open: false, uuid: ''})}
+                cancelText="Cancelar"
+                titulo="Confirmação de exclusão"
+                bodyText="Deseja realmente excluir este motivo de aprovação de PC com ressalva?"
             />
         </section>
     </>

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/ModalForm.js
@@ -5,10 +5,15 @@ import { ModalFormBodyText } from "../../../../../Globais/ModalBootstrap";
 import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
 import { Tooltip as ReactTooltip } from "react-tooltip";
 import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes"
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
 
 export const ModalForm = ({handleSubmitFormModal}) => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const {showModalForm, setShowModalForm, stateFormModal, bloquearBtnSalvarForm, setShowModalConfirmacaoExclusao} = useContext(MotivosAprovacaoPcRessalvaContext)
+    const { recursos } = useRecursoSelecionadoContext();
 
     const bodyTextarea = () => {
         return (
@@ -31,6 +36,32 @@ export const ModalForm = ({handleSubmitFormModal}) => {
                                 <div className='row'>
                                     <div className='col-12'>
                                         <p className='text-right mb-0'><small> * Preenchimento obrigatório</small></p>
+
+                                        <div className='form-group'>
+                                            <label htmlFor="recurso">Recurso *</label>
+                                            <select
+                                                data-qa="input-recurso"
+                                                value={values.recurso || ""}
+                                                disabled
+                                                name="recurso"
+                                                id="recurso"
+                                                className="form-control"
+                                                required
+                                            >
+                                                <option data-qa="option-recurso-vazio" value=''>Selecione um recurso</option>
+                                                {recursos?.map((recurso) =>
+                                                    <option
+                                                        data-qa={`option-recurso-${recurso.uuid}`}
+                                                        key={recurso.uuid}
+                                                        value={recurso.uuid}
+                                                    >
+                                                        {recurso.nome}
+                                                    </option>
+                                                )}
+                                            </select>
+                                            {props.touched.recurso && props.errors.recurso && <span className="span_erro text-danger mt-1"> {props.errors.recurso} </span>}
+                                        </div>
+
                                         <div className="form-group">
                                             <span
                                                 data-tooltip-id="tooltip-id-motivo"
@@ -64,11 +95,12 @@ export const ModalForm = ({handleSubmitFormModal}) => {
                                     <div className="p-Y flex-grow-1 bd-highlight">
                                         {values.uuid &&
                                             <button
-                                                onClick={()=>setShowModalConfirmacaoExclusao(true)}
+                                                onClick={()=>setShowModalConfirmacaoExclusao({open: true, uuid: values.uuid})}
                                                 type="button"
                                                 className="btn btn btn-danger mt-2 mr-2"
                                                 disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                             >
+                                                <FontAwesomeIcon icon={faXmark} style={{ marginRight: "8px", color: "white", fontWeight: "bold" }} />
                                                 Excluir
                                             </button>
                                         }

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Paginacao.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Paginacao.js
@@ -20,7 +20,7 @@ export const Paginacao = () => {
             {!isLoading && totalMotivosAprovacaoPcRessalva ? (
                     <Paginator
                         first={firstPage}
-                        rows={20}
+                        rows={10}
                         totalRecords={count}
                         template="PrevPageLink PageLinks NextPageLink"
                         onPageChange={onPageChange}

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/TopoComBotoes.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/TopoComBotoes.js
@@ -1,20 +1,26 @@
 import React, {useContext} from "react";
 import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
 import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes"
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
 
 export const TopoComBotoes = () => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const {setShowModalForm, setStateFormModal, initialStateFormModal} = useContext(MotivosAprovacaoPcRessalvaContext)
+    const { selectedRecurso } = useAbasPorRecursoContext();
 
     return(
-        <div className="d-flex bd-highlight align-items-center">
-            <div className="p-2 flex-grow-1 bd-highlight">
-                {/* <h5 className="titulo-explicativo mb-0">Consulta dos motivos</h5> */}
+        <div className="d-flex justify-content-between align-items-end mb-3">
+            <div>
+                <h5 className="font-weight-bold">{selectedRecurso?.nome}</h5>
+                <p className="m-0">Confira abaixo os motivos de aprovação com ressalvas do {selectedRecurso?.nome_exibicao}.</p>
             </div>
             <div className="p-2 bd-highlight">
                 <button
                     onClick={()=>{
-                        setStateFormModal(initialStateFormModal);
+                        setStateFormModal({
+                            ...initialStateFormModal,
+                            recurso: selectedRecurso ? selectedRecurso.uuid : ''
+                        });
                         setShowModalForm(true);
                     }}
                     className="btn btn-success"

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/context/MotivosAprovacaoPcRessalva.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/context/MotivosAprovacaoPcRessalva.js
@@ -1,13 +1,16 @@
-import React, { createContext, useMemo, useState } from 'react';
+import React, { createContext, useMemo, useState, useEffect } from 'react';
+import { useAbasPorRecursoContext } from '../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext';
 
 const initialFilter = {
-    motivo:''
+    motivo: '',
+    recurso: '',
 };
 
 const initialStateFormModal = {
     id: '',
     uuid: '',
     motivo: '',
+    recurso: '',
 };
 
 export const MotivosAprovacaoPcRessalvaContext = createContext({
@@ -25,7 +28,7 @@ export const MotivosAprovacaoPcRessalvaContext = createContext({
     stateFormModal: initialStateFormModal,
     setStateFormModal: () => {},
 
-    showModalConfirmacaoExclusao: false,
+    showModalConfirmacaoExclusao: { open: false, uuid: '' },
     setShowModalConfirmacaoExclusao: () => {},
 
     bloquearBtnSalvarForm: '',
@@ -33,6 +36,8 @@ export const MotivosAprovacaoPcRessalvaContext = createContext({
 })
 
 export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
+
+    const { selectedRecurso } = useAbasPorRecursoContext();
 
     const [filter, setFilter] = useState(initialFilter);
 
@@ -42,9 +47,20 @@ export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
     const [showModalForm, setShowModalForm] = useState(false);
     const [stateFormModal, setStateFormModal] = useState(initialStateFormModal);
 
-    const [showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao] = useState(false);
+    const [showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao] = useState({ open: false, uuid: '' });
 
     const [bloquearBtnSalvarForm, setBloquearBtnSalvarForm] = useState(false);
+
+    // Monitora mudanças no recurso selecionado e atualiza o filtro
+    useEffect(() => {
+        setFilter(prevFilter => ({
+            ...prevFilter,
+            recurso: selectedRecurso ? selectedRecurso.uuid : ''
+        }));
+        // Reseta para a primeira página quando muda de aba
+        setCurrentPage(1);
+        setFirstPage(0);
+    }, [selectedRecurso]);
 
     const contextValue = useMemo(() => {
         return {

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/index.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/index.js
@@ -7,6 +7,7 @@ import { Lista } from "./components/Lista";
 import { Paginacao } from "./components/Paginacao";
 import { Filtros } from "./components/Filtros";
 import { ExibicaoQuantidade } from "./components/ExibicaoQuantidade";
+import { AbasPorRecurso } from "../../componentes/AbasPorRecurso";
 
 
 
@@ -16,9 +17,10 @@ export const ParametrizacoesMotivosAprovacaoPcRessalva = () => {
             <PaginasContainer>
                 <h1 className="titulo-itens-painel mt-5">Motivos de aprovação de PC com ressalvas</h1>
                 <div className="page-content-inner">
-                    <TopoComBotoes/>
                     <Filtros/>
-                    <ExibicaoQuantidade/>
+                    <AbasPorRecurso />
+                    <TopoComBotoes/>
+                    {/* <ExibicaoQuantidade/> */}
                     <Lista/>
                     <Paginacao/>
                 </div>

--- a/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/ModalFormPeriodos.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/Periodos/ModalFormPeriodos.js
@@ -7,6 +7,9 @@ import {YupSignupSchemaPeriodos} from "./YupSignupSchemaPeriodos";
 import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
 import { useRecursoSelecionadoContext } from "../../../../../context/RecursoSelecionado";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+
 const ModalFormPeriodos = ({
     show, 
     stateFormModal, 
@@ -225,6 +228,7 @@ const ModalFormPeriodos = ({
                                             className="btn btn btn-danger mt-2 mr-2"
                                             disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                         >
+                                            <FontAwesomeIcon icon={faXmark} style={{ marginRight: "8px", color: "white", fontWeight: "bold" }} />
                                             Excluir
                                         </button>
                                     ): null}

--- a/src/services/dres/PrestacaoDeContas.service.js
+++ b/src/services/dres/PrestacaoDeContas.service.js
@@ -134,12 +134,20 @@ export const postNotificarPendenciaGeracaoAtaRetificacao = async (prestacao_cont
     return (await api.post(`/api/prestacoes-contas/${prestacao_conta_uuid}/notificar/pendencia_geracao_ata_retificacao/`, null, authHeader())).data
 };
 
-export const getMotivosAprovadoComRessalva = async () => {
-    return (await api.get(`/api/motivos-aprovacao-ressalva/`, authHeader())).data
+export const getMotivosAprovadoComRessalva = async (recurso_uuid = "") => {
+    let url = `/api/motivos-aprovacao-ressalva/`;
+    if (recurso_uuid) {
+        url += `?recurso_uuid=${recurso_uuid}`;
+    }
+    return (await api.get(url, authHeader())).data
 };
 
-export const getMotivosReprovacao = async () => {
-    return (await api.get(`/api/motivos-reprovacao/`, authHeader())).data
+export const getMotivosReprovacao = async (recurso_uuid = "") => {
+    let url = `/api/motivos-reprovacao/`;
+    if (recurso_uuid) {
+        url += `?recurso_uuid=${recurso_uuid}`;
+    }
+    return (await api.get(url, authHeader())).data
 };
 
 export const getVisualizarArquivoDeReferencia = async (nome_do_arquivo, uuid, tipo) => {

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -1206,14 +1206,19 @@ export const deleteMotivoDevolucaoTesouro = async (
 
 // Motivos de Aprovação de PC com ressalva
 export const getMotivosAprovacaoPcRessalva = async (filter, currentPage) => {
-  const { motivo } = filter;
+  const { motivo, recurso } = filter;
+  let url = `/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=${10}`;
+  if (recurso) {
+    url += `&recurso_uuid=${recurso}`;
+  }
   return (
     await api.get(
-      `/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=${20}`,
+      url,
       {
         ...authHeader(),
         params: {
           motivo: motivo,
+          recurso: recurso,
           page: currentPage,
         },
       }

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -1787,7 +1787,7 @@ describe('Testes para funções de análise', () => {
             motivo: filter.motivo,
             page: currentPage,
         };
-        expect(api.get).toHaveBeenCalledWith(`/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=20`, {
+        expect(api.get).toHaveBeenCalledWith(`/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=10`, {
             ...authHeader(),
             params: expectedParams,
         });


### PR DESCRIPTION
Este PR inclui:

- Passa parâmetro recurso_uuid em rotas GET de motivos de aprovação de PC com ressalvas e motivos de reprovação;
- Adiciona navegação por abas de recurso na página de Parametrizações: Motivos de aprovação de PC com ressalvas por recurso;
- Inclui recurso da aba selecionada em campo bloqueado no modal de criação/edição de motivo de aprovação de PC com ressalvas;
- Altera modal de exclusão de Motivo de aprovação de PC com ressalva para novo formato;
- Inclui ícone "X" (close) no botão de Excluir dos modais de edição de Motivos de aprovação de PC com ressalvas e Períodos;
- Altera páginação de motivos para 10 registros por página;
- Correção/validação de testes unitários.

História: [AB#146627](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146627)
Tarefa: [AB#148553](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148553)