### PR TITLE
feat(145936): Ajusta exibição de id nos modais.

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/ModalForm.js
@@ -85,10 +85,11 @@ export const ModalForm = ({handleSubmitFormModal}) => {
                                     </div>
                                 </div>
                                 <div className='row mt-3'>
-                                    <div className='col-6'>
-                                        <p className='mb-2'>ID</p>
-                                        <p id='id'>{values.id}</p>
-                                    </div>
+                                    { values.id && (
+                                        <div className='col-6'>
+                                            <p className='mb-2'>ID: {values.id}</p>
+                                        </div>
+                                    ) }
                                 </div>
 
                                 <div className="d-flex bd-highlight mt-2">

--- a/src/componentes/sme/Parametrizacoes/Estrutura/TiposConta/ModalAddEditTipoConta.js
+++ b/src/componentes/sme/Parametrizacoes/Estrutura/TiposConta/ModalAddEditTipoConta.js
@@ -191,8 +191,7 @@ const ModalAddEditTipoConta = ({show, stateFormModal, handleClose, handleSubmitM
                                     values.id && 
                                     <div className='row mt-3'>   
                                         <div className='col'>
-                                            <p className='mb-2'>ID</p>
-                                            <p className='mb-2'>{values.id}</p>
+                                            <p className='mb-2'>ID: {values.id}</p>
                                         </div>
                                     </div>
                                 }


### PR DESCRIPTION
Este PR inclui:

- Apenas exibe nome "ID" nos modais de edição;
- Padroniza exibição para "ID: {id}" removendo a quebra de linha entre os dados;

História: [AB#145936](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145936)
Tarefa: [AB#146154](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/146154)