### PR TITLE
feature(139810): cancelar retificacao paa

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostPrioridade.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Prioridades/hooks/usePostPrioridade.js
@@ -1,5 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postPrioridade, postDuplicarPrioridade } from "../../../../../../../services/escolas/Paa.service";
+import {
+  postPrioridade,
+  postDuplicarPrioridade,
+} from "../../../../../../../services/escolas/Paa.service";
 import { toastCustom } from "../../../../../../Globais/ToastCustom";
 
 export const usePostPrioridade = (onClose) => {
@@ -8,12 +11,16 @@ export const usePostPrioridade = (onClose) => {
     mutationFn: ({ payload }) => postPrioridade(payload),
     onSuccess: (data) => {
       toastCustom.ToastCustomSuccess("Prioridade criada com sucesso.");
-      queryClient.invalidateQueries({ queryKey: ["prioridades"], exact: false });
+      queryClient.invalidateQueries({
+        queryKey: ["prioridades"],
+        exact: false,
+      });
       queryClient.invalidateQueries({ queryKey: ["prioridades-resumo"] });
       onClose && onClose();
     },
     onError: (e) => {
-      const mensagemDeErro = e?.response?.data?.mensagem || "Houve um erro ao criar a prioridade.";
+      const mensagemDeErro =
+        e?.response?.data?.mensagem || "Houve um erro ao criar a prioridade.";
       toastCustom.ToastCustomError(mensagemDeErro);
     },
   });
