### PR TITLE
refac(149048): limpa paginação ao mudar de recurso

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/components/Lista.js
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { EditIconButton } from '../../../../../Globais/UI/Button';
 
 
-export const Lista = ({isLoading, tiposDeCredito, count, firstPage, onPageChange}) => {
+export const Lista = ({isLoading, tiposDeCredito, count, firstPage, onPageChange, rowsPerPage}) => {
     const navigate = useNavigate();
 
     const handleEditFormModal = (rowData) => {
@@ -114,7 +114,7 @@ export const Lista = ({isLoading, tiposDeCredito, count, firstPage, onPageChange
                   </div>
                   <Paginator
                       first={firstPage}
-                      rows={10}
+                      rows={rowsPerPage}
                       totalRecords={count}
                       template="PrevPageLink PageLinks NextPageLink"
                       onPageChange={onPageChange}

--- a/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/hooks/useGetTiposCredito.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/hooks/useGetTiposCredito.js
@@ -6,6 +6,7 @@ const tratarFiltros = (valoresFiltros) => {
     const { e_repasse, e_estorno, e_devolucao, e_rendimento, tipo, unidades__uuid, classificacao, ...restoFiltros } = valoresFiltros;
 
     let filtrosTratados = { ...restoFiltros };
+    delete filtrosTratados.currentPage;
 
     if (unidades__uuid && typeof unidades__uuid === "object" && Object.keys(unidades__uuid).length > 0 && unidades__uuid.uuid) {
       filtrosTratados.unidades__uuid = unidades__uuid.unidade.uuid;
@@ -36,13 +37,13 @@ const tratarFiltros = (valoresFiltros) => {
 
 export const useGetTiposCredito = (params) => {
     const { isFetching, isError, data = {count: 0, results: []}, error, refetch } = useQuery({
-        queryKey: ['tipos-creditos', params?.filters, params?.currentPage, params?.filters?.recurso_uuid],
+        queryKey: ['tipos-creditos', params?.filters, params?.filters?.currentPage, params?.filters?.recurso_uuid],
         queryFn: ()=> {
             if (!params?.filters?.recurso_uuid) {
                 return Promise.resolve({count: 0, results: []});
             }
             
-            return getTiposDeCredito(tratarFiltros({...params?.filters, recurso_uuid: params?.filters?.recurso_uuid}), params?.currentPage)
+            return getTiposDeCredito(tratarFiltros({...params?.filters, recurso_uuid: params?.filters?.recurso_uuid}), params?.filters?.currentPage)
         },
         keepPreviousData: true,
         staleTime: 5000, // 5 segundos

--- a/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/index.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/TiposDeCredito/index.js
@@ -10,6 +10,7 @@ import { useAbasPorRecursoContext } from "../../componentes/AbasPorRecurso/hooks
 import { useGetFiltrosTiposReceita } from "../TiposReceita/hooks/useGetFiltrosTiposReceita";
 
 export const TiposDeCredito = () => {
+  const ROWS_PER_PAGE = 10;
   const { selectedRecurso } = useAbasPorRecursoContext();
 
   const initialFilter = {
@@ -19,42 +20,40 @@ export const TiposDeCredito = () => {
     tipos_conta__uuid: '',
     unidades__uuid: '',
     recurso_uuid: selectedRecurso ? selectedRecurso.uuid : null,
+    currentPage: 1,
   };
 
   const [draftFilters, setDraftFilters] = useState(initialFilter);
   const [appliedFilters, setAppliedFilters] = useState(initialFilter);
 
-  const [currentPage, setCurrentPage] = useState(1);
-  const [firstPage, setFirstPage] = useState(1);
-
   const { data: dadosDosFiltros } = useGetFiltrosTiposReceita({recurso_uuid: selectedRecurso ? selectedRecurso.uuid : null, });
-  const { results: tiposDeCredito, count, isLoading } = useGetTiposCredito({ filters: appliedFilters, currentPage });
+  const { results: tiposDeCredito, count, isLoading } = useGetTiposCredito({ filters: appliedFilters });
+
+  const fisrtPage = (appliedFilters.currentPage - 1) * ROWS_PER_PAGE;
 
   useEffect(() => {
-    const initalFilterWithRecurso = { ...initialFilter, recurso_uuid: selectedRecurso ? selectedRecurso.uuid : null };
+    const initalFilterWithRecurso = { ...initialFilter, currentPage: 1, recurso_uuid: selectedRecurso ? selectedRecurso.uuid : null };
 
     setDraftFilters(initalFilterWithRecurso)
     setAppliedFilters(initalFilterWithRecurso);
   }, [selectedRecurso?.uuid]);
 
+  const changePageFilters = (currentPage) => {
+    setAppliedFilters((prevState) => ({...prevState, currentPage}));
+  }
+
   const onPageChange = (event) => {
-    setCurrentPage(event.page + 1)
-    setFirstPage(event.first)
+    const currentPage = event.page + 1;
+    changePageFilters(currentPage);
   };
 
   const handleSubmitFormFilter = () => {
-    setCurrentPage(1);
-    setFirstPage(1);
-
     setAppliedFilters(draftFilters);
   };
 
   const clearFormFilter = () => {
     setDraftFilters(initialFilter);
     setAppliedFilters(initialFilter);
-
-    setFirstPage(0);
-    setCurrentPage(1);
   };
 
     return (
@@ -77,8 +76,9 @@ export const TiposDeCredito = () => {
                 isLoading={isLoading}
                 tiposDeCredito={tiposDeCredito}
                 count={count}
-                firstPage={firstPage}
+                firstPage={fisrtPage}
                 onPageChange={onPageChange}
+                rowsPerPage={ROWS_PER_PAGE}
               />
           </div>
       </PaginasContainer>


### PR DESCRIPTION
Este PR inclui:

- Limpa paginação ao mudar de recurso na tela de listagem de tipos de receita;
- Remove códigos sem uso;

História: [AB#148837](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148837)
Tarefa: [AB#149048](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149048)