### PR TITLE
refactor: :recycle: Refatora Receitas.service removendo TODO para Tipos de Créditos

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/index.js
+++ b/src/componentes/escolas/Receitas/Formularios/index.js
@@ -140,16 +140,14 @@ export const ReceitaForm = () => {
     const carregaTabelas = useCallback(async ()=>{
         let tabelas_receitas;
 
-        // TODO remover ignorar_filtro_recurso após criado e executado script
-        // para atualizar as receitas criada com o tipo de credito sem vinculo com Recurso
         if(parametros && parametros.state && parametros.state.uuid_associacao){
-            tabelas_receitas = await getTabelasReceitaReceita(parametros.state.uuid_associacao, !!uuid);
+            tabelas_receitas = await getTabelasReceitaReceita(parametros.state.uuid_associacao)
         }
         else{
-            tabelas_receitas = await getTabelasReceitaReceita(null, !!uuid);
+            tabelas_receitas = await getTabelasReceitaReceita()
         }
         setTabelas(tabelas_receitas)
-    }, [parametros, uuid])
+    }, [parametros])
 
     useEffect(()=>{
         carregaTabelas()

--- a/src/services/escolas/Receitas.service.js
+++ b/src/services/escolas/Receitas.service.js
@@ -21,15 +21,9 @@ export const getTabelasReceita = async () => {
         });
 };
 
-export const getTabelasReceitaReceita = async (associacao=null, ignorar_filtro_recurso=false) => {
-    // TODO remover ignorar_filtro_recurso após criado e executado script
-    // para atualizar as receitas criada com o tipo de credito sem vinculo com Recurso
+export const getTabelasReceitaReceita = async (associacao=null) => {
     let associacao_uuid = associacao ? associacao : localStorage.getItem(ASSOCIACAO_UUID);
-    let url = `api/receitas/tabelas/?associacao_uuid=${associacao_uuid}`;
-    if (ignorar_filtro_recurso) {
-        url += `&ignorar_filtro_recurso=${ignorar_filtro_recurso}`;
-    }
-    return (await api.get(url, authHeader())).data
+    return (await api.get(`api/receitas/tabelas/?associacao_uuid=${associacao_uuid}`, authHeader())).data
 };
 
 


### PR DESCRIPTION
Esse PR:

- Refatora Formulário e Receitas.service para remover TODO de Tipos de Créditos

História: [AB#149498](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149498) e Tarefa: [AB#150033](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150033)