### PR TITLE
hotfix(148847): adicionar mensagens de erro personalizada em gastos da escola

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.39.0",
+  "version": "9.39.1",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -692,7 +692,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
                         } catch (error) {
                             console.log(error);
                             setLoading(false);
-                            habilitaBtnSalvar();                            
+                            habilitaBtnSalvar();
                         }
                     }
                     else if (despesaContext.verboHttp === "PUT"){
@@ -721,7 +721,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
                                 }
 
                                 aux.getPath(origem, parametroLocation);
-                                
+
                             }
                             else {
                                 handleErroCriarDespesa(response);
@@ -740,7 +740,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
                 // Caso não seja origem de analise lancamento (reabertura seletiva), deve seguir o fluxo normal
                 // O loading será ativado apenas quando a mutation realmente executar (após confirmação da modal se necessário)
                 // Não ativamos o loading aqui para evitar que apareça antes da modal de confirmação
-                
+
                 if (despesaContext.verboHttp === "POST") {
                     mutationCreate.mutate({ payload: values });
                 }

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -6,6 +6,9 @@ import {
     periodoFechadoImposto
 } from "../../../../utils/ValidacoesAdicionaisFormularios";
 import {
+    getErrorMessage
+} from "../../../../utils/obtemMsgErroAxios";
+import {
     getDespesasTabelas,
     criarDespesa,
     alterarDespesa,
@@ -689,7 +692,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
                         } catch (error) {
                             console.log(error);
                             setLoading(false);
-                            habilitaBtnSalvar();
+                            habilitaBtnSalvar();                            
                         }
                     }
                     else if (despesaContext.verboHttp === "PUT"){
@@ -737,7 +740,7 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
                 // Caso não seja origem de analise lancamento (reabertura seletiva), deve seguir o fluxo normal
                 // O loading será ativado apenas quando a mutation realmente executar (após confirmação da modal se necessário)
                 // Não ativamos o loading aqui para evitar que apareça antes da modal de confirmação
-
+                
                 if (despesaContext.verboHttp === "POST") {
                     mutationCreate.mutate({ payload: values });
                 }
@@ -757,14 +760,13 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
             if (response.data.hasOwnProperty("rateios")) {
                 const rateios = response.data.rateios[0];
                 mensagemErro += " Rateios: " + rateios.mensagem.map((msg) => msg).join(", ")
-            }
-            if(response.data.hasOwnProperty("mensagem")){
-                if(response.data.mensagem.length){
-                    mensagemErro = response.data.mensagem[0];
-                }
+            } else {
+                const error = {response};
+                mensagemErro = getErrorMessage(error, "Ocorreu um erro criar/editar despesa.");
             }
         }
-        toastCustom.ToastCustomError('Erro ao tentar salvar despesa.', mensagemErro)                            
+        
+        toastCustom.ToastCustomError('Erro ao tentar salvar despesa.', mensagemErro)
     };
 
     const validateFormDespesas = async (values) => {

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/hooks/useMutationDespesaConfirmavel.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/hooks/useMutationDespesaConfirmavel.js
@@ -1,6 +1,8 @@
 import { useDispatch } from "react-redux";
 import { criarDespesa, alterarDespesa } from "../../../../../services/escolas/Despesas.service";
 import { useMutationConfirmavel } from "../../../../../hooks/Globais/useMutationConfirmavel";
+import { toastCustom } from "../../../../Globais/ToastCustom";
+import { getErrorMessage } from "../../../../../utils/obtemMsgErroAxios";
 import HTTP_STATUS from "http-status-codes";
 
 export const useMutationDespesaConfirmavel = (onSuccess, onError, setLoading, setBtnSubmitDisable) => {
@@ -42,11 +44,13 @@ export const useMutationDespesaConfirmavel = (onSuccess, onError, setLoading, se
       },
       onError: (error, variables) => {
         if (!error?.response?.data?.confirmar) {
-          onError && onError(error.response || error);
+          const mensagemErro = getErrorMessage(error, "Ocorreu um erro ao criar despesa");
+          toastCustom.ToastCustomError(mensagemErro);
+          onError && onError(error.response || error);     
         } else {
           // Se for erro de confirmação, não ativa loading ainda
           // O loading será ativado apenas quando o usuário confirmar
-          // Não precisa desativar porque nunca foi ativado na primeira chamada
+          // Não precisa desativar porque nunca foi ativado na primeira chamada          
         }
       },
     },
@@ -88,11 +92,13 @@ export const useMutationDespesaConfirmavel = (onSuccess, onError, setLoading, se
       },
       onError: (error) => {
         if (!error?.response?.data?.confirmar) {
-          onError && onError(error.response || error);
+          const mensagemErro = getErrorMessage(error, "Ocorreu um erro ao editar despesa");
+          toastCustom.ToastCustomError(mensagemErro);
+          onError && onError(error.response || error);          
         } else {
           // Se for erro de confirmação, não ativa loading ainda
           // O loading será ativado apenas quando o usuário confirmar
-          // Não precisa desativar porque nunca foi ativado na primeira chamada
+          // Não precisa desativar porque nunca foi ativado na primeira          
         }
       },
     },

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/hooks/useMutationDespesaConfirmavel.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/hooks/useMutationDespesaConfirmavel.js
@@ -50,7 +50,7 @@ export const useMutationDespesaConfirmavel = (onSuccess, onError, setLoading, se
         } else {
           // Se for erro de confirmação, não ativa loading ainda
           // O loading será ativado apenas quando o usuário confirmar
-          // Não precisa desativar porque nunca foi ativado na primeira chamada          
+          // Não precisa desativar porque nunca foi ativado na primeira chamada
         }
       },
     },
@@ -98,7 +98,7 @@ export const useMutationDespesaConfirmavel = (onSuccess, onError, setLoading, se
         } else {
           // Se for erro de confirmação, não ativa loading ainda
           // O loading será ativado apenas quando o usuário confirmar
-          // Não precisa desativar porque nunca foi ativado na primeira          
+          // Não precisa desativar porque nunca foi ativado na primeira chamada
         }
       },
     },


### PR DESCRIPTION
# O que este PR faz

- Adiciona mensagem personalizada de erro ao criar/editar despesa em Gastos da Escola.

Referência Azure: [AB#148847](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148847)