@@ -27,10 +34,15 @@ export const usePostDuplicarPrioridade = () => {
     mutationFn: ({ uuid }) => postDuplicarPrioridade(uuid),
     onSuccess: () => {
       toastCustom.ToastCustomSuccess("Prioridade duplicada com sucesso.");
-      queryClient.invalidateQueries(["prioridades"]);
+      queryClient.invalidateQueries({
+        queryKey: ["prioridades"],
+        exact: false,
+      });
     },
     onError: (e) => {
-      toastCustom.ToastCustomError(e?.response?.data?.mensagem || "Houve um erro ao duplicar prioridade.");
+      toastCustom.ToastCustomError(
+        e?.response?.data?.mensagem || "Houve um erro ao duplicar prioridade.",
+      );
     },
   });
 

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/__tests__/CancelarRetificacao.test.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/__tests__/CancelarRetificacao.test.js
@@ -1,0 +1,265 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import CancelarRetificacao from "../index";
+import { visoesService } from "../../../../../../services/visoes.service";
+import { usePostCancelarRetificacaoPaa } from "../hooks/usePostCancelarRetificacao";
+
+const mockNavigate = jest.fn();
+const mockMutateAsync = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("../../../../../../services/visoes.service", () => ({
+  visoesService: {
+    featureFlagAtiva: jest.fn(),
+  },
+}));
+
+jest.mock("../hooks/usePostCancelarRetificacao", () => ({
+  usePostCancelarRetificacaoPaa: jest.fn(),
+}));
+
+const defaultProps = {
+  paa: {
+    uuid: "123-uuid",
+    status: "EM_RETIFICACAO",
+  },
+};
+
+const renderComponent = (props = defaultProps) =>
+  render(
+    <MemoryRouter>
+      <CancelarRetificacao {...props} />
+    </MemoryRouter>,
+  );
+
+describe("CancelarRetificacao", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    visoesService.featureFlagAtiva.mockReturnValue(true);
+
+    usePostCancelarRetificacaoPaa.mockReturnValue({
+      mutationPost: {
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      },
+    });
+  });
+
+  it("deve renderizar botão de cancelar retificação", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("não deve renderizar componente quando feature flag estiver desativada", () => {
+    visoesService.featureFlagAtiva.mockReturnValue(false);
+
+    renderComponent();
+
+    expect(
+      screen.queryByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("não deve renderizar componente quando status for diferente de EM_RETIFICACAO", () => {
+    renderComponent({
+      paa: {
+        uuid: "123",
+        status: "RASCUNHO",
+      },
+    });
+
+    expect(
+      screen.queryByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("deve abrir modal ao clicar em cancelar retificação", () => {
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    expect(screen.getByText(/ao cancelar, as alterações/i)).toBeInTheDocument();
+  });
+
+  it("deve fechar modal ao clicar em voltar", async () => {
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /voltar/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/ao cancelar, as alterações/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("deve chamar mutation ao confirmar cancelamento", async () => {
+    mockMutateAsync.mockResolvedValue({});
+
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    const modal = screen.getByRole("dialog");
+
+    fireEvent.click(
+      within(modal).getByRole("button", {
+        name: /^cancelar retificação$/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        paaUuid: "123-uuid",
+      });
+    });
+  });
+
+  it("deve navegar após sucesso da mutation", async () => {
+    mockMutateAsync.mockResolvedValue({});
+
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    const modal = screen.getByRole("dialog");
+
+    fireEvent.click(
+      within(modal).getByRole("button", {
+        name: /^cancelar retificação$/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/paa-vigente-e-anteriores");
+    });
+  });
+
+  it("deve desabilitar botões quando mutation estiver pending", () => {
+    usePostCancelarRetificacaoPaa.mockReturnValue({
+      mutationPost: {
+        mutateAsync: mockMutateAsync,
+        isPending: true,
+      },
+    });
+
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    const modal = screen.getByRole("dialog");
+
+    expect(
+      within(modal).getByRole("button", {
+        name: /voltar/i,
+      }),
+    ).toBeDisabled();
+
+    expect(
+      within(modal).getByRole("button", {
+        name: /cancelando/i,
+      }),
+    ).toBeDisabled();
+  });
+
+  it("não deve fechar modal ao clicar em voltar durante loading", () => {
+    usePostCancelarRetificacaoPaa.mockReturnValue({
+      mutationPost: {
+        mutateAsync: mockMutateAsync,
+        isPending: true,
+      },
+    });
+
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /voltar/i,
+      }),
+    );
+
+    expect(screen.getByText(/ao cancelar, as alterações/i)).toBeInTheDocument();
+  });
+
+  it("deve tratar erro da mutation sem quebrar componente", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockMutateAsync.mockRejectedValue(new Error("erro"));
+
+    renderComponent();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /cancelar retificação/i,
+      }),
+    );
+
+    const modal = screen.getByRole("dialog");
+
+    fireEvent.click(
+      within(modal).getByRole("button", {
+        name: /^cancelar retificação$/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/hooks/usePostCancelarRetificacao.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/hooks/usePostCancelarRetificacao.js
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+import { postCancelarRetificacaoPaa } from "../../../../../../services/escolas/Paa.service";
+import { toastCustom } from "../../../../../Globais/ToastCustom";
+import { getErrorMessage } from "../../../../../../utils/obtemMsgErroAxios";
+
+export const usePostCancelarRetificacaoPaa = () => {
+  const mutationPost = useMutation({
+    mutationFn: ({ paaUuid }) => {
+      return postCancelarRetificacaoPaa(paaUuid);
+    },
+    onSuccess: () => {
+      toastCustom.ToastCustomSuccess("Retificação cancelada com sucesso.");
+    },
+    onError: (err) => {
+      const mensagemErro = getErrorMessage(
+        err,
+        "Ocorreu um erro ao tentar cancelar a retificação.",
+      );
+      toastCustom.ToastCustomError(mensagemErro);
+    },
+  });
+  return { mutationPost };
+};

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
@@ -27,6 +27,7 @@ const CancelarRetificacao = ({ paa }) => {
       });
 
       navigate("/paa-vigente-e-anteriores");
+      setTimeout(() => window.location.reload(), 1500);
     } catch (err) {
       console.error(err);
     }

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
@@ -77,7 +77,7 @@ const CancelarRetificacao = ({ paa }) => {
           >
             {mutationPost.isPending ? (
               <>
-                <Spinner animation="border" size="sm" className="me-2" />
+                <Spinner animation="border" size="sm" className="me-2" /> &nbsp;
                 Cancelando...
               </>
             ) : (

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
@@ -1,0 +1,93 @@
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { Modal, Spinner } from "react-bootstrap";
+import { visoesService } from "../../../../../services/visoes.service";
+import { usePostCancelarRetificacaoPaa } from "./hooks/usePostCancelarRetificacao";
+
+const CancelarRetificacao = ({ paa }) => {
+  const flagRetificacao = visoesService.featureFlagAtiva("paa-retificacao");
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+
+  const { mutationPost } = usePostCancelarRetificacaoPaa();
+
+  const onClose = () => {
+    if (mutationPost.isPending) return;
+    setOpen(false);
+  };
+
+  const handleCancelarRetificacaoPaa = () => {
+    setOpen(true);
+  };
+
+  const submitCancelarRetificacao = async () => {
+    try {
+      await mutationPost.mutateAsync({
+        paaUuid: paa.uuid,
+      });
+
+      navigate("/paa-vigente-e-anteriores");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return flagRetificacao && paa?.status === "EM_RETIFICACAO" ? (
+    <>
+      <button
+        className="btn btn-success d-flex align-items-center"
+        onClick={handleCancelarRetificacaoPaa}
+        style={{ minWidth: "180px", justifyContent: "center" }}
+      >
+        Cancelar Retificação
+      </button>
+
+      <Modal
+        centered
+        show={open}
+        onHide={onClose}
+        size="md"
+        backdrop="static"
+        keyboard={false}
+      >
+        <Modal.Header>
+          <Modal.Title>Cancelar retificação</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            Ao cancelar, as alterações da retificação serão perdidas e não{" "}
+            <br />
+            poderão ser recuperadas. Deseja continuar?
+          </p>
+        </Modal.Body>
+        <Modal.Footer id="main">
+          <button
+            type="button"
+            className="btn btn-outline-success"
+            disabled={mutationPost.isPending}
+            onClick={onClose}
+          >
+            Voltar
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={mutationPost.isPending}
+            onClick={() => submitCancelarRetificacao()}
+          >
+            {mutationPost.isPending ? (
+              <>
+                <Spinner animation="border" size="sm" className="me-2" />
+                Cancelando...
+              </>
+            ) : (
+              "Cancelar retificação"
+            )}
+          </button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  ) : null;
+};
+
+export default CancelarRetificacao;

--- a/src/componentes/escolas/Paa/componentes/ConteudoBase/__tests__/ConteudoBase.test.js
+++ b/src/componentes/escolas/Paa/componentes/ConteudoBase/__tests__/ConteudoBase.test.js
@@ -9,6 +9,10 @@ jest.mock("../../../../../../services/escolas/AtasPaa.service", () => ({
   iniciarAtaPaa: jest.fn(),
 }));
 
+jest.mock("../../CancelarRetificacao", () => () => (
+  <div data-testid="cancelar-retificacao-mock" />
+));
+
 jest.mock("../../../../../../services/visoes.service", () => ({
   visoesService: {
     getPermissoes: jest.fn(),
@@ -28,7 +32,9 @@ jest.mock("../../../../../Globais/Breadcrumb", () => ({
   __esModule: true,
   default: ({ items }) => (
     <nav aria-label="breadcrumb" data-testid="breadcrumb">
-      {items?.map((item, i) => <span key={i}>{item.label}</span>)}
+      {items?.map((item, i) => (
+        <span key={i}>{item.label}</span>
+      ))}
     </nav>
   ),
 }));
@@ -46,15 +52,25 @@ jest.mock("../../../../../Globais/TabSelector", () => ({
   ),
 }));
 
-jest.mock("../../../ElaboracaoPaa/ElaborarNovoPlano/LevantamentoDePrioridades", () => ({
-  __esModule: true,
-  default: () => <div data-testid="levantamento-prioridades">LevantamentoDePrioridades</div>,
-}));
+jest.mock(
+  "../../../ElaboracaoPaa/ElaborarNovoPlano/LevantamentoDePrioridades",
+  () => ({
+    __esModule: true,
+    default: () => (
+      <div data-testid="levantamento-prioridades">
+        LevantamentoDePrioridades
+      </div>
+    ),
+  }),
+);
 
 jest.mock("../../ReceitasPrevistas", () => ({
   __esModule: true,
   default: ({ receitasDestino }) => (
-    <div data-testid="receitas-previstas" data-receitas-destino={receitasDestino}>
+    <div
+      data-testid="receitas-previstas"
+      data-receitas-destino={receitasDestino}
+    >
       ReceitasPrevistas
     </div>
   ),
@@ -80,7 +96,11 @@ jest.mock("../../../ElaboracaoPaa/ElaborarNovoPlano/Relatorios", () => ({
 jest.mock("../../BarraTopoTitulo", () => ({
   __esModule: true,
   default: ({ origem, paa }) => (
-    <div data-testid="barra-topo" data-origem={origem || ""} data-paa-status={paa?.status || ""}>
+    <div
+      data-testid="barra-topo"
+      data-origem={origem || ""}
+      data-paa-status={paa?.status || ""}
+    >
       BarraTopo
     </div>
   ),
@@ -94,7 +114,11 @@ const defaultPaa = {
   associacao: "assoc-uuid-123",
 };
 
-const renderConteudoBase = (paaOverride = {}, locationOverride = {}, itemsBreadCrumb = []) => {
+const renderConteudoBase = (
+  paaOverride = {},
+  locationOverride = {},
+  itemsBreadCrumb = [],
+) => {
   const paa = { ...defaultPaa, ...paaOverride };
   mockUseLocation.mockReturnValue({ ...defaultLocation, ...locationOverride });
 
@@ -149,7 +173,9 @@ describe("ConteudoBase", () => {
     it("renderiza as abas: Levantamento de Prioridades, Receitas previstas, Prioridades, Relatórios quando status não é EM_RETIFICACAO", () => {
       renderConteudoBase();
 
-      expect(screen.getByText("Levantamento de Prioridades")).toBeInTheDocument();
+      expect(
+        screen.getByText("Levantamento de Prioridades"),
+      ).toBeInTheDocument();
       expect(screen.getByText("Receitas previstas")).toBeInTheDocument();
       expect(screen.getByText("Prioridades")).toBeInTheDocument();
       expect(screen.getByText("Relatórios")).toBeInTheDocument();
@@ -158,7 +184,9 @@ describe("ConteudoBase", () => {
     it("não renderiza a aba Levantamento de Prioridades quando status é EM_RETIFICACAO", () => {
       renderConteudoBase({ status: "EM_RETIFICACAO" });
 
-      expect(screen.queryByText("Levantamento de Prioridades")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Levantamento de Prioridades"),
+      ).not.toBeInTheDocument();
       expect(screen.getByText("Receitas previstas")).toBeInTheDocument();
       expect(screen.getByText("Prioridades")).toBeInTheDocument();
       expect(screen.getByText("Relatórios")).toBeInTheDocument();
@@ -169,7 +197,9 @@ describe("ConteudoBase", () => {
     it("inicia na aba 'prioridades' (Levantamento de Prioridades) por padrão", () => {
       renderConteudoBase();
 
-      expect(screen.getByTestId("levantamento-prioridades")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("levantamento-prioridades"),
+      ).toBeInTheDocument();
     });
 
     it("inicia na aba 'receitas' quando location.state.activeTab é 'receitas'", () => {
@@ -193,7 +223,9 @@ describe("ConteudoBase", () => {
     it("inicia na primeira aba quando location.state.activeTab é inválido", () => {
       renderConteudoBase({}, { state: { activeTab: "aba-invalida" } });
 
-      expect(screen.getByTestId("levantamento-prioridades")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("levantamento-prioridades"),
+      ).toBeInTheDocument();
     });
 
     it("inicia na aba 'receitas' quando status é EM_RETIFICACAO (primeira aba disponível)", () => {
@@ -234,7 +266,9 @@ describe("ConteudoBase", () => {
       fireEvent.click(screen.getByText("Receitas previstas"));
       fireEvent.click(screen.getByText("Levantamento de Prioridades"));
 
-      expect(screen.getByTestId("levantamento-prioridades")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("levantamento-prioridades"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -242,43 +276,72 @@ describe("ConteudoBase", () => {
     it("passa origem vazia quando não há estado especial", () => {
       renderConteudoBase();
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "",
+      );
     });
 
     it("passa origem 'plano-aplicacao' quando fromPlanoAplicacao é true", () => {
       renderConteudoBase({}, { state: { fromPlanoAplicacao: true } });
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "plano-aplicacao");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "plano-aplicacao",
+      );
     });
 
     it("passa origem 'plano-orcamentario' quando fromPlanoOrcamentario é true", () => {
       renderConteudoBase({}, { state: { fromPlanoOrcamentario: true } });
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "plano-orcamentario");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "plano-orcamentario",
+      );
     });
 
     it("passa origem 'atividades-previstas' quando fromAtividadesPrevistas é true no state", () => {
       renderConteudoBase({}, { state: { fromAtividadesPrevistas: true } });
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "atividades-previstas");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "atividades-previstas",
+      );
     });
 
     it("passa origem 'atividades-previstas' quando fromAtividadesPrevistas é valor truthy (1) no state", () => {
       renderConteudoBase({}, { state: { fromAtividadesPrevistas: 1 } });
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "atividades-previstas");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "atividades-previstas",
+      );
     });
 
     it("'atividades-previstas' tem prioridade sobre 'plano-aplicacao'", () => {
-      renderConteudoBase({}, { state: { fromPlanoAplicacao: true, fromAtividadesPrevistas: true } });
+      renderConteudoBase(
+        {},
+        { state: { fromPlanoAplicacao: true, fromAtividadesPrevistas: true } },
+      );
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "atividades-previstas");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "atividades-previstas",
+      );
     });
 
     it("'atividades-previstas' tem prioridade sobre 'plano-orcamentario'", () => {
-      renderConteudoBase({}, { state: { fromPlanoOrcamentario: true, fromAtividadesPrevistas: true } });
+      renderConteudoBase(
+        {},
+        {
+          state: { fromPlanoOrcamentario: true, fromAtividadesPrevistas: true },
+        },
+      );
 
-      expect(screen.getByTestId("barra-topo")).toHaveAttribute("data-origem", "atividades-previstas");
+      expect(screen.getByTestId("barra-topo")).toHaveAttribute(
+        "data-origem",
+        "atividades-previstas",
+      );
     });
   });
 
@@ -317,7 +380,6 @@ describe("ConteudoBase", () => {
         JSON.stringify(expandedSections),
       );
     });
-
   });
 
   describe("iniciarAtaPaa", () => {
@@ -338,7 +400,9 @@ describe("ConteudoBase", () => {
     });
 
     it("loga o erro no console quando iniciarAtaPaa falha", async () => {
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       iniciarAtaPaa.mockRejectedValueOnce(new Error("Erro de ata"));
 
       renderConteudoBase();
@@ -380,7 +444,9 @@ describe("ConteudoBase", () => {
     it("redireciona para /retificacao-paa/:uuid quando status é EM_RETIFICACAO", () => {
       renderConteudoBase({ status: "EM_RETIFICACAO", uuid: "paa-uuid-123" });
 
-      expect(mockNavigate).toHaveBeenCalledWith("/retificacao-paa/paa-uuid-123");
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "/retificacao-paa/paa-uuid-123",
+      );
     });
 
     it("não redireciona para /retificacao-paa quando status não é EM_RETIFICACAO", () => {
@@ -389,37 +455,6 @@ describe("ConteudoBase", () => {
       expect(mockNavigate).not.toHaveBeenCalledWith(
         expect.stringContaining("/retificacao-paa"),
       );
-    });
-  });
-
-  describe("Botão Cancelar Retificação", () => {
-    it("renderiza o botão Cancelar Retificação quando status é EM_RETIFICACAO", () => {
-      renderConteudoBase({ status: "EM_RETIFICACAO" });
-
-      expect(
-        screen.getByRole("button", { name: /Cancelar Retificação/i }),
-      ).toBeInTheDocument();
-    });
-
-    it("não renderiza o botão Cancelar Retificação quando status não é EM_RETIFICACAO", () => {
-      renderConteudoBase({ status: "EM_ELABORACAO" });
-
-      expect(
-        screen.queryByRole("button", { name: /Cancelar Retificação/i }),
-      ).not.toBeInTheDocument();
-    });
-
-    it("ao clicar em Cancelar Retificação chama alert e navega para /paa-vigente-e-anteriores", () => {
-      const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
-
-      renderConteudoBase({ status: "EM_RETIFICACAO" });
-
-      fireEvent.click(screen.getByRole("button", { name: /Cancelar Retificação/i }));
-
-      expect(alertSpy).toHaveBeenCalledWith("Em desenvolvimento");
-      expect(mockNavigate).toHaveBeenCalledWith("/paa-vigente-e-anteriores");
-
-      alertSpy.mockRestore();
     });
   });
 });

--- a/src/componentes/escolas/Paa/componentes/ConteudoBase/index.js
+++ b/src/componentes/escolas/Paa/componentes/ConteudoBase/index.js
@@ -7,6 +7,7 @@ import ReceitasPrevistas from "../ReceitasPrevistas";
 import Prioridades from "../../ElaboracaoPaa/ElaborarNovoPlano/Prioridades";
 import Relatorios from "../../ElaboracaoPaa/ElaborarNovoPlano/Relatorios";
 import BarraTopoTitulo from "../BarraTopoTitulo";
+import CancelarRetificacao from "../CancelarRetificacao";
 import { useLocation, useNavigate } from "react-router-dom";
 import { iniciarAtaPaa } from "../../../../../services/escolas/AtasPaa.service";
 import { visoesService } from "../../../../../services/visoes.service";
@@ -20,11 +21,18 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
   const [activeTab, setActiveTab] = useState("prioridades");
   const hasInitializedTab = useRef(false);
   const initialStateRef = useRef(location.state);
-  const relatoriosInitialExpandedSections = initialStateRef.current?.expandedSections;
+  const relatoriosInitialExpandedSections =
+    initialStateRef.current?.expandedSections;
 
-  const fromPlanoAplicacao = Boolean(initialStateRef.current?.fromPlanoAplicacao);
-  const fromPlanoOrcamentario = Boolean(initialStateRef.current?.fromPlanoOrcamentario);
-  const fromAtividadesPrevistas = Boolean(initialStateRef.current?.fromAtividadesPrevistas);
+  const fromPlanoAplicacao = Boolean(
+    initialStateRef.current?.fromPlanoAplicacao,
+  );
+  const fromPlanoOrcamentario = Boolean(
+    initialStateRef.current?.fromPlanoOrcamentario,
+  );
+  const fromAtividadesPrevistas = Boolean(
+    initialStateRef.current?.fromAtividadesPrevistas,
+  );
   const receitasDestino = initialStateRef.current?.receitasDestino || null;
 
   const origemBarra = fromAtividadesPrevistas
@@ -48,9 +56,7 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
           id: "receitas",
           label: "Receitas previstas",
           exibir: true,
-          component: (
-            <ReceitasPrevistas receitasDestino={receitasDestino} />
-          ),
+          component: <ReceitasPrevistas receitasDestino={receitasDestino} />,
         },
         {
           id: "prioridades-list",
@@ -108,15 +114,13 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
       // reativa a tab em caso de retificacao
       // Se em retificação levantamento de prioridades(prioridades) estiver selecionada,
       // considera o ref de location, caso contrário, considera tab de receitas por padrão
-      const tabAtiva = initialStateRef.current?.activeTab === "prioridades" ? "receitas" : initialStateRef.current?.activeTab || "receitas";
+      const tabAtiva =
+        initialStateRef.current?.activeTab === "prioridades"
+          ? "receitas"
+          : initialStateRef.current?.activeTab || "receitas";
       setActiveTab(tabAtiva);
     }
   }, [paa, navigate]);
-
-  const handleCancelarRetificacaoPaa = () => {
-    alert('Em desenvolvimento')
-    navigate('/paa-vigente-e-anteriores');
-  }
 
   return (
     <>
@@ -126,15 +130,8 @@ const ConteudoBase = ({ itemsBreadCrumb }) => {
         <div className="d-flex justify-content-between align-items-center mb-2">
           <BarraTopoTitulo origem={origemBarra} paa={paa} />
 
-          {paa?.status === "EM_RETIFICACAO" && (
-            <button
-              className="btn btn-success d-flex align-items-center"
-              onClick={handleCancelarRetificacaoPaa}
-              style={{ minWidth: "180px", justifyContent: "center" }}
-            >
-              Cancelar Retificação
-            </button>
-          )}
+          {/* Cancelar retifição */}
+          <CancelarRetificacao paa={paa} />
         </div>
 
         <TabSelector

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -23,6 +23,10 @@ export const postIniciarRetificacaoPaa = async (paa_uuid, payload={}) => {
   const result = await api.post(`/api/paa/${paa_uuid}/iniciar-retificacao/`, payload, authHeader());
   return result.data;
 };
+export const postCancelarRetificacaoPaa = async (paa_uuid) => {
+  const result = await api.post(`/api/paa/${paa_uuid}/cancelar-retificacao/`, {}, authHeader());
+  return result.data;
+};
 export const postGerarDocumentoPreviaPaa = async (paa_uuid) => {
   const result = await api.post(`/api/paa/${paa_uuid}/gerar-previa-documento/`, {}, authHeader());
   return result.data;


### PR DESCRIPTION
# O que este PR faz

Implementa a funcionalidade de cancelamento de retificação do PAA na interface, permitindo ao usuário cancelar uma retificação em andamento através de um modal de confirmação integrado com React Query.

---

# Funcionalidade implementada

Foi adicionado o componente:

```jsx id="tq9zxt"
<CancelarRetificacao />
```

- Testes unitários
---
