### PR TITLE
fix(149227): Ata de retificação não aparece para unidade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.39.1",
+  "version": "9.39.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/PrestacaoDeContas/__fixtures__/mockData.js
+++ b/src/componentes/escolas/PrestacaoDeContas/__fixtures__/mockData.js
@@ -33,6 +33,7 @@ const statusPeriodo = {
         legenda_cor: 3,
         prestacao_de_contas_uuid: null,
         requer_retificacao: false,
+        possui_ata_retificacao: false,
         tem_acertos_pendentes: false
     },
     prestacao_conta: "",

--- a/src/componentes/escolas/PrestacaoDeContas/index.js
+++ b/src/componentes/escolas/PrestacaoDeContas/index.js
@@ -540,7 +540,10 @@ export const PrestacaoDeContas = ({setStatusPC, registroFalhaGeracaoPc, setRegis
 
     const exibeBoxAtaRetificadora = useCallback(() => {
            return statusPrestacaoDeConta &&
-            statusPrestacaoDeConta.prestacao_contas_status && statusPrestacaoDeConta.prestacao_contas_status.requer_retificacao
+            statusPrestacaoDeConta.prestacao_contas_status && (
+                statusPrestacaoDeConta.prestacao_contas_status.requer_retificacao ||
+                statusPrestacaoDeConta.prestacao_contas_status.possui_ata_retificacao
+            )
     }, [statusPrestacaoDeConta])
 
     useEffect(()=>{


### PR DESCRIPTION
Esse PR:

- Corrige a visualização da ata de retificação para a unidade.

História: [AB#149227](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149227)