### PR TITLE
feature(139810): altera texto em modal de cancelar retificação

### DIFF
--- a/src/componentes/escolas/Paa/RetificacaoPaa/index.js
+++ b/src/componentes/escolas/Paa/RetificacaoPaa/index.js
@@ -5,7 +5,6 @@ import PaaBase from "../componentes/PaaBase";
 import { useGetPaaRetificacao } from "../componentes/hooks/useGetPaaRetificacao";
 import { PaaContext } from "../componentes/PaaContext";
 
-
 export const RetificacaoPaa = () => {
   const { uuid_paa } = useParams();
 
@@ -14,7 +13,6 @@ export const RetificacaoPaa = () => {
   const itemsBreadCrumb = useMemo(() => {
     return [
       { label: "Plano Anual de Atividades", url: "/retificacao-paa" },
-      { label: "Elaboração e histórico", active: false },
       { label: "PAA Vigente e Anteriores", active: true },
     ];
   }, []);
@@ -27,7 +25,7 @@ export const RetificacaoPaa = () => {
       <PaaContext.Provider value={{ paa, refetch }}>
         <PaaBase itemsBreadCrumb={itemsBreadCrumb} />
       </PaaContext.Provider>
-    )
+    );
   }, [paa, refetch, uuid_paa, itemsBreadCrumb]);
 
   return renderizar();

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/__tests__/CancelarRetificacao.test.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/__tests__/CancelarRetificacao.test.js
@@ -102,7 +102,9 @@ describe("CancelarRetificacao", () => {
       }),
     );
 
-    expect(screen.getByText(/ao cancelar, as alterações/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/As alterações da retificação serão apagadas/i),
+    ).toBeInTheDocument();
   });
 
   it("deve fechar modal ao clicar em voltar", async () => {
@@ -122,7 +124,7 @@ describe("CancelarRetificacao", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText(/ao cancelar, as alterações/i),
+        screen.queryByText(/As alterações da retificação serão apagadas/i),
       ).not.toBeInTheDocument();
     });
   });
@@ -230,7 +232,9 @@ describe("CancelarRetificacao", () => {
       }),
     );
 
-    expect(screen.getByText(/ao cancelar, as alterações/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/As alterações da retificação serão apagadas/i),
+    ).toBeInTheDocument();
   });
 
   it("deve tratar erro da mutation sem quebrar componente", async () => {

--- a/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
+++ b/src/componentes/escolas/Paa/componentes/CancelarRetificacao/index.js
@@ -56,9 +56,8 @@ const CancelarRetificacao = ({ paa }) => {
         </Modal.Header>
         <Modal.Body>
           <p>
-            Ao cancelar, as alterações da retificação serão perdidas e não{" "}
-            <br />
-            poderão ser recuperadas. Deseja continuar?
+            As alterações da retificação serão apagadas e não poderão ser <br />
+            recuperadas. Deseja continuar?
           </p>
         </Modal.Body>
         <Modal.Footer id="main">


### PR DESCRIPTION
# O que este PR faz

- altera mensagem quando é aberto o modal de cancelar retificação (fluxo retificar)
- remove breadcrumb incoerente
- ajusta testes unitários

Referência Azure: [AB#139810](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/139810)