### PR TITLE
Refactor/149736 alterar exibicao abas recurso e filtros motivos reprovacao

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Filtros.test.js
@@ -8,7 +8,7 @@ describe('Filtros', () => {
   const mockSetFilter = jest.fn();
   const mockSetCurrentPage = jest.fn();
   const mockSetFirstPage = jest.fn();
-  const initialFilter = { motivo: '' };
+  const initialFilter = { motivo: '', page: 1, page_size: 10 };
 
   const renderComponent = () => {
     return render(
@@ -45,7 +45,7 @@ describe('Filtros', () => {
     expect(input.value).toBe('Teste');
   });
 
-  test('Deve chamar setFilter, setCurrentPage e setFirstPage com os valores corretos quando o botão "Filtrar" é clicado', () => {
+  test('Deve chamar setFilter com os valores corretos quando o botão "Filtrar" é clicado', () => {
     renderComponent();
     const input = screen.getByPlaceholderText('Busque por motivo');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
@@ -54,14 +54,18 @@ describe('Filtros', () => {
     fireEvent.click(filtrarButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: 'Teste' });
-    expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
-    expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
-    expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
-    expect(mockSetFirstPage).toHaveBeenCalledWith(0);
+    
+    const updater = mockSetFilter.mock.calls[0][0];
+    
+    expect(typeof updater).toBe('function');
+    expect(updater({ recurso_uuid: 'abc' })).toEqual({
+      ...initialFilter,
+      motivo: "Teste",
+      recurso_uuid: 'abc',
+    });
   });
 
-  test('Deve chamar setFilter, setCurrentPage e setFirstPage com o valor inicial quando o botão "Limpar" é clicado', () => {
+  test('Deve chamar setFilter com o valor inicial quando o botão "Limpar" é clicado', () => {
     renderComponent();
     const input = screen.getByPlaceholderText('Busque por motivo');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
@@ -70,11 +74,15 @@ describe('Filtros', () => {
     fireEvent.click(limparButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith(initialFilter);
-    expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
-    expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
-    expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
-    expect(mockSetFirstPage).toHaveBeenCalledWith(0);
+    // expect(mockSetFilter).toHaveBeenCalledWith((prevState) => ({...initialFilter, recurso_uuid: prevState.recurso_uuid}));
+
+    const updater = mockSetFilter.mock.calls[0][0];
+    
+    expect(typeof updater).toBe('function');
+    expect(updater({ recurso_uuid: 'abc' })).toEqual({
+      ...initialFilter,
+      recurso_uuid: 'abc',
+    });
     expect(input.value).toBe("");
   });
 
@@ -87,7 +95,8 @@ describe('Filtros', () => {
         expect(divPrincipal).toHaveClass('d-flex')
         expect(divPrincipal).toHaveClass('bd-highlight')
         expect(divPrincipal).toHaveClass('align-items-end')
-        expect(divPrincipal).toHaveClass('mt-2')
+        expect(divPrincipal).toHaveClass('mt-4')
+        expect(divPrincipal).toHaveClass('mb-4')
 
         expect(form).toBeInTheDocument()
         expect(form).toBeInstanceOf(HTMLFormElement)

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Lista.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Lista.test.js
@@ -40,9 +40,10 @@ const contexto = {
   setBloquearBtnSalvarForm: jest.fn(),
   handleEditFormModal: jest.fn(),
   handleExcluirMotivo: jest.fn(),
-  showModalConfirmacaoExclusao: { is_open: false, motivo_uuid: '' }
+  showModalConfirmacaoExclusao: { is_open: false, motivo_uuid: '' },
+  filter: { page: 1, page_size: 10  }
 }
-const itemMock = { id: 1, motivo: "Motivo 1", uuid: "123", recurso_uuid: "r1", recurso: "r1" };
+const itemMock = { id: 1, motivo: "Motivo 1", uuid: "123", recurso_uuid: "r1", recurso: "r1", page: 1 };
 
 describe("Lista", () => {
   beforeEach(() => {
@@ -107,8 +108,8 @@ describe("Lista", () => {
       </MotivosReprovacaoPcContext.Provider>
     );
 
-    const editButton = screen.getAllByRole("button", { selector: "btn-editar-membro" });
-    fireEvent.click(editButton[1]);
+    const editButton = screen.getByTestId("btn-editar-motivo-reprovacao-pc");
+    fireEvent.click(editButton);
 
     expect(contexto.setStateFormModal).toHaveBeenCalledWith({ ...itemMock, isOpen: true });
   });

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/index.test.js
@@ -62,7 +62,6 @@ describe('ParametrizacoesMotivosReprovacaoPc', () => {
         expect(screen.getByTestId('topo-com-botoes')).toBeInTheDocument();
         expect(screen.getByTestId('filtros')).toBeInTheDocument();
         expect(screen.getByTestId('lista')).toBeInTheDocument();
-        expect(screen.getByTestId('paginacao')).toBeInTheDocument();
         
     });
 

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Filtros.js
@@ -1,10 +1,16 @@
-import React, { useState} from "react";
+import React, { useEffect, useState} from "react";
 import { useMotivosReprovacaoPcContext } from "../hooks/useMotivoReprovacaoContext"
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
 
 export const Filtros = () => {
+    const { selectedRecurso } = useAbasPorRecursoContext();
 
-    const {setFilter, initialFilter, setCurrentPage, setFirstPage} = useMotivosReprovacaoPcContext();
+    const { setFilter, initialFilter } = useMotivosReprovacaoPcContext();
     const [formFilter, setFormFilter] = useState(initialFilter);
+
+    useEffect(() => {
+        setFormFilter(initialFilter)
+    }, [selectedRecurso?.uuid])
 
     const handleChangeFormFilter = (name, value) => {
         setFormFilter({
@@ -14,16 +20,18 @@ export const Filtros = () => {
     };
 
     const handleSubmitFormFilter = () => {
-        setCurrentPage(1)
-        setFirstPage(0)
-        setFilter(formFilter);
+        setFilter(prevState => ({
+            ...formFilter,
+            recurso_uuid: prevState?.recurso_uuid
+        }));
     };
 
     const clearFilter = () => {
-        setCurrentPage(1)
-        setFirstPage(0)
         setFormFilter(initialFilter);
-        setFilter(initialFilter);
+        setFilter(prevState => ({
+            ...initialFilter,
+            recurso_uuid: prevState?.recurso_uuid
+        }));
     };
 
     const handleSubmitForm = (e) => {
@@ -33,7 +41,7 @@ export const Filtros = () => {
     }
     
     return (
-        <div className="d-flex bd-highlight align-items-end mt-2">
+        <div className="d-flex bd-highlight align-items-end mt-4 mb-4">
             <div className="flex-grow-1 bd-highlight mr-4">
                 <form onSubmit={handleSubmitForm} id="form-filtros-motivos-reprovacao-pc" data-qa="form-filtros-motivos-reprovacao-pc">
                     <label htmlFor="motivo">Filtrar por motivo de reprovação de PC</label>

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Lista.js
@@ -6,10 +6,9 @@ import { ModalForm } from "./ModalForm";
 import { ModalConfirmarExclusao } from "../../../../../Globais/ModalAntDesign/ModalConfirmarExclusao";
 import {MsgImgCentralizada} from "../../../../../Globais/Mensagens/MsgImgCentralizada";
 import Img404 from "../../../../../../assets/img/img-404.svg";
-import { EditIconButton, IconButton } from "../../../../../Globais/UI/Button";
+import { EditIconButton } from "../../../../../Globais/UI/Button";
 import { toastCustom } from "../../../../../Globais/ToastCustom";
-import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
-import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import { Paginacao } from './Paginacao';
 import { useMotivosReprovacaoPcContext } from "../hooks/useMotivoReprovacaoContext";
 import { useGetMotivosReprovacaoPc } from "../hooks/useGetMotivosReprovacaoPc";
 import { usePostMotivoReprovacaoPc } from "../hooks/usePostMotivoReprovacaoPc";
@@ -18,11 +17,8 @@ import { useDeleteMotivoReprovacaoPc } from "../hooks/useDeleteMotivoReprovacaoP
 
 
 export const Lista = () => {
-  const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
-  const { selectedRecurso } = useAbasPorRecursoContext();
-
-  const { stateFormModal, setStateFormModal, setBloquearBtnSalvarForm, handleOpenCreateModal, showModalConfirmacaoExclusao, handleCloseModalConfirmacaoExclusao } = useMotivosReprovacaoPcContext();
-  const { isLoading, data } = useGetMotivosReprovacaoPc({ is_required_recurso_uuid: true, recurso_uuid: selectedRecurso?.uuid })
+  const { stateFormModal, setStateFormModal, setBloquearBtnSalvarForm, showModalConfirmacaoExclusao, handleCloseModalConfirmacaoExclusao } = useMotivosReprovacaoPcContext();
+  const { isLoading, data, total } = useGetMotivosReprovacaoPc()
   const { mutationPost } = usePostMotivoReprovacaoPc()
   const { mutationPatch } = usePatchMotivoReprovacaoPc()
   const { mutationDelete } = useDeleteMotivoReprovacaoPc()
@@ -34,6 +30,7 @@ export const Lista = () => {
       return (
         <EditIconButton
             onClick={() => handleEditFormModal(rowData)}
+            data-testid="btn-editar-motivo-reprovacao-pc"
         />
       )
   };
@@ -84,22 +81,6 @@ export const Lista = () => {
   }
   return (
     <>
-        <div className="d-flex justify-content-between align-items-end mb-3">
-            <div>
-                <h5 className="font-weight-bold">{selectedRecurso?.nome}</h5>
-                <p className="m-0">Confira abaixo os motivos de reprovação do {selectedRecurso?.nome_exibicao}.</p>
-            </div>
-
-            <IconButton
-                icon="faPlus"
-                iconProps={{ style: {fontSize: '15px', marginRight: "5", color:"#fff"} }}
-                label="Adicionar motivo de reprovação"
-                onClick={() => handleOpenCreateModal(selectedRecurso)}
-                variant="success"
-                disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-            />
-        </div>
-
         {results && results.length > 0 ? (
             <DataTable
                 value={results}
@@ -124,6 +105,11 @@ export const Lista = () => {
                 img={Img404}
             />
         }
+
+        <Paginacao
+            isLoading={isLoading}
+            total={total}
+        />
       
         <ModalForm
             handleSubmitFormModal={handleSubmitFormModal}

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/ModalForm.js
@@ -7,6 +7,9 @@ import {RetornaSeTemPermissaoEdicaoPainelParametrizacoes} from "../../../../Para
 import { useMotivosReprovacaoPcContext } from "../hooks/useMotivoReprovacaoContext";
 import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+
 export const ModalForm = ({handleSubmitFormModal}) => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const { stateFormModal, bloquearBtnSalvarForm, handleOpenModalConfirmacaoExclusao, handleCloseModalForm} = useMotivosReprovacaoPcContext();
@@ -105,6 +108,7 @@ export const ModalForm = ({handleSubmitFormModal}) => {
                                             disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                             data-testid="btn-excluir-motivo"
                                         >
+                                            <FontAwesomeIcon icon={faXmark} style={{ marginRight: "8px", color: "white", fontWeight: "bold" }} />
                                             Excluir
                                         </button>
                                     }

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Paginacao.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/Paginacao.js
@@ -1,18 +1,19 @@
 import React from "react";
 import {Paginator} from 'primereact/paginator';
-import { useGetMotivosReprovacaoPc } from "../hooks/useGetMotivosReprovacaoPc";
 import { useMotivosReprovacaoPcContext } from "../hooks/useMotivoReprovacaoContext";
 
 
-export const Paginacao = () => {
-    const {isLoading, data, total} = useGetMotivosReprovacaoPc()
-    const {count} = data
-    const {setCurrentPage, firstPage,setFirstPage} = useMotivosReprovacaoPcContext();
-
+export const Paginacao = ({ isLoading, total }) => {
+    const { setFilter, filter } = useMotivosReprovacaoPcContext();
+    const firstPage = (filter.page - 1) * filter.page_size;
 
     const onPageChange = (event) => {
-        setCurrentPage(event.page + 1)
-        setFirstPage(event.first)
+        const currentPage = event.page + 1;
+
+        setFilter((prev) => ({
+            ...prev,
+            page: currentPage
+        }))
     };
 
     return (
@@ -20,8 +21,8 @@ export const Paginacao = () => {
             {!isLoading && total ? (
                     <Paginator
                         first={firstPage}
-                        rows={20}
-                        totalRecords={count}
+                        rows={filter.page_size}
+                        totalRecords={total}
                         template="PrevPageLink PageLinks NextPageLink"
                         onPageChange={onPageChange}
                     />

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/TopoComBotoes.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/components/TopoComBotoes.js
@@ -1,14 +1,30 @@
 import React from "react";
 
+import { IconButton } from "../../../../../Globais/UI/Button";
+import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
+import { useMotivosReprovacaoPcContext } from "../hooks/useMotivoReprovacaoContext";
+
 export const TopoComBotoes = () => {
+    const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
+    const { selectedRecurso } = useAbasPorRecursoContext();
+    const { handleOpenCreateModal } = useMotivosReprovacaoPcContext();
+
     return(
-        <div className="d-flex bd-highlight align-items-center">
-            <div className="mb-4">
-                <h4 className="font-weight-bold mb-0">Refine sua busca</h4>
-                <p>
-                    Utilize o filtro por motivo para localizar motivos de reprovação específicos do recurso selecionado.
-                </p>
+        <div className="d-flex justify-content-between align-items-end mb-3">
+            <div>
+                <h5 className="font-weight-bold">{selectedRecurso?.nome}</h5>
+                <p className="m-0">Confira abaixo os motivos de reprovação do {selectedRecurso?.nome_exibicao}.</p>
             </div>
+
+            <IconButton
+                icon="faPlus"
+                iconProps={{ style: {fontSize: '15px', marginRight: "5", color:"#fff"} }}
+                label="Adicionar motivo de reprovação"
+                onClick={() => handleOpenCreateModal(selectedRecurso)}
+                variant="success"
+                disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+            />
         </div>
     )
 

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/context/MotivosReprovacaoPc.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/context/MotivosReprovacaoPc.js
@@ -1,7 +1,12 @@
-import React, { createContext, useMemo, useState } from 'react';
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+import { useAbasPorRecursoContext } from '../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext';
 
 const initialFilter = {
-    motivo:''
+    motivo:'',
+    page: 1,
+    page_size: 10,
+    recurso_uuid: '',
+    is_required_recurso_uuid: true,
 };
 
 const initialStateFormModal = {
@@ -42,7 +47,8 @@ export const MotivosReprovacaoPcContext = createContext({
     handleCloseModalForm: () => {},
 })
 
-export const MotivosReprovacaoPcProvider = ({children}) => {    
+export const MotivosReprovacaoPcProvider = ({children}) => {
+    const { selectedRecurso } = useAbasPorRecursoContext();
     const [filter, setFilter] = useState(initialFilter);
 
     const [currentPage, setCurrentPage] = useState(1);
@@ -70,6 +76,15 @@ export const MotivosReprovacaoPcProvider = ({children}) => {
     const handleCloseModalConfirmacaoExclusao = () => {
         setShowModalConfirmacaoExclusao({ is_open: false, motivo_uuid: '' });
     }
+
+    useEffect(() => {
+        const initialFilterWithRecurso = {
+            ...initialFilter,
+            recurso_uuid: selectedRecurso?.uuid || '',
+        }
+        
+        setFilter(initialFilterWithRecurso);
+    }, [selectedRecurso?.uuid])
 
     const contextValue = useMemo(() => {
         return {

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/hooks/useGetMotivosReprovacaoPc.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/hooks/useGetMotivosReprovacaoPc.js
@@ -3,18 +3,18 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useMotivosReprovacaoPcContext } from "./useMotivoReprovacaoContext";
 
-export const useGetMotivosReprovacaoPc = (params) => {
+export const useGetMotivosReprovacaoPc = () => {
 
-    const {filter, currentPage} = useMotivosReprovacaoPcContext();
+    const { filter } = useMotivosReprovacaoPcContext();
 
     const { isFetching, isError, data = {count: 0, results: []}, error, refetch } = useQuery({
-        queryKey: ['motivos-reprovacao-pc', filter, currentPage, params?.recurso_uuid],
+        queryKey: ['motivos-reprovacao-pc', filter?.recurso_uuid, filter?.motivo, filter?.page],
         queryFn: ()=> {
-            if (params?.is_required_recurso_uuid && !params?.recurso_uuid) {
+            if (filter?.is_required_recurso_uuid && !filter?.recurso_uuid) {
                 return Promise.resolve({count: 0, results: []});
             }
 
-            return getMotivosReprovacaoPc({...filter, recurso_uuid: params?.recurso_uuid}, currentPage)
+            return getMotivosReprovacaoPc({ ...filter }, filter?.page)
         },
         keepPreviousData: true,
         staleTime: 5000, // 5 segundos

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/index.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/index.js
@@ -3,7 +3,6 @@ import React from "react";
 import { TopoComBotoes } from "./components/TopoComBotoes";
 import { Filtros } from "./components/Filtros";
 import { Lista } from "./components/Lista";
-import { Paginacao } from "./components/Paginacao";
 import { PaginasContainer } from "../../../../../paginas/PaginasContainer";
 import { AbasPorRecurso } from "../../componentes/AbasPorRecurso";
 import { MotivosReprovacaoPcProvider } from "./context/MotivosReprovacaoPc";
@@ -15,15 +14,13 @@ export const ParametrizacoesMotivosReprovacaoPc = () => {
                 <h1 className="titulo-itens-painel mt-5">Motivos de reprovação de PC</h1>
 
                 <div className="page-content-inner">
+                    <AbasPorRecurso />
+                    
                     <TopoComBotoes />
 
                     <Filtros />
 
-                    <AbasPorRecurso />
-
                     <Lista />
-
-                    <Paginacao />
                 </div>
             </PaginasContainer>
         </MotivosReprovacaoPcProvider>


### PR DESCRIPTION
Este PR inclui:

- Ajusta tela de exibição em tela de listagem de motivos de reprovação em parametrizações;
- Limpa filtros e paginação ao mudar de recurso;
- Adiciona/ajusta testes unitários;

História: [AB#149736](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149736)
Tarefa: [AB#149770](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149770)