### PR TITLE
feat(145697): Adiciona lógica de geração de Documento Prévia e Final

### DIFF
--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDespesasPeriodosAnteriores/__tests__/index.test.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDespesasPeriodosAnteriores/__tests__/index.test.js
@@ -92,7 +92,7 @@ const mockStore = createStore((state = {}, action) => {
   }
 });
 
-// ───────────────────────── helpers ─────────────────────────
+// helpers
 
 const mockContas = [{ uuid: 'conta-uuid', tipo_conta: { nome: 'Cheque' } }];
 const mockContasMultiplas = [
@@ -213,7 +213,7 @@ const mockLancamentosComMensagemInativaEExterno = [{
   }
 }];
 
-// ── Helper para criar acertos com status específico ──────────────────────────
+// Helper para criar acertos com status específico
 const makeAcerto = (uuid, status) => ({
   uuid,
   ordem: 1,
@@ -326,7 +326,7 @@ function setupDefaultMocks(contas = mockContas, lancamentos = mockLancamentos, a
 // Mock Redux store
 const mockNavigate = jest.fn();
 
-// ───────────────────────── tests ─────────────────────────
+// tests
 
 describe('AcertosDespesasPeriodosAnteriores', () => {
   const defaultProps = {
@@ -380,7 +380,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     return null;
   };
 
-  // ── Render inicial ──────────────────────────────────────
+  // Render inicial
 
   describe('Render e carregamento inicial', () => {
     it('renderiza o loading inicialmente', () => {
@@ -423,7 +423,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Seleção de conta ────────────────────────────────────
+  // Seleção de conta
 
   describe('Seleção de conta', () => {
     it('usa conta salva no estado quando disponível', async () => {
@@ -493,7 +493,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Troca de aba ────────────────────────────────────────
+  // Troca de aba
 
   describe('Troca de aba (Tabs)', () => {
     it('renderiza Tabs com as contas como abas', async () => {
@@ -550,7 +550,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Ações na tabela ─────────────────────────────────────
+  // Ações na tabela
 
   describe('Ação: limparStatus', () => {
     it('chama postLimparStatusLancamentoPrestacaoConta', async () => {
@@ -709,7 +709,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Checkboxes e seleção ────────────────────────────────
+  // Checkboxes e seleção
 
   describe('Checkboxes e seleção', () => {
     it('selecionarTodosItensDosLancamentosGlobal retorna um checkbox', async () => {
@@ -792,7 +792,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── rowExpansionTemplateLancamentos ─────────────────────
+  // rowExpansionTemplateLancamentos
 
   describe('rowExpansionTemplateLancamentos', () => {
     it('retorna undefined quando não há acertos na solicitacao', async () => {
@@ -1016,7 +1016,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Navegação ───────────────────────────────────────────
+  // Navegação
 
   describe('Navegação', () => {
     it('navega para detalhe ao clicar em "Editar acertos solicitados"', async () => {
@@ -1098,7 +1098,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Props passadas para componentes filhos ───────────────
+  // Props passadas para componentes filhos
 
   describe('Props passadas para TabelaAcertosDespesasPeriodosAnteriores', () => {
     it('passa lancamentosAjustes corretamente', async () => {
@@ -1159,7 +1159,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Permissões ──────────────────────────────────────────
+  // Permissões
 
   describe('Permissões', () => {
     it('não permite edição quando usuário não tem permissão (editavel false)', async () => {
@@ -1172,7 +1172,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Interações com checkboxes (detalhe) ─────────────────
+  // Interações com checkboxes (detalhe)
 
   describe('Interações avançadas com checkboxes', () => {
     it('selecionarTodosGlobal desseleciona todos quando todos já estavam selecionados', async () => {
@@ -1377,7 +1377,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Interações na expansão (textareas e botões de salvar) ─
+  // Interações na expansão (textareas e botões de salvar)
 
   describe('Interações na expansão: justificativa e esclarecimento', () => {
     it('handleChangeTextareaJustificativa atualiza o estado ao digitar na textarea', async () => {
@@ -1636,7 +1636,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── acoesDisponiveis: todas as combinações de status ────────────────────────
+  // acoesDisponiveis: todas as combinações de status
 
   describe('acoesDisponiveis: combinações de status', () => {
     const selecionarTodos = async () => {
@@ -1717,7 +1717,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Navegação: Crédito ───────────────────────────────────
+  // Navegação: Crédito
 
   describe('Navegação: Crédito', () => {
     it('navega para edição de receita ao clicar em "Ir para receita"', async () => {
@@ -1769,7 +1769,7 @@ describe('AcertosDespesasPeriodosAnteriores', () => {
     });
   });
 
-  // ── Rows expandidas ─────────────────────────────────────
+  // Rows expandidas
 
   describe('Estado de linhas expandidas', () => {
     it('restaura linhas expandidas do localStorage ao carregar lancamentos', async () => {

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDocumentos/__tests__/index.test.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosDocumentos/__tests__/index.test.js
@@ -83,7 +83,7 @@ jest.mock("../../../../../services/dres/PrestacaoDeContas.service", () => ({
   postRestaurarJustificativasAdicionais: jest.fn(),
 }));
 
-// ── Dados de mock ──
+// Dados de mock
 
 const mockAnaliseDocumentos = {
   editavel: true,
@@ -140,7 +140,7 @@ const defaultProps = {
 const setup = (props = {}) =>
   render(<AcertosDocumentos {...defaultProps} {...props} />);
 
-// ── Configuração padrão dos mocks ──
+// Configuração padrão dos mocks
 
 beforeEach(() => {
   capturedTabelaProps = {};
@@ -168,7 +168,7 @@ beforeEach(() => {
 });
 
 describe("AcertosDocumentos", () => {
-  // ── Estado de carregamento ──
+  // Estado de carregamento
 
   it("exibe Loading enquanto os dados estão sendo carregados", () => {
     getAnaliseDocumentosPrestacaoConta.mockReturnValue(new Promise(() => {}));
@@ -201,7 +201,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── Props passadas para TabelaAcertosDocumentos ──
+  // Props passadas para TabelaAcertosDocumentos
 
   it("passa analisePermiteEdicao correto para TabelaAcertosDocumentos", async () => {
     setup();
@@ -268,7 +268,7 @@ describe("AcertosDocumentos", () => {
     });
   });
 
-  // ── selecionarTodosItensDosDocumentosGlobal ──
+  // selecionarTodosItensDosDocumentosGlobal
 
   it("selecionarTodosItensDosDocumentosGlobal retorna checkbox", async () => {
     setup();
@@ -283,7 +283,7 @@ describe("AcertosDocumentos", () => {
     expect(container.querySelector("input[type='checkbox']")).toBeInTheDocument();
   });
 
-  // ── selecionarTodosItensDoDocumentoRow ──
+  // selecionarTodosItensDoDocumentoRow
 
   it("selecionarTodosItensDoDocumentoRow retorna checkbox para a linha", async () => {
     setup();
@@ -298,7 +298,7 @@ describe("AcertosDocumentos", () => {
     expect(container.querySelector("input[type='checkbox']")).toBeInTheDocument();
   });
 
-  // ── rowExpansionTemplateDocumentos ──
+  // rowExpansionTemplateDocumentos
 
   it("rowExpansionTemplateDocumentos retorna undefined para data sem solicitacoes", async () => {
     setup();
@@ -566,7 +566,7 @@ describe("AcertosDocumentos", () => {
     expect(getByTestId("botoes-detalhes")).toBeInTheDocument();
   });
 
-  // ── tagJustificativa no rowExpansionTemplateDocumentos ──
+  // tagJustificativa no rowExpansionTemplateDocumentos
 
   it("rowExpansionTemplateDocumentos usa tagJustificativa para exibir status do acerto", async () => {
     setup();
@@ -602,7 +602,7 @@ describe("AcertosDocumentos", () => {
     expect(tagElements[0].textContent).toBe("Realizado");
   });
 
-  // ── limparDocumentoStatus ──
+  // limparDocumentoStatus
 
   it("limparDocumentoStatus chama postLimparStatusDocumentoPrestacaoConta", async () => {
     setup();
@@ -620,7 +620,7 @@ describe("AcertosDocumentos", () => {
     });
   });
 
-  // ── marcarDocumentoComoRealizado ──
+  // marcarDocumentoComoRealizado
 
   it("marcarDocumentoComoRealizado chama postMarcarComoRealizadoDocumentoPrestacaoConta", async () => {
     setup();
@@ -659,7 +659,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── justificarNaoRealizacaoDocumentos ──
+  // justificarNaoRealizacaoDocumentos
 
   it("justificarNaoRealizacaoDocumentos chama postJustificarNaoRealizacaoDocumentoPrestacaoConta", async () => {
     setup();
@@ -698,7 +698,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── acaoCancelar ──
+  // acaoCancelar
 
   it("acaoCancelar redefine quantidadeSelecionada para 0", async () => {
     setup();
@@ -716,7 +716,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── ModalRestaurarJustificativa ──
+  // ModalRestaurarJustificativa
 
   it("ModalRestaurarJustificativa não está visível inicialmente", async () => {
     setup();
@@ -871,7 +871,7 @@ describe("AcertosDocumentos", () => {
     });
   });
 
-  // ── acoesDisponiveis ──
+  // acoesDisponiveis
 
   it("acoesDisponiveis retorna PENDENTE=true quando todos selecionados têm status PENDENTE", async () => {
     setup();
@@ -887,7 +887,7 @@ describe("AcertosDocumentos", () => {
     expect(acoes).toHaveProperty("REALIZADO");
   });
 
-  // ── expanded rows e localStorage ──
+  // expanded rows e localStorage
 
   it("salvaEstadoExpandedRowsDocumentosLocalStorage é chamado ao setar expandedRows", async () => {
     setup();
@@ -907,7 +907,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── JSX tree helper ──
+  // JSX tree helper
   // Traverses a React JSX tree and returns the first element matching predicate
   const findInJSX = (jsx, predicate) => {
     if (jsx === null || jsx === undefined || typeof jsx !== "object" || !jsx.props)
@@ -923,7 +923,7 @@ describe("AcertosDocumentos", () => {
     return null;
   };
 
-  // ── Seleção global ──
+  // Seleção global
 
   it("selecionarTodosItensDosDocumentosGlobal retorna input com checked=false inicialmente", async () => {
     setup();
@@ -941,7 +941,7 @@ describe("AcertosDocumentos", () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  // ── selecionarTodosGlobal ──
+  // selecionarTodosGlobal
 
   it("selecionarTodosGlobal seleciona todos os acertos ao ativar o checkbox global", async () => {
     setup();
@@ -989,7 +989,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── tratarSelecionado (checkbox de linha da tabela) ──
+  // tratarSelecionado (checkbox de linha da tabela)
 
   it("tratarSelecionado incrementa quantidadeSelecionada ao marcar uma linha", async () => {
     setup();
@@ -1037,7 +1037,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── tratarSelecionadoIndividual (checkbox de acerto individual na expansão) ──
+  // tratarSelecionadoIndividual (checkbox de acerto individual na expansão)
 
   it("tratarSelecionadoIndividual incrementa quantidadeSelecionada ao marcar acerto individual", async () => {
     setup();
@@ -1063,7 +1063,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── acoesDisponiveis - todas as combinações de status ──
+  // acoesDisponiveis - todas as combinações de status
 
   const makeDocumento = (statuses) => ({
     uuid: "doc-uuid",
@@ -1150,7 +1150,7 @@ describe("AcertosDocumentos", () => {
     await selecionarTodosECheckarAcoes("JUSTIFICADO_E_PENDENTE");
   });
 
-  // ── acaoCancelar reseta seleção ──
+  // acaoCancelar reseta seleção
 
   it("acaoCancelar zera quantidadeSelecionada após seleção", async () => {
     setup();
@@ -1178,7 +1178,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── handleChangeTextareaJustificativa + salvarJustificativa ──
+  // handleChangeTextareaJustificativa + salvarJustificativa
 
   it("handleChangeTextareaJustificativa atualiza estado ao digitar na textarea de justificativa", async () => {
     setup();
@@ -1277,7 +1277,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── handleChangeTextareaEsclarecimentoDocumento + marcarComoEsclarecido ──
+  // handleChangeTextareaEsclarecimentoDocumento + marcarComoEsclarecido
 
   it("handleChangeTextareaEsclarecimentoDocumento atualiza estado ao digitar esclarecimento", async () => {
     setup();
@@ -1376,7 +1376,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── handleChangeTextareaJustificativaAdicionais + salvarJustificativasAdicionais ──
+  // handleChangeTextareaJustificativaAdicionais + salvarJustificativasAdicionais
 
   it("handleChangeTextareaJustificativaAdicionais atualiza estado ao digitar", async () => {
     setup();
@@ -1479,7 +1479,7 @@ describe("AcertosDocumentos", () => {
     );
   });
 
-  // ── Tratamento de erros nos serviços ──
+  // Tratamento de erros nos serviços
 
   it("limparDocumentoStatus não quebra quando postLimparStatusDocumentoPrestacaoConta rejeita", async () => {
     postLimparStatusDocumentoPrestacaoConta.mockRejectedValue(new Error("falha"));
@@ -1528,7 +1528,7 @@ describe("AcertosDocumentos", () => {
     ).resolves.not.toThrow();
   });
 
-  // ── possuiSolicitacaoEsclarecimento / possuiSolicitacaoEdicaoInformacao com null ──
+  // possuiSolicitacaoEsclarecimento / possuiSolicitacaoEdicaoInformacao com null
 
   it("rowExpansionTemplateDocumentos não exibe esclarecimento para acerto com tipo null", async () => {
     setup();
@@ -1560,7 +1560,7 @@ describe("AcertosDocumentos", () => {
     expect(queryByText("Justificativas e informações adicionais")).not.toBeInTheDocument();
   });
 
-  // ── verificaDisableRestaurarJustificativa branches ──
+  // verificaDisableRestaurarJustificativa branches
 
   it("botão Restaurar Justificativas está desabilitado quando justificativa é igual à original", async () => {
     setup();
@@ -1640,7 +1640,7 @@ describe("AcertosDocumentos", () => {
     expect(queryByText("Restaurar Justificativas")).not.toBeInTheDocument();
   });
 
-  // ── useEffect: expanded rows a partir do localStorage ──
+  // useEffect: expanded rows a partir do localStorage
 
   it("expande linhas conforme expanded salvo no localStorage quando correspondem aos documentos", async () => {
     meapcservice.getAnaliseDreUsuarioLogado.mockReturnValue({
@@ -1662,7 +1662,7 @@ describe("AcertosDocumentos", () => {
     });
   });
 
-  // ── limparDocumentoStatus com selecionados ──
+  // limparDocumentoStatus com selecionados
 
   it("limparDocumentoStatus envia uuids dos acertos selecionados", async () => {
     setup();

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/__tests__/index.test.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/__tests__/index.test.js
@@ -90,7 +90,7 @@ const mockStore = createStore((state = {}, action) => {
   }
 });
 
-// ───────────────────────── helpers ─────────────────────────
+// helpers
 
 const mockContas = [{ uuid: 'conta-uuid', tipo_conta: { nome: 'Cheque' } }];
 const mockContasMultiplas = [
@@ -211,7 +211,7 @@ const mockLancamentosComMensagemInativaEExterno = [{
   }
 }];
 
-// ── Helper para criar acertos com status específico ──────────────────────────
+// Helper para criar acertos com status específico
 const makeAcerto = (uuid, status) => ({
   uuid,
   ordem: 1,
@@ -323,7 +323,7 @@ function setupDefaultMocks(contas = mockContas, lancamentos = mockLancamentos, a
 
 const mockNavigate = jest.fn();
 
-// ───────────────────────── tests ─────────────────────────
+// tests
 
 describe('AcertosLancamentos', () => {
   const defaultProps = {
@@ -376,7 +376,7 @@ describe('AcertosLancamentos', () => {
     return null;
   };
 
-  // ── Render inicial ──────────────────────────────────────
+  // Render inicial
 
   describe('Render e carregamento inicial', () => {
     it('renderiza o loading inicialmente', () => {
@@ -419,7 +419,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Seleção de conta ────────────────────────────────────
+  // Seleção de conta
 
   describe('Seleção de conta', () => {
     it('usa conta salva no estado quando disponível', async () => {
@@ -489,7 +489,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Troca de aba ────────────────────────────────────────
+  // Troca de aba
 
   describe('Troca de aba (abas nativas)', () => {
     it('renderiza abas nativas com as contas', async () => {
@@ -539,7 +539,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Ações na tabela ─────────────────────────────────────
+  // Ações na tabela
 
   describe('Ação: limparStatus', () => {
     it('chama postLimparStatusLancamentoPrestacaoConta', async () => {
@@ -698,7 +698,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Checkboxes e seleção ────────────────────────────────
+  // Checkboxes e seleção
 
   describe('Checkboxes e seleção', () => {
     it('selecionarTodosItensDosLancamentosGlobal retorna um checkbox', async () => {
@@ -777,7 +777,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── rowExpansionTemplateLancamentos ─────────────────────
+  // rowExpansionTemplateLancamentos
 
   describe('rowExpansionTemplateLancamentos', () => {
     it('retorna undefined quando não há acertos na solicitacao', async () => {
@@ -1001,7 +1001,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Navegação ───────────────────────────────────────────
+  // Navegação
 
   describe('Navegação', () => {
     it('navega para detalhe ao clicar em "Editar acertos solicitados"', async () => {
@@ -1082,7 +1082,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Props passadas para componentes filhos ───────────────
+  // Props passadas para componentes filhos
 
   describe('Props passadas para TabelaAcertosLancamentos', () => {
     it('passa lancamentosAjustes corretamente', async () => {
@@ -1143,7 +1143,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Permissões ──────────────────────────────────────────
+  // Permissões
 
   describe('Permissões', () => {
     it('não permite edição quando usuário não tem permissão (editavel false)', async () => {
@@ -1156,7 +1156,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Interações com checkboxes (detalhe) ─────────────────
+  // Interações com checkboxes (detalhe)
 
   describe('Interações avançadas com checkboxes', () => {
     it('selecionarTodosGlobal desseleciona todos quando todos já estavam selecionados', async () => {
@@ -1341,7 +1341,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Interações na expansão (textareas e botões de salvar) ─
+  // Interações na expansão (textareas e botões de salvar)
 
   describe('Interações na expansão: justificativa e esclarecimento', () => {
     it('handleChangeTextareaJustificativa atualiza o estado ao digitar na textarea', async () => {
@@ -1587,7 +1587,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── acoesDisponiveis: todas as combinações de status ────────────────────────
+  // acoesDisponiveis: todas as combinações de status
 
   describe('acoesDisponiveis: combinações de status', () => {
     const selecionarTodos = async () => {
@@ -1668,7 +1668,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Navegação: Crédito ───────────────────────────────────
+  // Navegação: Crédito
 
   describe('Navegação: Crédito', () => {
     it('navega para edição de receita ao clicar em "Ir para receita"', async () => {
@@ -1720,7 +1720,7 @@ describe('AcertosLancamentos', () => {
     });
   });
 
-  // ── Rows expandidas ─────────────────────────────────────
+  // Rows expandidas
 
   describe('Estado de linhas expandidas', () => {
     it('restaura linhas expandidas do localStorage ao carregar lancamentos', async () => {

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisForm.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisForm.test.js
@@ -22,10 +22,10 @@ import {
 import { getTabelaAssociacoes } from '../../../../services/dres/Associacoes.service';
 import { valida_cpf_cnpj } from '../../../../utils/ValidacoesAdicionaisFormularios';
 
-// ── Capture props passed to child ──────────────────────────────────────────────
+// Capture props passed to child
 let capturedFormikProps = null;
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../../../services/visoes.service', () => ({
     visoesService: { getItemUsuarioLogado: jest.fn() },
 }));
@@ -68,7 +68,7 @@ jest.mock('../GestaoDePerfisFormFormik', () => ({
     },
 }));
 
-// ── Test data ──────────────────────────────────────────────────────────────────
+// Test data
 const MOCK_VISOES_API = [
     { id: '1', nome: 'SME' },
     { id: '2', nome: 'DRE' },
@@ -97,7 +97,7 @@ const MOCK_USUARIO = {
     visoes: [{ nome: 'SME' }],
 };
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const setVisoesService = (visao = 'SME') => {
     visoesService.getItemUsuarioLogado.mockImplementation((key) => {
         if (key === 'visao_selecionada.nome') return visao;
@@ -152,7 +152,7 @@ const renderComponent = (visao = 'SME', idUsuario = null) => {
 const waitForRender = () =>
     waitFor(() => expect(screen.getByTestId('gestao-perfis-formik')).toBeInTheDocument());
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<GestaoDePerfisForm>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -161,7 +161,7 @@ describe('<GestaoDePerfisForm>', () => {
         window.location = { assign: jest.fn() };
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('renderiza título e formik para visão SME', async () => {
             setupDefaultMocks('SME');
@@ -204,7 +204,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── exibeGrupos ───────────────────────────────────────────────────────────
+    // exibeGrupos
     describe('exibeGrupos', () => {
         it('chama getGrupos com a visão atual para SME', async () => {
             setupDefaultMocks('SME');
@@ -276,7 +276,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── exibeVisoes ───────────────────────────────────────────────────────────
+    // exibeVisoes
     describe('exibeVisoes', () => {
         it('configura visões corretamente para SME sem unidades vinculadas', async () => {
             setupDefaultMocks('SME');
@@ -313,7 +313,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── pesquisaPermissaoExibicaoVisao ────────────────────────────────────────
+    // pesquisaPermissaoExibicaoVisao
     describe('pesquisaPermissaoExibicaoVisao', () => {
         it('retorna editavel correto para visão SME (todas editáveis)', async () => {
             setupDefaultMocks('SME');
@@ -343,7 +343,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── serviceTemUnidade ─────────────────────────────────────────────────────
+    // serviceTemUnidade
     describe('serviceTemUnidadeDre / serviceTemUnidadeUE', () => {
         it('serviceTemUnidadeDre retorna unidade DRE quando existe', async () => {
             setupDefaultMocks('SME');
@@ -385,7 +385,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── carregaDadosUsuario ───────────────────────────────────────────────────
+    // carregaDadosUsuario
     describe('carregaDadosUsuario', () => {
         it('carrega dados do usuário quando id_usuario está presente', async () => {
             setupDefaultMocks('SME');
@@ -430,7 +430,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── handleCloseUsuarioNaoCadastrado ───────────────────────────────────────
+    // handleCloseUsuarioNaoCadastrado
     describe('handleCloseUsuarioNaoCadastrado', () => {
         it('chama resetForm e fecha o modal', async () => {
             setupDefaultMocks('SME');
@@ -445,7 +445,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── handleCloseDeletePerfil ───────────────────────────────────────────────
+    // handleCloseDeletePerfil
     describe('handleCloseDeletePerfil', () => {
         it('fecha o modal de confirmação de delete', async () => {
             setupDefaultMocks('SME');
@@ -458,7 +458,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── onDeletePerfilTrue ────────────────────────────────────────────────────
+    // onDeletePerfilTrue
     describe('onDeletePerfilTrue', () => {
         it('chama deleteUsuario e redireciona ao sucesso', async () => {
             setupDefaultMocks('SME');
@@ -484,7 +484,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── handleChangeTipoUnidade ───────────────────────────────────────────────
+    // handleChangeTipoUnidade
     describe('handleChangeTipoUnidade', () => {
         const emptyValues = { unidades_vinculadas: [] };
 
@@ -554,7 +554,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── vinculaUnidadeUsuario ─────────────────────────────────────────────────
+    // vinculaUnidadeUsuario
     describe('vinculaUnidadeUsuario', () => {
         it('vincula unidade ao usuário com sucesso', async () => {
             setupDefaultMocks('SME');
@@ -602,7 +602,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── desvinculaUnidadeUsuario ──────────────────────────────────────────────
+    // desvinculaUnidadeUsuario
     describe('desvinculaUnidadeUsuario', () => {
         it('desvincula unidade do usuário com sucesso', async () => {
             setupDefaultMocks('SME');
@@ -640,7 +640,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── handleChangeGrupo ─────────────────────────────────────────────────────
+    // handleChangeGrupo
     describe('handleChangeGrupo', () => {
         it('adiciona grupo quando checked=true', async () => {
             setupDefaultMocks('SME');
@@ -673,7 +673,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── idUsuarioCondicionalMask ──────────────────────────────────────────────
+    // idUsuarioCondicionalMask
     describe('idUsuarioCondicionalMask', () => {
         it('retorna mask de 7 dígitos para servidor', async () => {
             setupDefaultMocks('SME');
@@ -690,7 +690,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── evitaDuplicacao ───────────────────────────────────────────────────────
+    // evitaDuplicacao
     describe('evitaDuplicacao', () => {
         it('remove grupos duplicados combinando visões', async () => {
             setupDefaultMocks('SME');
@@ -725,7 +725,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── buscaTipoUnidadeVisaoUE ───────────────────────────────────────────────
+    // buscaTipoUnidadeVisaoUE
     describe('buscaTipoUnidadeVisaoUE', () => {
         it('trata erro ao buscar unidade UE sem lançar exceção', async () => {
             setupDefaultMocks('UE');
@@ -736,7 +736,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── validacoesPersonalizadas ──────────────────────────────────────────────
+    // validacoesPersonalizadas
     describe('validacoesPersonalizadas', () => {
         it('retorna erro quando username está vazio', async () => {
             setupDefaultMocks('SME');
@@ -978,7 +978,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── handleSubmitPerfisForm ────────────────────────────────────────────────
+    // handleSubmitPerfisForm
     describe('handleSubmitPerfisForm', () => {
         it('edita usuário com sucesso quando values.id existe', async () => {
             setupDefaultMocks('SME');
@@ -1250,7 +1250,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── serviceUsuarioCadastrado com info_core_sso (linhas 365-367) ───────────
+    // serviceUsuarioCadastrado com info_core_sso (linhas 365-367)
     describe('serviceUsuarioCadastrado com info_core_sso preenchido', () => {
         it('SME: preenche name e email quando info_core_sso existe', async () => {
             setupDefaultMocks('SME');
@@ -1332,7 +1332,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── serviceVisaoUE branches ───────────────────────────────────────────────
+    // serviceVisaoUE branches
     describe('serviceVisaoUE branches adicionais', () => {
         it('não-servidor + não membro da associação exibe modal (linhas 397-401)', async () => {
             setupDefaultMocks('UE');
@@ -1433,7 +1433,7 @@ describe('<GestaoDePerfisForm>', () => {
         });
     });
 
-    // ── getEstadoInicialVisoesChecked e acessoCadastrarUnidade ────────────────
+    // getEstadoInicialVisoesChecked e acessoCadastrarUnidade
     describe('getEstadoInicialVisoesChecked / getEstadoInicialGruposChecked / acessoCadastrarUnidade', () => {
         it('getEstadoInicialVisoesChecked percorre elementos name=visoes (linhas 717-718)', async () => {
             setupDefaultMocks('SME');

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisFormAutocomplete.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisFormAutocomplete.test.js
@@ -1,7 +1,7 @@
 import { render, act } from '@testing-library/react';
 import GestaoDePerfisFormAutocomplete from '../GestaoDePerfisFormAutocomplete';
 
-// ── Captura de props do AutoComplete ───────────────────────────────────────────
+// Captura de props do AutoComplete
 let capturedAutoCompleteProps = null;
 
 jest.mock('primereact/autocomplete', () => ({
@@ -27,7 +27,7 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faSearch: 'faSearch',
 }));
 
-// ── Dados ──────────────────────────────────────────────────────────────────────
+// Dados
 const ACOES_MOCK = [
     { nome: 'Escola Alfa', id: 1 },
     { nome: 'Escola Beta', id: 2 },
@@ -42,7 +42,7 @@ const makeProps = (overrides = {}) => ({
     ...overrides,
 });
 
-// ── Setup ──────────────────────────────────────────────────────────────────────
+// Setup
 beforeEach(() => {
     capturedAutoCompleteProps = null;
     jest.useFakeTimers();
@@ -55,7 +55,7 @@ afterEach(() => {
 // ══════════════════════════════════════════════════════════════════════════════
 describe('GestaoDePerfisFormAutocomplete', () => {
 
-    // ── Renderização ───────────────────────────────────────────────────────────
+    // Renderização
     describe('renderização', () => {
         it('renderiza sem erros e expõe props ao AutoComplete', () => {
             render(<GestaoDePerfisFormAutocomplete {...makeProps()} />);
@@ -93,7 +93,7 @@ describe('GestaoDePerfisFormAutocomplete', () => {
         });
     });
 
-    // ── disabled e placeholder ─────────────────────────────────────────────────
+    // disabled e placeholder
     describe('disabled e placeholder', () => {
         it('disabled=false quando todasAsAcoesAutoComplete tem itens', () => {
             render(<GestaoDePerfisFormAutocomplete {...makeProps()} />);
@@ -118,7 +118,7 @@ describe('GestaoDePerfisFormAutocomplete', () => {
         });
     });
 
-    // ── searchAcao (completeMethod) ────────────────────────────────────────────
+    // searchAcao (completeMethod)
     describe('searchAcao (completeMethod com setTimeout de 250ms)', () => {
         it('não atualiza suggestions antes de 250ms', () => {
             render(<GestaoDePerfisFormAutocomplete {...makeProps()} />);
@@ -200,7 +200,7 @@ describe('GestaoDePerfisFormAutocomplete', () => {
         });
     });
 
-    // ── onChange ───────────────────────────────────────────────────────────────
+    // onChange
     describe('onChange', () => {
         it('atualiza selectedAcao quando onChange é chamado com um objeto', () => {
             render(<GestaoDePerfisFormAutocomplete {...makeProps()} />);
@@ -228,7 +228,7 @@ describe('GestaoDePerfisFormAutocomplete', () => {
         });
     });
 
-    // ── onSelect ───────────────────────────────────────────────────────────────
+    // onSelect
     describe('onSelect', () => {
         it('chama recebeAcaoAutoComplete com o valor e o setFieldValue corretos', () => {
             const recebeAcaoAutoComplete = jest.fn();

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisFormFormik.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/GestaoDePerfisFormFormik.test.js
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { GestaoDePerfisFormFormik } from '../GestaoDePerfisFormFormik';
 
-// ── FontAwesome ────────────────────────────────────────────────────────────────
+// FontAwesome
 jest.mock('@fortawesome/react-fontawesome', () => ({
     FontAwesomeIcon: () => null,
 }));
@@ -10,16 +10,16 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faTrashAlt: 'faTrashAlt',
 }));
 
-// ── react-text-mask → input simples ───────────────────────────────────────────
+// react-text-mask → input simples
 jest.mock('react-text-mask', () =>
     // eslint-disable-next-line react/prop-types
     ({ mask, guide, showMask, ...props }) => <input {...props} />
 );
 
-// ── Autocomplete ──────────────────────────────────────────────────────────────
+// Autocomplete
 jest.mock('../GestaoDePerfisFormAutocomplete', () => () => <div data-testid="autocomplete" />);
 
-// ── Modais — expostos com botões de teste ─────────────────────────────────────
+// Modais — expostos com botões de teste
 jest.mock('../ModalUsuarioNaoCadastrado', () => ({
     // eslint-disable-next-line react/prop-types
     ModalUsuarioNaoCadastrado: ({ show, handleClose, onCadastrarTrue }) =>
@@ -58,7 +58,7 @@ jest.mock('../ModalInfo', () => ({
         ) : null,
 }));
 
-// ── Dados base ─────────────────────────────────────────────────────────────────
+// Dados base
 const VISOES_MOCK = [
     { nome: 'DRE', id: 'visao-dre-id', editavel: true },
     { nome: 'SME', id: 'visao-sme-id', editavel: true },
@@ -121,7 +121,7 @@ const STATE_WITH_ID_UE = {
     ],
 };
 
-// ── Factory de props ───────────────────────────────────────────────────────────
+// Factory de props
 const makeProps = (overrides = {}) => ({
     initPerfisForm: DEFAULT_INIT,
     setStatePerfisForm: jest.fn(),
@@ -168,7 +168,7 @@ const makeProps = (overrides = {}) => ({
     ...overrides,
 });
 
-// ── Setup ──────────────────────────────────────────────────────────────────────
+// Setup
 beforeEach(() => {
     delete window.location;
     window.location = { assign: jest.fn() };
@@ -177,7 +177,7 @@ beforeEach(() => {
 // ══════════════════════════════════════════════════════════════════════════════
 describe('GestaoDePerfisFormFormik', () => {
 
-    // ── Título ─────────────────────────────────────────────────────────────────
+    // Título
     describe('título do formulário', () => {
         it('exibe "Adicionar usuário" quando statePerfisForm.id é nulo', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -190,7 +190,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Botões fixos ───────────────────────────────────────────────────────────
+    // Botões fixos
     describe('botões Salvar e Voltar', () => {
         it('sempre exibe o botão Salvar', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -209,7 +209,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Botão Desvincular ──────────────────────────────────────────────────────
+    // Botão Desvincular
     describe('botão Desvincular', () => {
         it('não exibe o botão Desvincular quando statePerfisForm.id é nulo', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -290,7 +290,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Botão Deletar usuário ──────────────────────────────────────────────────
+    // Botão Deletar usuário
     describe('botão Deletar usuário', () => {
         it('não exibe quando statePerfisForm.id é nulo', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -345,7 +345,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Campo tipo de usuário ──────────────────────────────────────────────────
+    // Campo tipo de usuário
     describe('campo tipo de usuário (e_servidor)', () => {
         it('renderiza as opções de tipo de usuário', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -387,7 +387,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Campo username ─────────────────────────────────────────────────────────
+    // Campo username
     describe('campo username (MaskedInput)', () => {
         it('está desabilitado quando e_servidor está vazio', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -437,7 +437,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Campo Nome ─────────────────────────────────────────────────────────────
+    // Campo Nome
     describe('campo Nome', () => {
         it('é readOnly quando bloquearCampoName é true', () => {
             const { container } = render(<GestaoDePerfisFormFormik {...makeProps({ bloquearCampoName: true })} />);
@@ -458,7 +458,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Campo Email ────────────────────────────────────────────────────────────
+    // Campo Email
     describe('campo Email', () => {
         it('renderiza o campo de email com placeholder', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -474,7 +474,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Checkboxes de Visões ───────────────────────────────────────────────────
+    // Checkboxes de Visões
     describe('checkboxes de visões', () => {
         it('renderiza um checkbox por visão', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -515,7 +515,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Checkboxes de Grupos ───────────────────────────────────────────────────
+    // Checkboxes de Grupos
     describe('checkboxes de grupos', () => {
         it('renderiza checkboxes de grupos filtrados por evitaDuplicacao', () => {
             const evitaDuplicacao = jest.fn((g) => g);
@@ -555,7 +555,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Seção de unidades ──────────────────────────────────────────────────────
+    // Seção de unidades
     describe('seção de unidades vinculadas', () => {
         it('exibe "Salve o usuário..." quando visao não é UE e id é nulo', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -581,7 +581,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── FieldArray ─────────────────────────────────────────────────────────────
+    // FieldArray
     describe('FieldArray de unidades vinculadas', () => {
         it('exibe o botão "+ Adicionar" quando id existe e visao não é UE', () => {
             render(<GestaoDePerfisFormFormik {...makeProps({ statePerfisForm: STATE_WITH_ID })} />);
@@ -740,7 +740,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Erros Yup na submissão ─────────────────────────────────────────────────
+    // Erros Yup na submissão
     describe('erros de validação Yup', () => {
         it('exibe erro de e_servidor obrigatório ao submeter formulário vazio', async () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);
@@ -797,7 +797,7 @@ describe('GestaoDePerfisFormFormik', () => {
         });
     });
 
-    // ── Modais ─────────────────────────────────────────────────────────────────
+    // Modais
     describe('ModalUsuarioNaoCadastrado', () => {
         it('não exibe quando showModalUsuarioNaoCadastrado é false', () => {
             render(<GestaoDePerfisFormFormik {...makeProps()} />);

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/ModalConfirmDeletePerfil.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/ModalConfirmDeletePerfil.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalConfirmDeletePerfil } from '../ModalConfirmDeletePerfil';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,
@@ -43,7 +43,7 @@ jest.mock('../../ModalBootstrap', () => ({
         ) : null,
 }));
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (overrides = {}) => {
     const props = {
         show: true,
@@ -61,13 +61,13 @@ const renderComponent = (overrides = {}) => {
     return { props, ...result };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ModalConfirmDeletePerfil>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('renderiza o modal quando show=true', () => {
             renderComponent();
@@ -122,7 +122,7 @@ describe('<ModalConfirmDeletePerfil>', () => {
         });
     });
 
-    // ── Interações ─────────────────────────────────────────────────────────────
+    // Interações
     describe('Interações', () => {
         it('chama handleClose ao clicar no primeiro botão', () => {
             const { props } = renderComponent();

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/ModalInfo.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/ModalInfo.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalInfo } from '../ModalInfo';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,
@@ -31,7 +31,7 @@ jest.mock('../../ModalBootstrap', () => ({
         ) : null,
 }));
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (overrides = {}) => {
     const props = {
         show: true,
@@ -46,13 +46,13 @@ const renderComponent = (overrides = {}) => {
     return { props, ...result };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ModalInfo>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('renderiza o modal quando show=true', () => {
             renderComponent();
@@ -85,7 +85,7 @@ describe('<ModalInfo>', () => {
         });
     });
 
-    // ── Interações ─────────────────────────────────────────────────────────────
+    // Interações
     describe('Interações', () => {
         it('chama handleClose ao clicar no primeiro botão', () => {
             const { props } = renderComponent();

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/ModalPerfisForm.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/ModalPerfisForm.test.js
@@ -4,7 +4,7 @@ import { ModalPerfisForm } from '../ModalPerfisForm';
 import { visoesService } from '../../../../services/visoes.service';
 import { getConsultarUsuario } from '../../../../services/GestaoDePerfis.service';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../ModalBootstrap', () => ({
     ModalBootstrapFormPerfis: ({ show, titulo, bodyText }) =>
         show ? (
@@ -31,7 +31,7 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faTrash: 'faTrash',
 }));
 
-// ── Test data ──────────────────────────────────────────────────────────────────
+// Test data
 const DEFAULT_GRUPOS = [
     { id: 1, nome: 'Grupo SME' },
     { id: 2, nome: 'Grupo DRE' },
@@ -46,7 +46,7 @@ const makeStatePerfisForm = (overrides = {}) => ({
     ...overrides,
 });
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (overrides = {}) => {
     const props = {
         show: true,
@@ -63,7 +63,7 @@ const renderComponent = (overrides = {}) => {
     return { props, ...result };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ModalPerfisForm>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -74,7 +74,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('não renderiza nada quando show=false', () => {
             renderComponent({ show: false });
@@ -167,7 +167,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── Interações de botão ────────────────────────────────────────────────────
+    // Interações de botão
     describe('Interações de botão', () => {
         it('chama handleClose ao clicar em "Cancelar"', () => {
             const { props } = renderComponent();
@@ -182,7 +182,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── Mudanças de campos ─────────────────────────────────────────────────────
+    // Mudanças de campos
     describe('Mudanças de campos (handleChange)', () => {
         it('chama handleChange ao alterar tipo_usuario', async () => {
             const { props } = renderComponent();
@@ -227,7 +227,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── validateFormPerfis ─────────────────────────────────────────────────────
+    // validateFormPerfis
     describe('validateFormPerfis', () => {
         // Helper: trigger Formik's validate by changing a field value.
         // We change nome_usuario to a known value and await the async cycle.
@@ -360,7 +360,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── Validações Yup ─────────────────────────────────────────────────────────
+    // Validações Yup
     describe('Validações Yup', () => {
         it('exibe erro de tipo_usuario ao submeter sem preenchê-lo', async () => {
             // nome_usuario and grupo_acesso provided so only tipo_usuario fails Yup
@@ -413,7 +413,7 @@ describe('<ModalPerfisForm>', () => {
         });
     });
 
-    // ── Submissão do formulário ────────────────────────────────────────────────
+    // Submissão do formulário
     describe('Submissão do formulário', () => {
         it('chama onSubmit ao submeter formulário com dados válidos', async () => {
             visoesService.getItemUsuarioLogado.mockReturnValue('SME');

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/ModalUsuarioCadastradoVinculado.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/ModalUsuarioCadastradoVinculado.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalUsuarioCadastradoVinculado } from '../ModalUsuarioCadastradoVinculado';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,
@@ -31,7 +31,7 @@ jest.mock('../../ModalBootstrap', () => ({
         ) : null,
 }));
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (overrides = {}) => {
     const props = {
         show: true,
@@ -46,13 +46,13 @@ const renderComponent = (overrides = {}) => {
     return { props, ...result };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ModalUsuarioCadastradoVinculado>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('renderiza o modal quando show=true', () => {
             renderComponent();
@@ -85,7 +85,7 @@ describe('<ModalUsuarioCadastradoVinculado>', () => {
         });
     });
 
-    // ── Interações ─────────────────────────────────────────────────────────────
+    // Interações
     describe('Interações', () => {
         it('chama handleClose ao clicar no primeiro botão', () => {
             const { props } = renderComponent();

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/ModalUsuarioNaoCadastrado.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/ModalUsuarioNaoCadastrado.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalUsuarioNaoCadastrado } from '../ModalUsuarioNaoCadastrado';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,
@@ -41,7 +41,7 @@ jest.mock('../../ModalBootstrap', () => ({
         ) : null,
 }));
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (overrides = {}) => {
     const props = {
         show: true,
@@ -59,13 +59,13 @@ const renderComponent = (overrides = {}) => {
     return { props, ...result };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ModalUsuarioNaoCadastrado>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    // ── Renderização básica ────────────────────────────────────────────────────
+    // Renderização básica
     describe('Renderização básica', () => {
         it('renderiza o modal quando show=true', () => {
             renderComponent();
@@ -108,7 +108,7 @@ describe('<ModalUsuarioNaoCadastrado>', () => {
         });
     });
 
-    // ── Interações ─────────────────────────────────────────────────────────────
+    // Interações
     describe('Interações', () => {
         it('chama handleClose ao clicar no primeiro botão', () => {
             const { props } = renderComponent();

--- a/src/componentes/Globais/GestaoDePerfis/__tests__/index.test.js
+++ b/src/componentes/Globais/GestaoDePerfis/__tests__/index.test.js
@@ -6,11 +6,11 @@ import { getGrupos, getUsuarios, getUsuariosFiltros } from '../../../../services
 import { visoesService } from '../../../../services/visoes.service';
 import { barraMensagemCustom } from '../../BarraMensagem';
 
-// ── Captured props ─────────────────────────────────────────────────────────────
+// Captured props
 let mockFormFiltrosProps = null;
 let mockBodyFns = {};
 
-// ── Mocks ─────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../../../services/GestaoDePerfis.service', () => ({
     getGrupos: jest.fn(),
     getUsuarios: jest.fn(),
@@ -87,7 +87,7 @@ jest.mock('../../UI/Button/EditIconButton', () => ({
     ),
 }));
 
-// ── Test data ──────────────────────────────────────────────────────────────────
+// Test data
 const UNIDADE_UUID = 'unidade-uuid-123';
 
 const GRUPOS_MOCK = [
@@ -108,7 +108,7 @@ const USUARIOS_MOCK = [
     },
 ];
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const renderComponent = (visao = 'UE') => {
     visoesService.getItemUsuarioLogado.mockImplementation((key) => {
         if (key === 'visao_selecionada.nome') return visao;
@@ -130,7 +130,7 @@ const renderAndWaitForLoad = async (visao = 'UE', usuarios = USUARIOS_MOCK) => {
     return result;
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('GestaoDePerfis', () => {
     beforeEach(() => {
         jest.clearAllMocks();

--- a/src/componentes/Globais/GestaoDeUsuariosAdicionarUnidade/components/__tests__/ListaDeUnidades.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosAdicionarUnidade/components/__tests__/ListaDeUnidades.test.js
@@ -6,13 +6,13 @@ import { useUnidadesDisponiveisInclusao } from '../../hooks/useUnidadesDisponive
 import { useIncluirUnidade } from '../../hooks/useIncluirUnidade';
 import { useUsuario } from '../../../GestaoDeUsuariosForm/hooks/useUsuario';
 
-// ── Router ────────────────────────────────────────────────────────────────────
+// Router
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useParams: () => ({ id_usuario: '42' }),
 }));
 
-// ── Hooks ─────────────────────────────────────────────────────────────────────
+// Hooks
 jest.mock('../../hooks/useUnidadesDisponiveisInclusao', () => ({
     useUnidadesDisponiveisInclusao: jest.fn(),
 }));
@@ -25,7 +25,7 @@ jest.mock('../../../GestaoDeUsuariosForm/hooks/useUsuario', () => ({
     useUsuario: jest.fn(),
 }));
 
-// ── PrimeReact ────────────────────────────────────────────────────────────────
+// PrimeReact
 jest.mock('primereact/datatable', () => ({
     DataTable: (props) => {
         const mockReact = require('react');
@@ -52,7 +52,7 @@ jest.mock('primereact/column', () => ({
     Column: () => null,
 }));
 
-// ── Globais ───────────────────────────────────────────────────────────────────
+// Globais
 jest.mock('../../../../../utils/Loading', () => ({
     __esModule: true,
     default: () => <div data-testid="loading" />,
@@ -80,7 +80,7 @@ jest.mock('../Paginacao', () => ({
 
 jest.mock('../../../../assets/img/img-404.svg', () => 'img-404-mock', { virtual: true });
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// Helpers
 const buildContext = (overrides = {}) => ({
     search: '',
     setSearch: jest.fn(),

--- a/src/componentes/Globais/GestaoDeUsuariosForm/__tests__/index.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/__tests__/index.test.js
@@ -2,22 +2,22 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { GestaoDeUsuariosFormPage } from '../index';
 
-// ── SCSS mock ─────────────────────────────────────────────────────────────────
+// SCSS mock
 jest.mock('../style/gestao-de-usuarios-form.scss', () => ({}));
 
-// ── PaginasContainer mock ─────────────────────────────────────────────────────
+// PaginasContainer mock
 jest.mock('../../../../paginas/PaginasContainer', () => ({
     PaginasContainer: ({ children }) => <div data-testid="paginas-container">{children}</div>,
 }));
 
-// ── GestaoDeUsuariosFormProvider mock ─────────────────────────────────────────
+// GestaoDeUsuariosFormProvider mock
 jest.mock('../context/GestaoDeUsuariosFormProvider', () => ({
     GestaoDeUsuariosFormProvider: ({ children }) => (
         <div data-testid="gestao-usuarios-form-provider">{children}</div>
     ),
 }));
 
-// ── GestaoDeUsuariosFormMain mock ─────────────────────────────────────────────
+// GestaoDeUsuariosFormMain mock
 jest.mock('../components/GestaoDeUsuariosFormMain', () => ({
     GestaoDeUsuariosFormMain: () => <div data-testid="gestao-usuarios-form-main" />,
 }));

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/BarraTopoForm.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/BarraTopoForm.test.js
@@ -3,13 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { BarraTopoForm } from '../BarraTopoForm';
 import { GestaoDeUsuariosFormContext } from '../../context/GestaoDeUsuariosFormProvider';
 
-// ── Navegação mock ────────────────────────────────────────────────────────────
+// Navegação mock
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => jest.fn(),
 }));
 
-// ── BtnVoltar mock ────────────────────────────────────────────────────────────
+// BtnVoltar mock
 jest.mock('../BtnVoltar', () => ({
     BtnVoltar: () => <button data-testid="btn-voltar">Voltar</button>,
 }));

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/BarraTopoListagem.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/BarraTopoListagem.test.js
@@ -4,7 +4,7 @@ import { BarraTopoListagem } from '../BarraTopoListagem';
 import { GestaoDeUsuariosFormContext } from '../../context/GestaoDeUsuariosFormProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-// ── Router mock ───────────────────────────────────────────────────────────────
+// Router mock
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     Link: ({ to, children, className, onClick }) => (
@@ -14,7 +14,7 @@ jest.mock('react-router-dom', () => ({
     ),
 }));
 
-// ── FontAwesome mock ──────────────────────────────────────────────────────────
+// FontAwesome mock
 jest.mock('@fortawesome/react-fontawesome', () => ({
     FontAwesomeIcon: ({ icon }) => <span data-testid={`icon-${icon?.iconName || 'icon'}`} />,
 }));
@@ -23,7 +23,7 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faPlus: { iconName: 'plus' },
 }));
 
-// ── Permissão mock ────────────────────────────────────────────────────────────
+// Permissão mock
 jest.mock('../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios', () => ({
     RetornaSeTemPermissaoEdicaoGestaoUsuarios: jest.fn(),
 }));

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/FormUsuario.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/FormUsuario.test.js
@@ -10,14 +10,14 @@ import { toastCustom } from '../../../ToastCustom';
 import { valida_cpf_cnpj } from '../../../../../utils/ValidacoesAdicionaisFormularios';
 import { RetornaSeTemPermissaoEdicaoGestaoUsuarios } from '../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios';
 
-// ── Router mock ───────────────────────────────────────────────────────────────
+// Router mock
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockNavigate,
 }));
 
-// ── Hooks mocks ───────────────────────────────────────────────────────────────
+// Hooks mocks
 jest.mock('../../hooks/useCreateUsuario', () => ({ useCreateUsuario: jest.fn() }));
 jest.mock('../../hooks/useUpdateUsuario', () => ({ useUpdateUsuario: jest.fn() }));
 jest.mock('../../hooks/useUsuarioStatus', () => ({ useUsuarioStatus: jest.fn() }));
@@ -25,17 +25,17 @@ jest.mock('../../../GestaoDeUsuarios/hooks/useRemoveAcessosUsuario', () => ({
     useRemoveAcessosUsuario: jest.fn(),
 }));
 
-// ── Service mock ──────────────────────────────────────────────────────────────
+// Service mock
 jest.mock('../../../../../services/GestaoDeUsuarios.service', () => ({
     removerAcessosUnidadeBase: jest.fn(),
 }));
 
-// ── Permission mock ───────────────────────────────────────────────────────────
+// Permission mock
 jest.mock('../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios', () => ({
     RetornaSeTemPermissaoEdicaoGestaoUsuarios: jest.fn(),
 }));
 
-// ── Toast mock ────────────────────────────────────────────────────────────────
+// Toast mock
 jest.mock('../../../ToastCustom', () => ({
     toastCustom: {
         ToastCustomSuccess: jest.fn(),
@@ -43,24 +43,24 @@ jest.mock('../../../ToastCustom', () => ({
     },
 }));
 
-// ── Loading mock ──────────────────────────────────────────────────────────────
+// Loading mock
 jest.mock('../../../../../utils/Loading', () => ({
     __esModule: true,
     default: () => <div data-testid="loading" />,
 }));
 
-// ── MaskedInput mock ──────────────────────────────────────────────────────────
+// MaskedInput mock
 jest.mock('react-text-mask', () => ({
     __esModule: true,
     default: ({ mask, guide, showMask, ...props }) => <input {...props} />,
 }));
 
-// ── Validation mock ───────────────────────────────────────────────────────────
+// Validation mock
 jest.mock('../../../../../utils/ValidacoesAdicionaisFormularios', () => ({
     valida_cpf_cnpj: jest.fn(),
 }));
 
-// ── Modal mocks ───────────────────────────────────────────────────────────────
+// Modal mocks
 jest.mock('../ModalConfirmacao', () => ({
     ModalConfirmacao: ({ show, botaoCancelarHandle, botaoConfirmarHandle }) =>
         show ? (
@@ -103,7 +103,7 @@ jest.mock('../../../GestaoDeUsuarios/utils/mensagens-remover-acesso', () => ({
     showMensagemErroAoRemoverAcesso: jest.fn(),
 }));
 
-// ── Context / Render helpers ──────────────────────────────────────────────────
+// Context / Render helpers
 const Modos = {
     INSERT: 'Adicionar Usuário',
     EDIT: 'Editar Usuário',
@@ -136,7 +136,7 @@ const renderComponent = (contextOverrides = {}, props = {}) =>
         </GestaoDeUsuariosFormContext.Provider>
     );
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// Tests
 describe('FormUsuario', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -148,7 +148,7 @@ describe('FormUsuario', () => {
         valida_cpf_cnpj.mockReturnValue(true);
     });
 
-    // ── Renderização básica ───────────────────────────────────────────────────
+    // Renderização básica
     describe('renderização básica', () => {
         it('renderiza o formulário com campos principais', () => {
             const { container } = renderComponent();
@@ -221,7 +221,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Prop usuario → popula formulário ─────────────────────────────────────
+    // Prop usuario → popula formulário
     describe('useEffect: popula valores a partir do prop usuario', () => {
         it('preenche o formulário quando usuario.e_servidor=true', async () => {
             const usuario = {
@@ -253,7 +253,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Navigate após INSERT ──────────────────────────────────────────────────
+    // Navigate após INSERT
     describe('useEffect: navega para novo usuário após INSERT', () => {
         it('navega quando modo=INSERT e resultPost.id existe', async () => {
             useCreateUsuario.mockReturnValue({
@@ -281,7 +281,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── useEffect: usuarioStatus ──────────────────────────────────────────────
+    // useEffect: usuarioStatus
     describe('useEffect: usuarioStatus', () => {
         it('não faz nada quando usuarioStatus é null', async () => {
             renderComponent();
@@ -417,7 +417,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Modal CoreSSO ─────────────────────────────────────────────────────────
+    // Modal CoreSSO
     describe('modal CoreSSO', () => {
         const setupCoreSSOModal = () => {
             useUsuarioStatus.mockReturnValue({
@@ -494,7 +494,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Modal Validação de Acesso ─────────────────────────────────────────────
+    // Modal Validação de Acesso
     describe('modal Validação de Acesso', () => {
         it('fecha o modal de validação ao clicar em Fechar', async () => {
             useUsuarioStatus.mockReturnValue({
@@ -518,7 +518,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Modal Remover Acesso ──────────────────────────────────────────────────
+    // Modal Remover Acesso
     describe('modal Remover Acesso', () => {
         it('abre modal ao clicar em "Remover acesso"', async () => {
             renderComponent({ modo: Modos.EDIT });
@@ -566,7 +566,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── validacoesPersonalizadas ──────────────────────────────────────────────
+    // validacoesPersonalizadas
     describe('validacoesPersonalizadas', () => {
         it('exibe erro quando username está vazio ao blur do select', async () => {
             renderComponent();
@@ -641,7 +641,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── idUsuarioCondicionalMask (via placeholder) ────────────────────────────
+    // idUsuarioCondicionalMask (via placeholder)
     describe('idUsuarioCondicionalMask: placeholder indica máscara correta', () => {
         it('RF placeholder (default) quando e_servidor está vazio', () => {
             renderComponent();
@@ -669,7 +669,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── handleSubmitUsuarioForm ───────────────────────────────────────────────
+    // handleSubmitUsuarioForm
     describe('handleSubmitUsuarioForm', () => {
         const usuarioValido = {
             id: 1,
@@ -800,7 +800,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── onClick nos campos limpa erros ────────────────────────────────────────
+    // onClick nos campos limpa erros
     describe('onClick nos campos: limpa erros', () => {
         it('click no select e_servidor não lança erro', async () => {
             renderComponent();
@@ -825,7 +825,7 @@ describe('FormUsuario', () => {
         });
     });
 
-    // ── Erros de validação Yup no submit ─────────────────────────────────────
+    // Erros de validação Yup no submit
     describe('erros de validação yup no submit', () => {
         it('exibe erro yup quando e_servidor não preenchido ao submeter', async () => {
             renderComponent({ modo: Modos.INSERT });

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/GestaoDeUsuariosFormMain.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/GestaoDeUsuariosFormMain.test.js
@@ -3,18 +3,18 @@ import { render, screen } from '@testing-library/react';
 import { GestaoDeUsuariosFormMain } from '../GestaoDeUsuariosFormMain';
 import { GestaoDeUsuariosFormContext } from '../../context/GestaoDeUsuariosFormProvider';
 
-// ── Router mock ───────────────────────────────────────────────────────────────
+// Router mock
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useParams: jest.fn(),
 }));
 
-// ── Hooks mocks ───────────────────────────────────────────────────────────────
+// Hooks mocks
 jest.mock('../../hooks/useUsuario', () => ({
     useUsuario: jest.fn(),
 }));
 
-// ── Child components mocks ────────────────────────────────────────────────────
+// Child components mocks
 jest.mock('../BarraTopoForm', () => ({
     BarraTopoForm: () => <div data-testid="barra-topo-form" />,
 }));

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/GruposAcesso.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/GruposAcesso.test.js
@@ -3,10 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { GrupoAcesso } from '../GruposAcesso';
 import { GestaoDeUsuariosFormContext } from '../../context/GestaoDeUsuariosFormProvider';
 
-// ── SCSS mock ─────────────────────────────────────────────────────────────────
+// SCSS mock
 jest.mock('../../style/grupos-acesso.scss', () => ({}));
 
-// ── FontAwesome mock ──────────────────────────────────────────────────────────
+// FontAwesome mock
 jest.mock('@fortawesome/react-fontawesome', () => ({
     FontAwesomeIcon: () => <span data-testid="icon-exclamation" />,
 }));
@@ -14,12 +14,12 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faExclamationCircle: {},
 }));
 
-// ── Permissão mock ────────────────────────────────────────────────────────────
+// Permissão mock
 jest.mock('../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios', () => ({
     RetornaSeTemPermissaoEdicaoGestaoUsuarios: jest.fn(),
 }));
 
-// ── Hooks mocks ───────────────────────────────────────────────────────────────
+// Hooks mocks
 jest.mock('../../hooks/useGruposDisponiveisAcesso', () => ({
     useGruposDisponiveisAcesso: jest.fn(),
 }));

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/ModalConfirmacao.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/ModalConfirmacao.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalConfirmacao } from '../ModalConfirmacao';
 
-// ── ModalBootstrap mock ───────────────────────────────────────────────────────
+// ModalBootstrap mock
 jest.mock('../../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/ModalValidacao.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/ModalValidacao.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ModalValidacao } from '../ModalValidacao';
 
-// ── ModalBootstrap mock ───────────────────────────────────────────────────────
+// ModalBootstrap mock
 jest.mock('../../../ModalBootstrap', () => ({
     ModalBootstrap: ({
         show,

--- a/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/UnidadesUsuario.test.js
+++ b/src/componentes/Globais/GestaoDeUsuariosForm/components/__tests__/UnidadesUsuario.test.js
@@ -4,7 +4,7 @@ import { UnidadesUsuario } from '../UnidadesUsuario';
 import { GestaoDeUsuariosFormContext } from '../../context/GestaoDeUsuariosFormProvider';
 import { UnidadesUsuarioContext } from '../../context/UnidadesUsuarioProvider';
 
-// ── PrimeReact DataTable mock — invoca body de cada Column para cobrir templates ─
+// PrimeReact DataTable mock — invoca body de cada Column para cobrir templates
 jest.mock('primereact/datatable', () => ({
     DataTable: ({ children, value }) => {
         // Normaliza children para array sem depender de React.Children (não permitido em factories)
@@ -30,7 +30,7 @@ jest.mock('primereact/column', () => ({
     Column: () => null,
 }));
 
-// ── FontAwesome mock ──────────────────────────────────────────────────────────
+// FontAwesome mock
 jest.mock('@fortawesome/react-fontawesome', () => ({
     FontAwesomeIcon: ({ icon }) => <span data-testid={`icon-${icon?.iconName || 'icon'}`} />,
 }));
@@ -39,7 +39,7 @@ jest.mock('@fortawesome/free-solid-svg-icons', () => ({
     faCheckCircle: { iconName: 'check-circle' },
 }));
 
-// ── Ant Design Switch mock ────────────────────────────────────────────────────
+// Ant Design Switch mock
 jest.mock('antd', () => ({
     Switch: ({ checked, onChange, disabled, className, name }) => (
         <input
@@ -55,28 +55,28 @@ jest.mock('antd', () => ({
     ),
 }));
 
-// ── react-tooltip mock ────────────────────────────────────────────────────────
+// react-tooltip mock
 jest.mock('react-tooltip', () => ({
     Tooltip: ({ id }) => <div data-testid={`tooltip-${id}`} />,
 }));
 
-// ── Loading mock ──────────────────────────────────────────────────────────────
+// Loading mock
 jest.mock('../../../../../utils/Loading', () => ({
     __esModule: true,
     default: () => <div data-testid="loading" />,
 }));
 
-// ── MsgImgCentralizada mock ───────────────────────────────────────────────────
+// MsgImgCentralizada mock
 jest.mock('../../../Mensagens/MsgImgCentralizada', () => ({
     MsgImgCentralizada: ({ texto }) => <div data-testid="msg-img-centralizada">{texto}</div>,
 }));
 
-// ── BarraTopoListagem mock ────────────────────────────────────────────────────
+// BarraTopoListagem mock
 jest.mock('../BarraTopoListagem', () => ({
     BarraTopoListagem: () => <div data-testid="barra-topo-listagem" />,
 }));
 
-// ── ModalConfirmacao mock ─────────────────────────────────────────────────────
+// ModalConfirmacao mock
 jest.mock('../ModalConfirmacao', () => ({
     ModalConfirmacao: ({ show, botaoCancelarHandle, botaoConfirmarHandle, titulo }) =>
         show ? (
@@ -88,12 +88,12 @@ jest.mock('../ModalConfirmacao', () => ({
         ) : null,
 }));
 
-// ── Permissão mock ────────────────────────────────────────────────────────────
+// Permissão mock
 jest.mock('../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios', () => ({
     RetornaSeTemPermissaoEdicaoGestaoUsuarios: jest.fn(),
 }));
 
-// ── Hooks mocks ───────────────────────────────────────────────────────────────
+// Hooks mocks
 jest.mock('../../hooks/useUnidadesUsuario', () => ({
     useUnidadesUsuario: jest.fn(),
 }));
@@ -104,7 +104,7 @@ jest.mock('../../hooks/useDesabilitarAcesso', () => ({
     useDesabilitarAcesso: jest.fn(),
 }));
 
-// ── SVG mock ──────────────────────────────────────────────────────────────────
+// SVG mock
 jest.mock('../../../../../assets/img/img-404.svg', () => 'img-404.svg');
 
 import { RetornaSeTemPermissaoEdicaoGestaoUsuarios } from '../../../GestaoDeUsuarios/utils/RetornaSeTemPermissaoEdicaoGestaoUsuarios';
@@ -112,7 +112,7 @@ import { useUnidadesUsuario } from '../../hooks/useUnidadesUsuario';
 import { useHabilitarAcesso } from '../../hooks/useHabilitarAcesso';
 import { useDesabilitarAcesso } from '../../hooks/useDesabilitarAcesso';
 
-// ── Dados de teste ────────────────────────────────────────────────────────────
+// Dados de teste
 const USUARIO_MOCK = { username: 'joao', id: 1, e_servidor: false };
 const USUARIO_SERVIDOR = { username: 'maria', id: 2, e_servidor: true };
 
@@ -166,7 +166,7 @@ const ROW_SERVIDOR_MEMBRO_INATIVO = {
 
 const UNIDADES_COMPLETAS = [ROW_MEMBRO_COM_ACESSO, ROW_NAO_MEMBRO_SEM_ACESSO, ROW_ACESSO_SME];
 
-// ── Helpers de contexto ───────────────────────────────────────────────────────
+// Helpers de contexto
 const buildFormContext = (overrides = {}) => ({
     visaoBase: 'DRE',
     uuidUnidadeBase: 'uuid-dre',
@@ -219,14 +219,13 @@ const renderComponent = (
     );
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
 describe('UnidadesUsuario', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         setupDefaultMocks();
     });
 
-    // ── Visibilidade geral ────────────────────────────────────────────────────
+    // Visibilidade geral
     describe('visibilidade geral', () => {
         it('retorna null (não renderiza nada) quando visaoBase é "UE"', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [] });
@@ -249,7 +248,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── Loading ───────────────────────────────────────────────────────────────
+    // Loading
     describe('estado de carregamento', () => {
         it('exibe loading quando modo é "Editar Usuário" e isLoading=true', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: true, data: [] });
@@ -264,7 +263,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── DataTable e estado vazio ──────────────────────────────────────────────
+    // DataTable e estado vazio
     describe('DataTable e estado vazio', () => {
         it('exibe DataTable quando modo é "Editar Usuário", há dados e usuario', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: UNIDADES_COMPLETAS });
@@ -292,7 +291,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── membroTemplate ────────────────────────────────────────────────────────
+    // membroTemplate
     describe('membroTemplate (coluna Membro)', () => {
         it('exibe ícone check quando membro=true', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [ROW_MEMBRO_COM_ACESSO] });
@@ -310,7 +309,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── unidadeEscolarTemplate ────────────────────────────────────────────────
+    // unidadeEscolarTemplate
     describe('unidadeEscolarTemplate (coluna Nome)', () => {
         it('exibe o nome da unidade', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [ROW_MEMBRO_COM_ACESSO] });
@@ -332,7 +331,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── temAcessoTemplate e disableSwitchTemAcesso ────────────────────────────
+    // temAcessoTemplate e disableSwitchTemAcesso
     describe('temAcessoTemplate (coluna Acesso)', () => {
         it('switch fica marcado (checked) quando tem_acesso=true', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [ROW_MEMBRO_COM_ACESSO] });
@@ -379,7 +378,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── handleChangeSwitchTemAcesso ───────────────────────────────────────────
+    // handleChangeSwitchTemAcesso
     describe('handleChangeSwitchTemAcesso', () => {
         it('abre o modal quando acesso_concedido_sme=true ao clicar no switch', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [ROW_ACESSO_SME] });
@@ -432,7 +431,7 @@ describe('UnidadesUsuario', () => {
         });
     });
 
-    // ── acaoSwitchTemAcesso via modal ─────────────────────────────────────────
+    // acaoSwitchTemAcesso via modal
     describe('acaoSwitchTemAcesso via modal de confirmação', () => {
         it('chama mutationDesabilitarAcesso ao confirmar o modal (tem_acesso padrão=true)', () => {
             useUnidadesUsuario.mockReturnValue({ isLoading: false, data: [] });

--- a/src/componentes/Globais/ValoresReprogramados/__tests__/ValoresReprogramados.test.js
+++ b/src/componentes/Globais/ValoresReprogramados/__tests__/ValoresReprogramados.test.js
@@ -14,13 +14,13 @@ import {
 import { trataNumericos, exibeDataPT_BR } from '../../../../utils/ValidacoesAdicionaisFormularios';
 import { toastCustom } from '../../ToastCustom';
 
-// ── Captured props ─────────────────────────────────────────────────────────────
+// Captured props
 let capturedFormikProps = null;
 let capturedFormRef     = null;
 let capturedBotoesProps = null;
 let capturedCabecalhoProps = null;
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// Mocks
 jest.mock('../../../../services/visoes.service', () => ({
     visoesService: {
         getItemUsuarioLogado: jest.fn(),
@@ -117,7 +117,7 @@ jest.mock('../TextoExplicativoDaPagina', () => ({
     ),
 }));
 
-// ── Test data ──────────────────────────────────────────────────────────────────
+// Test data
 const makeAcao = ({ valor_ue = 100, valor_dre = 100 } = {}) => ({
     custeio: { valor_ue, valor_dre, status_conferencia: 'correto', nome: 'custeio' },
     capital: { valor_ue, valor_dre, status_conferencia: 'correto', nome: 'capital' },
@@ -145,7 +145,7 @@ const MOCK_STATUS_FECHADO = { status: { texto: 'Fechado',      cor: 2, periodo_f
 const MOCK_TEXTO_UE  = { detail: 'Texto explicativo UE'  };
 const MOCK_TEXTO_DRE = { detail: 'Texto explicativo DRE' };
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
+// Helpers
 const setupVisoesService = (visao = 'UE') => {
     visoesService.getItemUsuarioLogado.mockImplementation(key => {
         if (key === 'visao_selecionada.nome')     return visao;
@@ -183,7 +183,7 @@ const setFormValues = (values) => {
     if (capturedFormRef) capturedFormRef.current = { values };
 };
 
-// ── Tests ──────────────────────────────────────────────────────────────────────
+// Tests
 describe('<ValoresReprogramados>', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -198,7 +198,7 @@ describe('<ValoresReprogramados>', () => {
         window.location = { assign: jest.fn() };
     });
 
-    // ── Renderização ──────────────────────────────────────────────────────────
+    // Renderização
     describe('Renderização', () => {
         it('mostra loading inicialmente', async () => {
             setupVisoesService('UE');
@@ -245,7 +245,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── carregaUuidAssociacao ─────────────────────────────────────────────────
+    // carregaUuidAssociacao
     describe('carregaUuidAssociacao', () => {
         it('UE: define uuidAssociacao a partir de associacao_selecionada', async () => {
             setupDefaultMocks('UE');
@@ -273,7 +273,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── carregaValoresReprogramados ───────────────────────────────────────────
+    // carregaValoresReprogramados
     describe('carregaValoresReprogramados', () => {
         it('seta falso quando API retorna null', async () => {
             setupDefaultMocks('UE');
@@ -293,7 +293,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── carregaStatusValoresReprogramados ─────────────────────────────────────
+    // carregaStatusValoresReprogramados
     describe('carregaStatusValoresReprogramados', () => {
         it('seta falso quando status retorna null', async () => {
             setupDefaultMocks('UE');
@@ -313,7 +313,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── carregaTextoExplicativo ───────────────────────────────────────────────
+    // carregaTextoExplicativo
     describe('carregaTextoExplicativo', () => {
         it('chama getTextoExplicativoUe para visão UE', async () => {
             setupDefaultMocks('UE');
@@ -332,7 +332,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── editavelUE ────────────────────────────────────────────────────────────
+    // editavelUE
     describe('editavelUE', () => {
         it('retorna true para NAO_FINALIZADO com permissão', async () => {
             setupDefaultMocks('UE');
@@ -386,7 +386,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── editavelDRE ───────────────────────────────────────────────────────────
+    // editavelDRE
     describe('editavelDRE', () => {
         it('retorna true para EM_CONFERENCIA_DRE com permissão', async () => {
             setupDefaultMocks('DRE');
@@ -442,7 +442,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── permiteSalvarOuConcluir / defineCorBarraStatus ────────────────────────
+    // permiteSalvarOuConcluir / defineCorBarraStatus
     describe('permiteSalvarOuConcluir / defineCorBarraStatus', () => {
         it('retorna resultado de editavelUE para visão UE', async () => {
             setupDefaultMocks('UE');
@@ -477,7 +477,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── exibeAcao ─────────────────────────────────────────────────────────────
+    // exibeAcao
     describe('exibeAcao', () => {
         it('retorna false quando acao não tem custeio, capital nem livre', async () => {
             setupDefaultMocks('UE');
@@ -508,7 +508,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── rowSpan ───────────────────────────────────────────────────────────────
+    // rowSpan
     describe('rowSpan', () => {
         it('retorna 1 quando sem tipos', async () => {
             setupDefaultMocks('UE');
@@ -546,7 +546,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── valoresSomadosUE ──────────────────────────────────────────────────────
+    // valoresSomadosUE
     describe('valoresSomadosUE', () => {
         it('soma corretamente capital + custeio + livre', async () => {
             setupDefaultMocks('UE');
@@ -584,7 +584,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── valoresSomadosDRE ─────────────────────────────────────────────────────
+    // valoresSomadosDRE
     describe('valoresSomadosDRE', () => {
         it('soma corretamente para DRE', async () => {
             setupDefaultMocks('UE');
@@ -612,7 +612,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── handleOnKeyDown ───────────────────────────────────────────────────────
+    // handleOnKeyDown
     describe('handleOnKeyDown', () => {
         const backspaceEvent = { keyCode: 8 };
         const otherKeyEvent  = { keyCode: 65 };
@@ -688,7 +688,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── handleChangeStatusConferencia ─────────────────────────────────────────
+    // handleChangeStatusConferencia
     describe('handleChangeStatusConferencia', () => {
         it('DRE: valores iguais → status correto', async () => {
             setupDefaultMocks('UE');
@@ -766,7 +766,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── handleClickEstaCorreto ────────────────────────────────────────────────
+    // handleClickEstaCorreto
     describe('handleClickEstaCorreto', () => {
         it('copia valor_ue para valor_dre e seta status correto', async () => {
             setupDefaultMocks('UE');
@@ -789,7 +789,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── textoPeriodo ──────────────────────────────────────────────────────────
+    // textoPeriodo
     describe('textoPeriodo', () => {
         it('retorna texto completo com referência e datas', async () => {
             setupDefaultMocks('UE');
@@ -836,7 +836,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── validaPayload ─────────────────────────────────────────────────────────
+    // validaPayload
     describe('validaPayload (via handleOnClickConcluirValoresReprogramados)', () => {
         it('UE: payload válido abre modal concluir', async () => {
             setupDefaultMocks('UE');
@@ -978,7 +978,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── handleSalvarValoresReprogramados ──────────────────────────────────────
+    // handleSalvarValoresReprogramados
     describe('handleSalvarValoresReprogramados', () => {
         it('salva com sucesso e exibe toast', async () => {
             setupDefaultMocks('UE');
@@ -1010,7 +1010,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── handleConcluirValoresReprogramados ────────────────────────────────────
+    // handleConcluirValoresReprogramados
     describe('handleConcluirValoresReprogramados', () => {
         it('conclui com sucesso e exibe toast', async () => {
             setupDefaultMocks('UE');
@@ -1056,7 +1056,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── objetosDiferentes / handleVoltar ──────────────────────────────────────
+    // objetosDiferentes / handleVoltar
     describe('handleVoltar', () => {
         it('redireciona diretamente quando objetos são iguais (UE)', async () => {
             setupDefaultMocks('UE');
@@ -1130,7 +1130,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── objetosDiferentes (capital / livre diferente) ─────────────────────────
+    // objetosDiferentes (capital / livre diferente)
     describe('objetosDiferentes — diferença em capital e livre', () => {
         it('detecta diferença no capital', async () => {
             setupDefaultMocks('UE');
@@ -1157,7 +1157,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── Modal conclusão não permitida ─────────────────────────────────────────
+    // Modal conclusão não permitida
     describe('Modal conclusão não permitida', () => {
         it('fechar o modal esconde ele', async () => {
             setupDefaultMocks('UE');
@@ -1179,7 +1179,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── Modal concluir: fechar ────────────────────────────────────────────────
+    // Modal concluir: fechar
     describe('Modal concluir', () => {
         it('fechar o modal esconde ele', async () => {
             setupDefaultMocks('UE');
@@ -1198,7 +1198,7 @@ describe('<ValoresReprogramados>', () => {
         });
     });
 
-    // ── Cobertura de branches adicionais ──────────────────────────────────────
+    // Cobertura de branches adicionais
     describe('editavelUE — sem associacao carregada', () => {
         it('retorna false quando valoresReprogramados não tem associacao', async () => {
             setupDefaultMocks('UE');

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/ModalInfoGeracaoDocumento.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/ModalInfoGeracaoDocumento.js
@@ -78,6 +78,37 @@ export const ModalConfirmaGeracaoFinal = memo(({ open, onClose, onConfirm }) => 
     );
 });
 
+export const ModalConfirmaGeracaoFinalRetificacao = memo(({ open, onClose, onConfirm }) => {
+
+    return (
+        <ModalFormBodyText
+        show={open}
+        onHide={onClose}
+        titulo={'Retificação do PAA'}
+        bodyText={
+            <>
+                Após a conclusão do PAA, não será possível realizar edições. Se houver necessidade de ajustes, será preciso efetuar uma retificação.
+
+                <Flex gap={16} justify="end" className="mt-3">
+                    <button
+                        type="button"
+                        className="btn btn-outline-success btn-sm"
+                        onClick={onClose}>
+                        Cancelar
+                    </button>
+                    <button
+                        type="button"
+                        className="btn btn-success btn-sm"
+                        onClick={onConfirm}>
+                        Continuar
+                    </button>
+                </Flex>
+            </>
+        }
+        />
+    );
+});
+
 
 export const ModalInfoPendenciasGeracaoFinal = memo(({ open, onClose, pendencias }) => {
     return (
@@ -98,6 +129,44 @@ export const ModalInfoPendenciasGeracaoFinal = memo(({ open, onClose, pendencias
                             {pendencia.includes('conclusão') ? 'Conclusão' : ''}
                         </li>
                         
+                    ))}
+                </ul>
+                <Flex gap={16} justify="end" className="mt-3">
+                    <button
+                        type="button"
+                        className="btn btn-success btn-sm"
+                        onClick={onClose}>
+                        Ok
+                    </button>
+                </Flex>
+            </>
+        }
+        />
+    );
+});
+
+export const ModalInfoPendenciasGeracaoFinalRetificacao = memo(({ open, onClose, pendencias }) => {
+    const pends = (pendencias||'').split('\n')
+
+    return (
+        <ModalFormBodyText
+        show={open}
+        onHide={onClose}
+        titulo={'Pendências para geração do PAA em retificação'}
+        bodyText={
+            <>
+                {(pends.length > 0)
+                    ? <div>É necessário preenchimento nas seguintes seções:</div> : ''}
+                <ul>
+                    {pends.map((pendencia) => (
+                        <li key={pendencia}>
+                            {pendencia.includes('Prioridades - há recurso com saldo.') ? 'Prioridades - há recurso com saldo' : ''}
+                            {pendencia.includes('Prioridades sem ação') ? 'Prioridades sem ação e/ou valor total' : ''}
+                            {pendencia.includes('introdução') ? 'Introdução' : ''}
+                            {pendencia.includes('objetivo') ? 'Objetivos' : ''}
+                            {pendencia.includes('conclusão') ? 'Conclusão' : ''}
+                            {pendencia.includes('Nenhuma alteração encontrada') ? 'Retificação sem alterações' : ''}
+                        </li>
                     ))}
                 </ul>
                 <Flex gap={16} justify="end" className="mt-3">

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BotaoGerarComponent.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BotaoGerarComponent.tsx
@@ -1,0 +1,9 @@
+import { IBotaoGerarDocumentoProps } from "./types";
+
+export const BotaoGerarComponent = (props: IBotaoGerarDocumentoProps) => (
+    <button
+        className="btn btn-outline-success"
+        {...props.botaoProps}>
+        {props.texto ?? '-'}
+    </button>
+)

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarFinalOriginal.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarFinalOriginal.tsx
@@ -1,0 +1,138 @@
+import { useState, ComponentType, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePostPaaGeracaoDocumentoFinal } from "./../../hooks/usePostPaaGeracaoDocumento";
+import { usePollingStatusDocumento } from "./../../hooks/usePollingStatusDocumento";
+import { toastCustom } from "../../../../../../../Globais/ToastCustom";
+import { ModalConfirmaGeracaoFinal, ModalInfoPendenciasGeracaoFinal } from "../../ModalInfoGeracaoDocumento";
+import { visoesService } from "../../../../../../../../services/visoes.service";
+import { IGerarDocumentoProps } from "./types";
+import { BotaoGerarComponent } from "./BotaoGerarComponent";
+
+const ModalConfirmaFinal = ModalConfirmaGeracaoFinal as ComponentType<{
+    open: boolean; onClose: () => void, onConfirm: () => void
+}>;
+const ModalInfoPendenciasFinal = ModalInfoPendenciasGeracaoFinal as ComponentType<{
+    open: boolean; onClose: () => void, pendencias: string
+}>;
+
+export const BtnGerarFinalOriginal = ({ paa }: IGerarDocumentoProps) => {
+    const podeEditar = useMemo(() => visoesService.getPermissoes(["custom_change_paa"]), []);
+    const navigate = useNavigate();
+
+    const [pendenciasGeracao, setPendenciasGeracao] = useState("");
+    const [openModalConfirmarGeracao, setOpenModalConfirmarGeracao] = useState(false);
+    const [openModalValidacoes, setOpenModalValidacoes] = useState(false);
+    const [gerandoDocFinal, setGerandoDocFinal] = useState(false);
+
+    const { statusDocumento, isLoadingStatusDocumento, iniciarPolling } =
+        usePollingStatusDocumento({
+            paaUuid: paa.uuid,
+            onConcluidoFinal: () => navigate("/paa-vigente-e-anteriores"),
+        });
+
+    const onErrorValidacoes = (data: { confirmar: boolean; mensagem: string, error: string }) => {
+        if (data?.confirmar) {
+            setOpenModalConfirmarGeracao(true);
+        } else if (data?.error === 'valida_gerar_documento_final') {
+                toastCustom.ToastCustomError("Validação!", data?.mensagem);
+        } else {
+            setOpenModalValidacoes(true);
+            setPendenciasGeracao(data?.mensagem);
+        }
+    };
+
+    const mutateGerar = usePostPaaGeracaoDocumentoFinal({
+        onSuccessGerarDocumento: iniciarPolling,
+        onErrorGerarDocumento: onErrorValidacoes as unknown as () => void,
+    }) as unknown as {
+        mutateAsync: (vars: { uuid: string; payload: { confirmar: number } }) => Promise<unknown>;
+        isPending: boolean;
+    };
+
+    const handleGerar = async (confirmar = 0) => {
+        if (!podeEditar) return;
+
+        const docJaFoiGerado =
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL";
+
+        if (docJaFoiGerado){
+            toastCustom.ToastCustomError(
+                "Documento final",
+                "Não é possível gerar o documento final, o mesmo já foi gerado",
+            );
+            return
+        };
+
+        setOpenModalConfirmarGeracao(false);
+
+        try {
+            setGerandoDocFinal(true);
+            if (paa.uuid) {
+                await mutateGerar.mutateAsync({ uuid: paa.uuid, payload: { confirmar } });
+            } else {
+                toastCustom.ToastCustomError(
+                    "Erro!", "PAA não identificado para geração final.");
+            }
+        } catch (err) {
+            console.error("Erro ao gerar documento final:", err);
+        } finally {
+            setGerandoDocFinal(false);
+        }
+    };
+
+    const defaultDesabilitado = useMemo(() => {
+        const validacoes = [
+            statusDocumento?.status === "EM_PROCESSAMENTO",
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL",
+            !podeEditar,
+            isLoadingStatusDocumento,
+            mutateGerar.isPending,
+            gerandoDocFinal,
+        ];
+    
+        return validacoes.includes(true);
+    }, [
+        statusDocumento?.status,
+        statusDocumento?.versao,
+        podeEditar,
+        isLoadingStatusDocumento,
+        mutateGerar.isPending,
+        gerandoDocFinal,
+    ]);
+
+    return (
+        <span>
+            <BotaoGerarComponent
+                botaoProps={
+                    {
+                        disabled: defaultDesabilitado,
+                        onClick: () => handleGerar(0),
+                        title: "Gerar documento PAA final",
+                        className: "btn btn-success"
+                    }
+                }
+                texto="Gerar"
+            />
+
+            <ModalConfirmaFinal
+                open={openModalConfirmarGeracao}
+                onClose={() => {
+                    setGerandoDocFinal(false);
+                    setOpenModalConfirmarGeracao(false);
+                }}
+                onConfirm={() => handleGerar(1)}
+            />
+    
+            <ModalInfoPendenciasFinal
+                open={openModalValidacoes}
+                onClose={() => {
+                    setGerandoDocFinal(false);
+                    setOpenModalValidacoes(false)
+                }}
+                pendencias={pendenciasGeracao}
+            />
+        </span>
+    );
+};
+
+

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarFinalRetificacao.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarFinalRetificacao.tsx
@@ -1,0 +1,137 @@
+import { useState, ComponentType, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePostPaaGeracaoDocumentoFinalRetificacao } from "./../../hooks/usePostPaaGeracaoDocumento";
+import { usePollingStatusDocumento } from "./../../hooks/usePollingStatusDocumento";
+import { toastCustom } from "../../../../../../../Globais/ToastCustom";
+import {
+    ModalConfirmaGeracaoFinalRetificacao,
+    ModalInfoPendenciasGeracaoFinalRetificacao,
+} from "../../ModalInfoGeracaoDocumento";
+import { visoesService } from "../../../../../../../../services/visoes.service";
+import { IGerarDocumentoProps } from "./types";
+import { BotaoGerarComponent } from "./BotaoGerarComponent";
+
+const ModalConfirmaFinalRetificacao = ModalConfirmaGeracaoFinalRetificacao as ComponentType<{
+    open: boolean; onClose: () => void, onConfirm: () => void
+}>;
+const ModalInfoPendenciasFinalRetificacao = ModalInfoPendenciasGeracaoFinalRetificacao as ComponentType<{
+    open: boolean; onClose: () => void, pendencias: string
+}>;
+
+export const BtnGerarFinalRetificacao = ({ paa }: IGerarDocumentoProps) => {
+    const podeEditar = useMemo(() => visoesService.getPermissoes(["custom_change_paa"]), []);
+    const navigate = useNavigate();
+
+    const [pendenciasGeracao, setPendenciasGeracao] = useState("");
+    const [openModalConfirmarGeracao, setOpenModalConfirmarGeracao] = useState(false);
+    const [openModalValidacoes, setOpenModalValidacoes] = useState(false);
+    const [gerandoDocFinal, setGerandoDocFinal] = useState(false);
+
+    const { statusDocumento, isLoadingStatusDocumento, iniciarPolling } =
+        usePollingStatusDocumento({
+            paaUuid: paa.uuid,
+            onConcluidoFinal: () => navigate("/paa-vigente-e-anteriores"),
+        });
+
+    const onErrorValidacoes = (data: { confirmar: boolean; mensagem: string }) => {
+        if (data?.confirmar) {
+            setOpenModalConfirmarGeracao(true);
+        } else {
+            setOpenModalValidacoes(true);
+            setPendenciasGeracao(data?.mensagem);
+        }
+    };
+
+    const mutateGerar = usePostPaaGeracaoDocumentoFinalRetificacao({
+        onSuccessGerarDocumentoRetificacao: iniciarPolling,
+        onErrorGerarDocumentoRetificacao: onErrorValidacoes as unknown as () => void,
+    }) as unknown as {
+        mutateAsync: (vars: { uuid: string; payload: { confirmar: number } }) => Promise<unknown>;
+        isPending: boolean;
+    };
+
+    const handleGerar = async (confirmar = 0) => {
+        if (!podeEditar) return;
+
+        const docJaFoiGerado = statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL";
+        if (docJaFoiGerado){
+            toastCustom.ToastCustomError(
+                "Documento final de retificação",
+                "Não é possível gerar o documento final de retificação, o mesmo já foi gerado",
+            );
+            return
+        };
+
+        setOpenModalConfirmarGeracao(false);
+
+        try {
+            setGerandoDocFinal(true);
+            if (paa.uuid) {
+                await mutateGerar.mutateAsync({ uuid: paa.uuid, payload: { confirmar } });
+            } else {
+                toastCustom.ToastCustomError(
+                    "Erro!", "PAA não identificado para geração final de retificação.");
+            }
+        } catch (err) {
+            console.error("Erro ao gerar documento final de retificação:", err);
+        } finally {
+            setGerandoDocFinal(false);
+        }
+    };
+
+    const defaultDesabilitado = useMemo(() => {
+        const validacoes = [
+            statusDocumento?.status === "EM_PROCESSAMENTO",
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL",
+            !podeEditar,
+            isLoadingStatusDocumento,
+            mutateGerar.isPending,
+            gerandoDocFinal,
+        ];
+    
+        return validacoes.includes(true);
+    }, [
+        statusDocumento?.status,
+        statusDocumento?.versao,
+        podeEditar,
+        isLoadingStatusDocumento,
+        mutateGerar.isPending,
+        gerandoDocFinal,
+    ]);
+
+    return (
+        <span>
+            <BotaoGerarComponent
+                botaoProps={
+                    {
+                        disabled: defaultDesabilitado,
+                        onClick: () => handleGerar(0),
+                        title: "Gerar documento PAA final retificado",
+                        className: "btn btn-success"
+                    }
+                }
+                texto="Gerar"
+            />
+
+            <ModalConfirmaFinalRetificacao
+                open={openModalConfirmarGeracao}
+                onClose={() => {
+                    setGerandoDocFinal(false);
+                    setOpenModalConfirmarGeracao(false);
+                }}
+                onConfirm={() => handleGerar(1)}
+            />
+    
+            <ModalInfoPendenciasFinalRetificacao
+                open={openModalValidacoes}
+                onClose={() => {
+                    setGerandoDocFinal(false);
+                    setOpenModalValidacoes(false)
+                }}
+                pendencias={pendenciasGeracao}
+            />
+        </span>
+    );
+};
+
+

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaOriginal.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaOriginal.tsx
@@ -1,0 +1,86 @@
+import { useState, ComponentType, useMemo } from "react";
+import { usePostPaaGeracaoDocumentoPrevia } from "./../../hooks/usePostPaaGeracaoDocumento";
+import { usePollingStatusDocumento } from "./../../hooks/usePollingStatusDocumento";
+import { toastCustom } from "../../../../../../../Globais/ToastCustom";
+import { ModalInfoGeracaoDocumentoPrevia } from "../../ModalInfoGeracaoDocumento";
+import { visoesService } from "../../../../../../../../services/visoes.service";
+import { IGerarDocumentoProps } from "./types";
+import { BotaoGerarComponent } from "./BotaoGerarComponent";
+
+const ModalInfoPrevia = ModalInfoGeracaoDocumentoPrevia as ComponentType<{ open: boolean; onClose: () => void }>;
+
+export const BtnGerarPreviaOriginal = ({ paa }: IGerarDocumentoProps) => {
+    const podeEditar = useMemo(() => visoesService.getPermissoes(["custom_change_paa"]), []);
+    const [ openInfoModal, setOpenInfoModal] = useState<boolean>(false);
+
+    const { statusDocumento, isLoadingStatusDocumento, iniciarPolling } =
+        usePollingStatusDocumento({ paaUuid: paa.uuid });
+    
+    const checkStatus = async () => {
+        setOpenInfoModal(true);
+        iniciarPolling();
+    };
+    
+    const mutateGerar = usePostPaaGeracaoDocumentoPrevia({
+        onSuccessGerarDocumento: checkStatus,
+    }) as unknown as { mutate: (uuid: string) => void; isPending: boolean };
+
+    const handleGerar = () => {
+        const docJaFoiGerado =
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL";
+
+        if (docJaFoiGerado){
+            toastCustom.ToastCustomError(
+                "Documento Final",
+                "Não é possível gerar o documento prévia, o documento final já foi gerado",
+            );
+            return
+        };
+
+        if (paa.uuid) {
+          mutateGerar.mutate(paa.uuid);
+        } else {
+          toastCustom.ToastCustomError(
+            "Erro!", "PAA vigente não identificado para geração de prévia."
+          );
+        }
+    };
+
+    const defaultDesabilitado = useMemo(() => {
+        const validacoes = [
+            statusDocumento?.status === "EM_PROCESSAMENTO",
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL",
+            !podeEditar,
+            mutateGerar.isPending,
+            isLoadingStatusDocumento,
+            //TODO: considerar !paa????
+        ];
+        return validacoes.includes(true);
+    }, [
+        statusDocumento?.status,
+        statusDocumento?.versao,
+        podeEditar,
+        mutateGerar.isPending,
+        isLoadingStatusDocumento
+    ]);
+
+    return (
+        <span>
+            <BotaoGerarComponent
+                botaoProps={
+                    {
+                        disabled: defaultDesabilitado,
+                        onClick: handleGerar,
+                        title: "Gerar Prévia de documento PAA",
+                        className: "btn btn-outline-success"
+                    }
+                }
+                texto="Prévia"
+            />
+            <ModalInfoPrevia
+                open={openInfoModal}
+                onClose={() => setOpenInfoModal(false)}
+            />
+        </span>
+    )
+}

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaOriginal.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaOriginal.tsx
@@ -53,7 +53,6 @@ export const BtnGerarPreviaOriginal = ({ paa }: IGerarDocumentoProps) => {
             !podeEditar,
             mutateGerar.isPending,
             isLoadingStatusDocumento,
-            //TODO: considerar !paa????
         ];
         return validacoes.includes(true);
     }, [

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaRetificacao.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaRetificacao.tsx
@@ -1,0 +1,88 @@
+import { useState, ComponentType, useMemo } from "react";
+import { usePostPaaGeracaoDocumentoPreviaRetificacao } from "./../../hooks/usePostPaaGeracaoDocumento";
+import { usePollingStatusDocumento } from "./../../hooks/usePollingStatusDocumento";
+import { toastCustom } from "../../../../../../../Globais/ToastCustom";
+import { ModalInfoGeracaoDocumentoPrevia } from "../../ModalInfoGeracaoDocumento";
+import { visoesService } from "../../../../../../../../services/visoes.service";
+import { IGerarDocumentoProps } from "./types";
+import { BotaoGerarComponent } from "./BotaoGerarComponent";
+
+const ModalInfoPrevia = ModalInfoGeracaoDocumentoPrevia as ComponentType<{ open: boolean; onClose: () => void }>;
+
+
+export const BtnGerarPreviaRetificacao = ({ paa }: IGerarDocumentoProps) => {
+    const podeEditar = useMemo(() => visoesService.getPermissoes(["custom_change_paa"]), []);
+    const [ openInfoModal, setOpenInfoModal] = useState<boolean>(false);
+
+    const { statusDocumento, isLoadingStatusDocumento, iniciarPolling } =
+        usePollingStatusDocumento({ paaUuid: paa.uuid });
+    
+    const checkStatus = async () => {
+        setOpenInfoModal(true);
+        iniciarPolling();
+    };
+    
+    const mutateGerar = usePostPaaGeracaoDocumentoPreviaRetificacao({
+        onSuccessGerarDocumentoRetificacao: checkStatus,
+    }) as unknown as { mutate: (uuid: string) => void; isPending: boolean };
+
+    const handleGerar = () => {
+        const docJaFoiGerado =
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL";
+
+        if (docJaFoiGerado){
+            toastCustom.ToastCustomError(
+                "Documento Final de Retificação",
+                "Não é possível gerar o documento prévia, o documento final de retificação já foi gerado",
+            );
+            return
+        };
+
+        if (paa.uuid) {
+          mutateGerar.mutate(paa.uuid);
+        } else {
+          toastCustom.ToastCustomError(
+            "Erro!", "PAA vigente não identificado para geração de prévia de retificação.",
+          );
+        }
+    };
+
+    const defaultDesabilitado = useMemo(() => {
+        const validacoes = [
+            statusDocumento?.status === "EM_PROCESSAMENTO",
+            statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL",
+            !podeEditar,
+            mutateGerar.isPending,
+            isLoadingStatusDocumento,
+            //TODO: considerar !paa????
+        ];
+    
+        return validacoes.includes(true);
+    }, [
+        statusDocumento?.status,
+        statusDocumento?.versao,
+        podeEditar,
+        mutateGerar.isPending,
+        isLoadingStatusDocumento,
+    ]);
+
+    return (
+        <span>
+            <BotaoGerarComponent
+                botaoProps={
+                    {
+                        disabled: defaultDesabilitado,
+                        onClick: handleGerar,
+                        title: "Gerar Prévia de Retificação",
+                        className: "btn btn-outline-success"
+                    }
+                }
+                texto="Prévia"
+            />
+            <ModalInfoPrevia
+                open={openInfoModal}
+                onClose={() => setOpenInfoModal(false)}
+            />
+        </span>
+    )
+}

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaRetificacao.tsx
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/BtnGerarPreviaRetificacao.tsx
@@ -54,7 +54,6 @@ export const BtnGerarPreviaRetificacao = ({ paa }: IGerarDocumentoProps) => {
             !podeEditar,
             mutateGerar.isPending,
             isLoadingStatusDocumento,
-            //TODO: considerar !paa????
         ];
     
         return validacoes.includes(true);

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BotaoGerarComponent.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BotaoGerarComponent.test.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BotaoGerarComponent } from '../BotaoGerarComponent';
+
+const DEFAULT_PROPS = {
+    botaoProps: {
+        disabled: false,
+        onClick: jest.fn(),
+        title: 'Título do botão',
+    },
+    texto: 'Texto do Botão',
+};
+
+describe('BotaoGerarComponent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renderiza o botão com o texto fornecido', () => {
+        render(<BotaoGerarComponent {...DEFAULT_PROPS} texto="Gerar Orig" />);
+        expect(screen.getByRole('button', { name: 'Gerar Orig' })).toBeInTheDocument();
+    });
+
+    it('renderiza "-" quando texto não é fornecido', () => {
+        render(
+            <BotaoGerarComponent
+                botaoProps={{ disabled: false, onClick: jest.fn(), title: 'Test' }}
+            />
+        );
+        expect(screen.getByRole('button', { name: '-' })).toBeInTheDocument();
+    });
+
+    it('chama onClick ao clicar no botão', () => {
+        const onClick = jest.fn();
+        render(
+            <BotaoGerarComponent
+                texto="Clique"
+                botaoProps={{ disabled: false, onClick, title: 'Test' }}
+            />
+        );
+        fireEvent.click(screen.getByRole('button'));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('botão fica desabilitado quando disabled=true', () => {
+        render(
+            <BotaoGerarComponent
+                texto="Gerar"
+                botaoProps={{ disabled: true, onClick: jest.fn(), title: 'Test' }}
+            />
+        );
+        expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('botão fica habilitado quando disabled=false', () => {
+        render(
+            <BotaoGerarComponent
+                texto="Gerar"
+                botaoProps={{ disabled: false, onClick: jest.fn(), title: 'Test' }}
+            />
+        );
+        expect(screen.getByRole('button')).not.toBeDisabled();
+    });
+
+    it('aplica o atributo title do botaoProps', () => {
+        render(
+            <BotaoGerarComponent
+                texto="Gerar"
+                botaoProps={{ disabled: false, onClick: jest.fn(), title: 'Meu Título' }}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveAttribute('title', 'Meu Título');
+    });
+
+    it('aplica className do botaoProps', () => {
+        render(
+            <BotaoGerarComponent
+                texto="Gerar"
+                botaoProps={{
+                    disabled: false,
+                    onClick: jest.fn(),
+                    title: 'Test',
+                    className: 'btn-custom-class',
+                }}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveClass('btn-custom-class');
+    });
+
+    it('possui classes base btn e btn-outline-success', () => {
+        render(<BotaoGerarComponent {...DEFAULT_PROPS} />);
+        expect(screen.getByRole('button')).toHaveClass('btn', 'btn-outline-success');
+    });
+
+    it('sobrescreve a classe base com className do botaoProps', () => {
+        render(
+            <BotaoGerarComponent
+                texto="Gerar"
+                botaoProps={{
+                    disabled: false,
+                    onClick: jest.fn(),
+                    title: 'Test',
+                    className: 'btn btn-success',
+                }}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveClass('btn', 'btn-success');
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalOriginal.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalOriginal.test.js
@@ -1,0 +1,292 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BtnGerarFinalOriginal } from '../BtnGerarFinalOriginal';
+import { visoesService } from '../../../../../../../../../services/visoes.service';
+
+// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+const mockNavigate = jest.fn();
+const mockMutateAsync = jest.fn();
+const mockIniciarPolling = jest.fn();
+const mockToastError = jest.fn();
+
+let mockStatusDocumento = undefined;
+let mockIsLoading = false;
+let mockIsPending = false;
+let capturedOnError;
+let capturedOnSuccess;
+let capturedOnConcluidoFinal;
+
+// ─── mocks de módulos ─────────────────────────────────────────────────────────
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../../../../../../services/visoes.service', () => ({
+    visoesService: {
+        getPermissoes: jest.fn(() => true),
+    },
+}));
+
+jest.mock('../../../../../../../../Globais/ToastCustom', () => ({
+    toastCustom: {
+        ToastCustomError: (...args) => mockToastError(...args),
+    },
+}));
+
+jest.mock('../../../hooks/usePollingStatusDocumento', () => ({
+    usePollingStatusDocumento: ({ paaUuid, onConcluidoFinal }) => {
+        capturedOnConcluidoFinal = onConcluidoFinal;
+        return {
+            statusDocumento: mockStatusDocumento,
+            isLoadingStatusDocumento: mockIsLoading,
+            iniciarPolling: mockIniciarPolling,
+        };
+    },
+}));
+
+jest.mock('../../../hooks/usePostPaaGeracaoDocumento', () => ({
+    usePostPaaGeracaoDocumentoFinal: ({ onSuccessGerarDocumento, onErrorGerarDocumento }) => {
+        capturedOnError = onErrorGerarDocumento;
+        capturedOnSuccess = onSuccessGerarDocumento;
+        return { mutateAsync: mockMutateAsync, isPending: mockIsPending };
+    },
+}));
+
+jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
+    ModalConfirmaGeracaoFinal: ({ open, onClose, onConfirm }) =>
+        open ? (
+            <div data-testid="modal-confirmar-final">
+                <button onClick={onClose} data-testid="btn-cancelar-confirmar">
+                    Cancelar
+                </button>
+                <button onClick={onConfirm} data-testid="btn-confirmar-geracao">
+                    Continuar
+                </button>
+            </div>
+        ) : null,
+    ModalInfoPendenciasGeracaoFinal: ({ open, onClose, pendencias }) =>
+        open ? (
+            <div data-testid="modal-pendencias-final">
+                <span data-testid="texto-pendencias">{pendencias}</span>
+                <button onClick={onClose} data-testid="btn-fechar-pendencias">
+                    Ok
+                </button>
+            </div>
+        ) : null,
+}));
+
+// ─── dados padrão ────────────────────────────────────────────────────────────
+const DEFAULT_PAA = { uuid: 'uuid-final-orig-789', status: 'EM_ELABORACAO' };
+
+describe('BtnGerarFinalOriginal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        visoesService.getPermissoes.mockReturnValue(true);
+        mockStatusDocumento = undefined;
+        mockIsLoading = false;
+        mockIsPending = false;
+        capturedOnError = undefined;
+        capturedOnSuccess = undefined;
+        capturedOnConcluidoFinal = undefined;
+        mockMutateAsync.mockResolvedValue({});
+    });
+
+    // ── renderização ──────────────────────────────────────────────────────────
+    it('renderiza o botão com texto "Gerar"', () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeInTheDocument();
+    });
+
+    it('botão tem o título correto', () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toHaveAttribute(
+            'title',
+            'Gerar documento PAA final'
+        );
+    });
+
+    it('botão está habilitado no estado padrão', () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).not.toBeDisabled();
+    });
+
+    // ── estados desabilitados ─────────────────────────────────────────────────
+    it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
+        visoesService.getPermissoes.mockReturnValue(false);
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status é EM_PROCESSAMENTO', () => {
+        mockStatusDocumento = { status: 'EM_PROCESSAMENTO' };
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status=CONCLUIDO e versao=FINAL', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'FINAL' };
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando isLoadingStatusDocumento=true', () => {
+        mockIsLoading = true;
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando mutação está pendente', () => {
+        mockIsPending = true;
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    // ── interações de clique ──────────────────────────────────────────────────
+    it('clicar no botão chama mutateAsync com confirmar=0', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Gerar' }));
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            uuid: 'uuid-final-orig-789',
+            payload: { confirmar: 0 },
+        });
+    });
+
+    it('clicar no botão com uuid vazio exibe toast de erro', async () => {
+        render(<BtnGerarFinalOriginal paa={{ uuid: '', status: 'EM_ELABORACAO' }} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Gerar' }));
+        });
+
+        expect(mockToastError).toHaveBeenCalledWith(
+            'Erro!',
+            'PAA não identificado para geração final.'
+        );
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    // ── callback de erro – branch confirmar ──────────────────────────────────
+    it('onError com confirmar=true abre o modal de confirmação', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        expect(screen.queryByTestId('modal-confirmar-final')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: 'Confirme para continuar', error: '' });
+        });
+
+        expect(screen.getByTestId('modal-confirmar-final')).toBeInTheDocument();
+    });
+
+    // ── callback de erro – branch valida_gerar_documento_final ───────────────
+    it('onError com error=valida_gerar_documento_final exibe toast de validação', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({
+                confirmar: false,
+                mensagem: 'Há pendências obrigatórias.',
+                error: 'valida_gerar_documento_final',
+            });
+        });
+
+        expect(mockToastError).toHaveBeenCalledWith(
+            'Validação!',
+            'Há pendências obrigatórias.'
+        );
+        expect(screen.queryByTestId('modal-confirmar-final')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('modal-pendencias-final')).not.toBeInTheDocument();
+    });
+
+    // ── callback de erro – branch else (pendências) ──────────────────────────
+    it('onError sem confirmar e sem error específico abre modal de pendências', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        expect(screen.queryByTestId('modal-pendencias-final')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: false, mensagem: 'introdução\nobjetivo', error: '' });
+        });
+
+        expect(screen.getByTestId('modal-pendencias-final')).toBeInTheDocument();
+        expect(screen.getByTestId('texto-pendencias').textContent).toContain('introdução');
+        expect(screen.getByTestId('texto-pendencias').textContent).toContain('objetivo');
+    });
+
+    // ── modal de confirmação ──────────────────────────────────────────────────
+    it('cancelar no modal de confirmação fecha o modal', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: '', error: '' });
+        });
+
+        expect(screen.getByTestId('modal-confirmar-final')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-cancelar-confirmar'));
+
+        expect(screen.queryByTestId('modal-confirmar-final')).not.toBeInTheDocument();
+    });
+
+    it('confirmar no modal chama mutateAsync com confirmar=1', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: '', error: '' });
+        });
+
+        expect(screen.getByTestId('modal-confirmar-final')).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('btn-confirmar-geracao'));
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            uuid: 'uuid-final-orig-789',
+            payload: { confirmar: 1 },
+        });
+    });
+
+    // ── modal de pendências ───────────────────────────────────────────────────
+    it('fechar o modal de pendências fecha o modal', async () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: false, mensagem: 'conclusão', error: '' });
+        });
+
+        expect(screen.getByTestId('modal-pendencias-final')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-fechar-pendencias'));
+
+        expect(screen.queryByTestId('modal-pendencias-final')).not.toBeInTheDocument();
+    });
+
+    // ── callback de sucesso ───────────────────────────────────────────────────
+    it('onSuccessGerarDocumento chama iniciarPolling', () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        act(() => {
+            capturedOnSuccess?.();
+        });
+
+        expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
+    });
+
+    // ── navegação pós-conclusão ───────────────────────────────────────────────
+    it('navega para /paa-vigente-e-anteriores quando onConcluidoFinal é chamado', () => {
+        render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
+
+        act(() => {
+            capturedOnConcluidoFinal?.();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/paa-vigente-e-anteriores');
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalOriginal.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalOriginal.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { BtnGerarFinalOriginal } from '../BtnGerarFinalOriginal';
 import { visoesService } from '../../../../../../../../../services/visoes.service';
 
-// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+// variáveis de controle dos mocks
 const mockNavigate = jest.fn();
 const mockMutateAsync = jest.fn();
 const mockIniciarPolling = jest.fn();
@@ -17,7 +17,7 @@ let capturedOnError;
 let capturedOnSuccess;
 let capturedOnConcluidoFinal;
 
-// ─── mocks de módulos ─────────────────────────────────────────────────────────
+// mocks de módulos
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockNavigate,
@@ -77,7 +77,7 @@ jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
         ) : null,
 }));
 
-// ─── dados padrão ────────────────────────────────────────────────────────────
+// dados padrão
 const DEFAULT_PAA = { uuid: 'uuid-final-orig-789', status: 'EM_ELABORACAO' };
 
 describe('BtnGerarFinalOriginal', () => {
@@ -93,7 +93,7 @@ describe('BtnGerarFinalOriginal', () => {
         mockMutateAsync.mockResolvedValue({});
     });
 
-    // ── renderização ──────────────────────────────────────────────────────────
+    // renderização
     it('renderiza o botão com texto "Gerar"', () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
         expect(screen.getByRole('button', { name: 'Gerar' })).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.getByRole('button', { name: 'Gerar' })).not.toBeDisabled();
     });
 
-    // ── estados desabilitados ─────────────────────────────────────────────────
+    // estados desabilitados
     it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
         visoesService.getPermissoes.mockReturnValue(false);
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
@@ -143,7 +143,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
     });
 
-    // ── interações de clique ──────────────────────────────────────────────────
+    // interações de clique
     it('clicar no botão chama mutateAsync com confirmar=0', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -171,7 +171,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(mockMutateAsync).not.toHaveBeenCalled();
     });
 
-    // ── callback de erro – branch confirmar ──────────────────────────────────
+    // callback de erro – branch confirmar
     it('onError com confirmar=true abre o modal de confirmação', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -184,7 +184,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.getByTestId('modal-confirmar-final')).toBeInTheDocument();
     });
 
-    // ── callback de erro – branch valida_gerar_documento_final ───────────────
+    // callback de erro – branch valida_gerar_documento_final
     it('onError com error=valida_gerar_documento_final exibe toast de validação', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -204,7 +204,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.queryByTestId('modal-pendencias-final')).not.toBeInTheDocument();
     });
 
-    // ── callback de erro – branch else (pendências) ──────────────────────────
+    // callback de erro – branch else (pendências)
     it('onError sem confirmar e sem error específico abre modal de pendências', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -219,7 +219,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.getByTestId('texto-pendencias').textContent).toContain('objetivo');
     });
 
-    // ── modal de confirmação ──────────────────────────────────────────────────
+    // modal de confirmação
     it('cancelar no modal de confirmação fecha o modal', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -253,7 +253,7 @@ describe('BtnGerarFinalOriginal', () => {
         });
     });
 
-    // ── modal de pendências ───────────────────────────────────────────────────
+    // modal de pendências
     it('fechar o modal de pendências fecha o modal', async () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -268,7 +268,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(screen.queryByTestId('modal-pendencias-final')).not.toBeInTheDocument();
     });
 
-    // ── callback de sucesso ───────────────────────────────────────────────────
+    // callback de sucesso
     it('onSuccessGerarDocumento chama iniciarPolling', () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 
@@ -279,7 +279,7 @@ describe('BtnGerarFinalOriginal', () => {
         expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
     });
 
-    // ── navegação pós-conclusão ───────────────────────────────────────────────
+    // navegação pós-conclusão
     it('navega para /paa-vigente-e-anteriores quando onConcluidoFinal é chamado', () => {
         render(<BtnGerarFinalOriginal paa={DEFAULT_PAA} />);
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalRetificacao.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalRetificacao.test.js
@@ -1,0 +1,274 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BtnGerarFinalRetificacao } from '../BtnGerarFinalRetificacao';
+import { visoesService } from '../../../../../../../../../services/visoes.service';
+
+// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+const mockNavigate = jest.fn();
+const mockMutateAsync = jest.fn();
+const mockIniciarPolling = jest.fn();
+const mockToastError = jest.fn();
+
+let mockStatusDocumento = undefined;
+let mockIsLoading = false;
+let mockIsPending = false;
+let capturedOnError;
+let capturedOnSuccess;
+let capturedOnConcluidoFinal;
+
+// ─── mocks de módulos ─────────────────────────────────────────────────────────
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../../../../../../services/visoes.service', () => ({
+    visoesService: {
+        getPermissoes: jest.fn(() => true),
+    },
+}));
+
+jest.mock('../../../../../../../../Globais/ToastCustom', () => ({
+    toastCustom: {
+        ToastCustomError: (...args) => mockToastError(...args),
+    },
+}));
+
+jest.mock('../../../hooks/usePollingStatusDocumento', () => ({
+    usePollingStatusDocumento: ({ paaUuid, onConcluidoFinal }) => {
+        capturedOnConcluidoFinal = onConcluidoFinal;
+        return {
+            statusDocumento: mockStatusDocumento,
+            isLoadingStatusDocumento: mockIsLoading,
+            iniciarPolling: mockIniciarPolling,
+        };
+    },
+}));
+
+jest.mock('../../../hooks/usePostPaaGeracaoDocumento', () => ({
+    usePostPaaGeracaoDocumentoFinalRetificacao: ({
+        onSuccessGerarDocumentoRetificacao,
+        onErrorGerarDocumentoRetificacao,
+    }) => {
+        capturedOnError = onErrorGerarDocumentoRetificacao;
+        capturedOnSuccess = onSuccessGerarDocumentoRetificacao;
+        return { mutateAsync: mockMutateAsync, isPending: mockIsPending };
+    },
+}));
+
+jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
+    ModalConfirmaGeracaoFinalRetificacao: ({ open, onClose, onConfirm }) =>
+        open ? (
+            <div data-testid="modal-confirmar-retif">
+                <button onClick={onClose} data-testid="btn-cancelar-confirmar-retif">
+                    Cancelar
+                </button>
+                <button onClick={onConfirm} data-testid="btn-confirmar-geracao-retif">
+                    Continuar
+                </button>
+            </div>
+        ) : null,
+    ModalInfoPendenciasGeracaoFinalRetificacao: ({ open, onClose, pendencias }) =>
+        open ? (
+            <div data-testid="modal-pendencias-retif">
+                <span data-testid="texto-pendencias-retif">{pendencias}</span>
+                <button onClick={onClose} data-testid="btn-fechar-pendencias-retif">
+                    Ok
+                </button>
+            </div>
+        ) : null,
+}));
+
+// ─── dados padrão ────────────────────────────────────────────────────────────
+const DEFAULT_PAA = { uuid: 'uuid-final-retif-321', status: 'RETIFICACAO' };
+
+describe('BtnGerarFinalRetificacao', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        visoesService.getPermissoes.mockReturnValue(true);
+        mockStatusDocumento = undefined;
+        mockIsLoading = false;
+        mockIsPending = false;
+        capturedOnError = undefined;
+        capturedOnSuccess = undefined;
+        capturedOnConcluidoFinal = undefined;
+        mockMutateAsync.mockResolvedValue({});
+    });
+
+    // ── renderização ──────────────────────────────────────────────────────────
+    it('renderiza o botão com texto "Gerar"', () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeInTheDocument();
+    });
+
+    it('botão tem o título correto', () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toHaveAttribute(
+            'title',
+            'Gerar documento PAA final retificado'
+        );
+    });
+
+    it('botão está habilitado no estado padrão', () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).not.toBeDisabled();
+    });
+
+    // ── estados desabilitados ─────────────────────────────────────────────────
+    it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
+        visoesService.getPermissoes.mockReturnValue(false);
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status é EM_PROCESSAMENTO', () => {
+        mockStatusDocumento = { status: 'EM_PROCESSAMENTO' };
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status=CONCLUIDO e versao=FINAL', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'FINAL' };
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando isLoadingStatusDocumento=true', () => {
+        mockIsLoading = true;
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando mutação está pendente', () => {
+        mockIsPending = true;
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
+    });
+
+    // ── interações de clique ──────────────────────────────────────────────────
+    it('clicar no botão chama mutateAsync com confirmar=0', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Gerar' }));
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            uuid: 'uuid-final-retif-321',
+            payload: { confirmar: 0 },
+        });
+    });
+
+    it('clicar no botão com uuid vazio exibe toast de erro', async () => {
+        render(<BtnGerarFinalRetificacao paa={{ uuid: '', status: 'RETIFICACAO' }} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Gerar' }));
+        });
+
+        expect(mockToastError).toHaveBeenCalledWith(
+            'Erro!',
+            'PAA não identificado para geração final de retificação.'
+        );
+        expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    // ── callback de erro – branch confirmar ──────────────────────────────────
+    it('onError com confirmar=true abre o modal de confirmação de retificação', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        expect(screen.queryByTestId('modal-confirmar-retif')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: 'Confirme para continuar' });
+        });
+
+        expect(screen.getByTestId('modal-confirmar-retif')).toBeInTheDocument();
+    });
+
+    // ── callback de erro – branch else (pendências) ──────────────────────────
+    it('onError com confirmar=false abre modal de pendências com a mensagem', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        expect(screen.queryByTestId('modal-pendencias-retif')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: false, mensagem: 'Nenhuma alteração encontrada' });
+        });
+
+        expect(screen.getByTestId('modal-pendencias-retif')).toBeInTheDocument();
+        expect(screen.getByTestId('texto-pendencias-retif')).toHaveTextContent(
+            'Nenhuma alteração encontrada'
+        );
+    });
+
+    // ── modal de confirmação ──────────────────────────────────────────────────
+    it('cancelar no modal de confirmação fecha o modal', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: '' });
+        });
+
+        expect(screen.getByTestId('modal-confirmar-retif')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-cancelar-confirmar-retif'));
+
+        expect(screen.queryByTestId('modal-confirmar-retif')).not.toBeInTheDocument();
+    });
+
+    it('confirmar no modal de retificação chama mutateAsync com confirmar=1', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: true, mensagem: '' });
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('btn-confirmar-geracao-retif'));
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            uuid: 'uuid-final-retif-321',
+            payload: { confirmar: 1 },
+        });
+    });
+
+    // ── modal de pendências ───────────────────────────────────────────────────
+    it('fechar o modal de pendências fecha o modal', async () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnError?.({ confirmar: false, mensagem: 'introdução' });
+        });
+
+        expect(screen.getByTestId('modal-pendencias-retif')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-fechar-pendencias-retif'));
+
+        expect(screen.queryByTestId('modal-pendencias-retif')).not.toBeInTheDocument();
+    });
+
+    // ── callback de sucesso ───────────────────────────────────────────────────
+    it('onSuccessGerarDocumentoRetificacao chama iniciarPolling', () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        act(() => {
+            capturedOnSuccess?.();
+        });
+
+        expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
+    });
+
+    // ── navegação pós-conclusão ───────────────────────────────────────────────
+    it('navega para /paa-vigente-e-anteriores quando onConcluidoFinal é chamado', () => {
+        render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
+
+        act(() => {
+            capturedOnConcluidoFinal?.();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/paa-vigente-e-anteriores');
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalRetificacao.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarFinalRetificacao.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { BtnGerarFinalRetificacao } from '../BtnGerarFinalRetificacao';
 import { visoesService } from '../../../../../../../../../services/visoes.service';
 
-// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+//  variáveis de controle dos mocks
 const mockNavigate = jest.fn();
 const mockMutateAsync = jest.fn();
 const mockIniciarPolling = jest.fn();
@@ -17,7 +17,7 @@ let capturedOnError;
 let capturedOnSuccess;
 let capturedOnConcluidoFinal;
 
-// ─── mocks de módulos ─────────────────────────────────────────────────────────
+//  mocks de módulos
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockNavigate,
@@ -80,7 +80,7 @@ jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
         ) : null,
 }));
 
-// ─── dados padrão ────────────────────────────────────────────────────────────
+//  dados padrão
 const DEFAULT_PAA = { uuid: 'uuid-final-retif-321', status: 'RETIFICACAO' };
 
 describe('BtnGerarFinalRetificacao', () => {
@@ -96,7 +96,7 @@ describe('BtnGerarFinalRetificacao', () => {
         mockMutateAsync.mockResolvedValue({});
     });
 
-    // ── renderização ──────────────────────────────────────────────────────────
+    //  renderização
     it('renderiza o botão com texto "Gerar"', () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
         expect(screen.getByRole('button', { name: 'Gerar' })).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(screen.getByRole('button', { name: 'Gerar' })).not.toBeDisabled();
     });
 
-    // ── estados desabilitados ─────────────────────────────────────────────────
+    //  estados desabilitados
     it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
         visoesService.getPermissoes.mockReturnValue(false);
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
@@ -146,7 +146,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(screen.getByRole('button', { name: 'Gerar' })).toBeDisabled();
     });
 
-    // ── interações de clique ──────────────────────────────────────────────────
+    //  interações de clique
     it('clicar no botão chama mutateAsync com confirmar=0', async () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -174,7 +174,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(mockMutateAsync).not.toHaveBeenCalled();
     });
 
-    // ── callback de erro – branch confirmar ──────────────────────────────────
+    //  callback de erro – branch confirmar
     it('onError com confirmar=true abre o modal de confirmação de retificação', async () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -187,7 +187,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(screen.getByTestId('modal-confirmar-retif')).toBeInTheDocument();
     });
 
-    // ── callback de erro – branch else (pendências) ──────────────────────────
+    //  callback de erro – branch else (pendências)
     it('onError com confirmar=false abre modal de pendências com a mensagem', async () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -203,7 +203,7 @@ describe('BtnGerarFinalRetificacao', () => {
         );
     });
 
-    // ── modal de confirmação ──────────────────────────────────────────────────
+    //  modal de confirmação
     it('cancelar no modal de confirmação fecha o modal', async () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -235,7 +235,7 @@ describe('BtnGerarFinalRetificacao', () => {
         });
     });
 
-    // ── modal de pendências ───────────────────────────────────────────────────
+    //  modal de pendências
     it('fechar o modal de pendências fecha o modal', async () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -250,7 +250,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(screen.queryByTestId('modal-pendencias-retif')).not.toBeInTheDocument();
     });
 
-    // ── callback de sucesso ───────────────────────────────────────────────────
+    //  callback de sucesso
     it('onSuccessGerarDocumentoRetificacao chama iniciarPolling', () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 
@@ -261,7 +261,7 @@ describe('BtnGerarFinalRetificacao', () => {
         expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
     });
 
-    // ── navegação pós-conclusão ───────────────────────────────────────────────
+    //  navegação pós-conclusão
     it('navega para /paa-vigente-e-anteriores quando onConcluidoFinal é chamado', () => {
         render(<BtnGerarFinalRetificacao paa={DEFAULT_PAA} />);
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaOriginal.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaOriginal.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { BtnGerarPreviaOriginal } from '../BtnGerarPreviaOriginal';
 import { visoesService } from '../../../../../../../../../services/visoes.service';
 
-// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+// variáveis de controle dos mocks
 const mockNavigate = jest.fn();
 const mockMutate = jest.fn();
 const mockIniciarPolling = jest.fn();
@@ -15,7 +15,7 @@ let mockIsLoading = false;
 let mockIsPending = false;
 let capturedOnSuccess;
 
-// ─── mocks de módulos ─────────────────────────────────────────────────────────
+// mocks de módulos
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockNavigate,
@@ -59,7 +59,7 @@ jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
         ) : null,
 }));
 
-// ─── dados padrão ────────────────────────────────────────────────────────────
+// dados padrão
 const DEFAULT_PAA = { uuid: 'uuid-previa-orig-123', status: 'EM_ELABORACAO' };
 
 describe('BtnGerarPreviaOriginal', () => {
@@ -72,7 +72,7 @@ describe('BtnGerarPreviaOriginal', () => {
         capturedOnSuccess = undefined;
     });
 
-    // ── renderização ──────────────────────────────────────────────────────────
+    // renderização
     it('renderiza o botão com texto "Prévia"', () => {
         render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
         expect(screen.getByRole('button', { name: 'Prévia' })).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('BtnGerarPreviaOriginal', () => {
         expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
     });
 
-    // ── estados desabilitados ─────────────────────────────────────────────────
+    // estados desabilitados
     it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
         visoesService.getPermissoes.mockReturnValue(false);
         render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
@@ -128,7 +128,7 @@ describe('BtnGerarPreviaOriginal', () => {
         expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
     });
 
-    // ── interações de clique ──────────────────────────────────────────────────
+    // interações de clique
     it('clicar no botão chama mutate com o uuid do paa', () => {
         render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
         fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
@@ -145,7 +145,7 @@ describe('BtnGerarPreviaOriginal', () => {
         expect(mockMutate).not.toHaveBeenCalled();
     });
 
-    // ── callback de sucesso ───────────────────────────────────────────────────
+    // callback de sucesso
     it('onSuccessGerarDocumento abre o modal e chama iniciarPolling', async () => {
         render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
         expect(screen.queryByTestId('modal-info-previa')).not.toBeInTheDocument();

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaOriginal.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaOriginal.test.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BtnGerarPreviaOriginal } from '../BtnGerarPreviaOriginal';
+import { visoesService } from '../../../../../../../../../services/visoes.service';
+
+// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+const mockNavigate = jest.fn();
+const mockMutate = jest.fn();
+const mockIniciarPolling = jest.fn();
+const mockToastError = jest.fn();
+
+let mockStatusDocumento = undefined;
+let mockIsLoading = false;
+let mockIsPending = false;
+let capturedOnSuccess;
+
+// ─── mocks de módulos ─────────────────────────────────────────────────────────
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../../../../../../services/visoes.service', () => ({
+    visoesService: {
+        getPermissoes: jest.fn(() => true),
+    },
+}));
+
+jest.mock('../../../../../../../../Globais/ToastCustom', () => ({
+    toastCustom: {
+        ToastCustomError: (...args) => mockToastError(...args),
+    },
+}));
+
+jest.mock('../../../hooks/usePollingStatusDocumento', () => ({
+    usePollingStatusDocumento: () => ({
+        statusDocumento: mockStatusDocumento,
+        isLoadingStatusDocumento: mockIsLoading,
+        iniciarPolling: mockIniciarPolling,
+    }),
+}));
+
+jest.mock('../../../hooks/usePostPaaGeracaoDocumento', () => ({
+    usePostPaaGeracaoDocumentoPrevia: ({ onSuccessGerarDocumento }) => {
+        capturedOnSuccess = onSuccessGerarDocumento;
+        return { mutate: mockMutate, isPending: mockIsPending };
+    },
+}));
+
+jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
+    ModalInfoGeracaoDocumentoPrevia: ({ open, onClose }) =>
+        open ? (
+            <div data-testid="modal-info-previa">
+                <button onClick={onClose} data-testid="btn-fechar-modal">
+                    Fechar
+                </button>
+            </div>
+        ) : null,
+}));
+
+// ─── dados padrão ────────────────────────────────────────────────────────────
+const DEFAULT_PAA = { uuid: 'uuid-previa-orig-123', status: 'EM_ELABORACAO' };
+
+describe('BtnGerarPreviaOriginal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        visoesService.getPermissoes.mockReturnValue(true);
+        mockStatusDocumento = undefined;
+        mockIsLoading = false;
+        mockIsPending = false;
+        capturedOnSuccess = undefined;
+    });
+
+    // ── renderização ──────────────────────────────────────────────────────────
+    it('renderiza o botão com texto "Prévia"', () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeInTheDocument();
+    });
+
+    it('botão tem o título correto', () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toHaveAttribute(
+            'title',
+            'Gerar Prévia de documento PAA'
+        );
+    });
+
+    it('botão está habilitado no estado padrão', () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
+    });
+
+    // ── estados desabilitados ─────────────────────────────────────────────────
+    it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
+        visoesService.getPermissoes.mockReturnValue(false);
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status é EM_PROCESSAMENTO', () => {
+        mockStatusDocumento = { status: 'EM_PROCESSAMENTO' };
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status=CONCLUIDO e versao=FINAL', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'FINAL' };
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando isLoadingStatusDocumento=true', () => {
+        mockIsLoading = true;
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando mutação está pendente', () => {
+        mockIsPending = true;
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica habilitado quando status=CONCLUIDO e versao=PREVIA', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'PREVIA' };
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
+    });
+
+    // ── interações de clique ──────────────────────────────────────────────────
+    it('clicar no botão chama mutate com o uuid do paa', () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
+        expect(mockMutate).toHaveBeenCalledWith('uuid-previa-orig-123');
+    });
+
+    it('clicar no botão com uuid vazio exibe toast de erro', () => {
+        render(<BtnGerarPreviaOriginal paa={{ uuid: '', status: 'EM_ELABORACAO' }} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
+        expect(mockToastError).toHaveBeenCalledWith(
+            'Erro!',
+            'PAA vigente não identificado para geração de prévia.'
+        );
+        expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    // ── callback de sucesso ───────────────────────────────────────────────────
+    it('onSuccessGerarDocumento abre o modal e chama iniciarPolling', async () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+        expect(screen.queryByTestId('modal-info-previa')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnSuccess?.();
+        });
+
+        expect(screen.getByTestId('modal-info-previa')).toBeInTheDocument();
+        expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
+    });
+
+    it('fechar o modal atualiza o estado corretamente', async () => {
+        render(<BtnGerarPreviaOriginal paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnSuccess?.();
+        });
+
+        expect(screen.getByTestId('modal-info-previa')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-fechar-modal'));
+
+        expect(screen.queryByTestId('modal-info-previa')).not.toBeInTheDocument();
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaRetificacao.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaRetificacao.test.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BtnGerarPreviaRetificacao } from '../BtnGerarPreviaRetificacao';
+import { visoesService } from '../../../../../../../../../services/visoes.service';
+
+// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+const mockNavigate = jest.fn();
+const mockMutate = jest.fn();
+const mockIniciarPolling = jest.fn();
+const mockToastError = jest.fn();
+
+let mockStatusDocumento = undefined;
+let mockIsLoading = false;
+let mockIsPending = false;
+let capturedOnSuccess;
+
+// ─── mocks de módulos ─────────────────────────────────────────────────────────
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../../../../../../services/visoes.service', () => ({
+    visoesService: {
+        getPermissoes: jest.fn(() => true),
+    },
+}));
+
+jest.mock('../../../../../../../../Globais/ToastCustom', () => ({
+    toastCustom: {
+        ToastCustomError: (...args) => mockToastError(...args),
+    },
+}));
+
+jest.mock('../../../hooks/usePollingStatusDocumento', () => ({
+    usePollingStatusDocumento: () => ({
+        statusDocumento: mockStatusDocumento,
+        isLoadingStatusDocumento: mockIsLoading,
+        iniciarPolling: mockIniciarPolling,
+    }),
+}));
+
+jest.mock('../../../hooks/usePostPaaGeracaoDocumento', () => ({
+    usePostPaaGeracaoDocumentoPreviaRetificacao: ({ onSuccessGerarDocumentoRetificacao }) => {
+        capturedOnSuccess = onSuccessGerarDocumentoRetificacao;
+        return { mutate: mockMutate, isPending: mockIsPending };
+    },
+}));
+
+jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
+    ModalInfoGeracaoDocumentoPrevia: ({ open, onClose }) =>
+        open ? (
+            <div data-testid="modal-info-previa-retif">
+                <button onClick={onClose} data-testid="btn-fechar-modal">
+                    Fechar
+                </button>
+            </div>
+        ) : null,
+}));
+
+// ─── dados padrão ────────────────────────────────────────────────────────────
+const DEFAULT_PAA = { uuid: 'uuid-previa-retif-456', status: 'RETIFICACAO' };
+
+describe('BtnGerarPreviaRetificacao', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        visoesService.getPermissoes.mockReturnValue(true);
+        mockStatusDocumento = undefined;
+        mockIsLoading = false;
+        mockIsPending = false;
+        capturedOnSuccess = undefined;
+    });
+
+    // ── renderização ──────────────────────────────────────────────────────────
+    it('renderiza o botão com texto "Prévia"', () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeInTheDocument();
+    });
+
+    it('botão tem o título correto', () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toHaveAttribute(
+            'title',
+            'Gerar Prévia de Retificação'
+        );
+    });
+
+    it('botão está habilitado no estado padrão', () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
+    });
+
+    // ── estados desabilitados ─────────────────────────────────────────────────
+    it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
+        visoesService.getPermissoes.mockReturnValue(false);
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status é EM_PROCESSAMENTO', () => {
+        mockStatusDocumento = { status: 'EM_PROCESSAMENTO' };
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando status=CONCLUIDO e versao=FINAL', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'FINAL' };
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando isLoadingStatusDocumento=true', () => {
+        mockIsLoading = true;
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica desabilitado quando mutação está pendente', () => {
+        mockIsPending = true;
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).toBeDisabled();
+    });
+
+    it('botão fica habilitado quando status=CONCLUIDO e versao=PREVIA', () => {
+        mockStatusDocumento = { status: 'CONCLUIDO', versao: 'PREVIA' };
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
+    });
+
+    // ── interações de clique ──────────────────────────────────────────────────
+    it('clicar no botão chama mutate com o uuid do paa', () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
+        expect(mockMutate).toHaveBeenCalledWith('uuid-previa-retif-456');
+    });
+
+    it('clicar no botão com uuid vazio exibe toast de erro', () => {
+        render(<BtnGerarPreviaRetificacao paa={{ uuid: '', status: 'RETIFICACAO' }} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
+        expect(mockToastError).toHaveBeenCalledWith(
+            'Erro!',
+            'PAA vigente não identificado para geração de prévia de retificação.'
+        );
+        expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    // ── callback de sucesso ───────────────────────────────────────────────────
+    it('onSuccessGerarDocumentoRetificacao abre o modal e chama iniciarPolling', async () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+        expect(screen.queryByTestId('modal-info-previa-retif')).not.toBeInTheDocument();
+
+        await act(async () => {
+            capturedOnSuccess?.();
+        });
+
+        expect(screen.getByTestId('modal-info-previa-retif')).toBeInTheDocument();
+        expect(mockIniciarPolling).toHaveBeenCalledTimes(1);
+    });
+
+    it('fechar o modal atualiza o estado corretamente', async () => {
+        render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
+
+        await act(async () => {
+            capturedOnSuccess?.();
+        });
+
+        expect(screen.getByTestId('modal-info-previa-retif')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('btn-fechar-modal'));
+
+        expect(screen.queryByTestId('modal-info-previa-retif')).not.toBeInTheDocument();
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaRetificacao.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/__tests__/BtnGerarPreviaRetificacao.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { BtnGerarPreviaRetificacao } from '../BtnGerarPreviaRetificacao';
 import { visoesService } from '../../../../../../../../../services/visoes.service';
 
-// ─── variáveis de controle dos mocks ─────────────────────────────────────────
+// variáveis de controle dos mocks
 const mockNavigate = jest.fn();
 const mockMutate = jest.fn();
 const mockIniciarPolling = jest.fn();
@@ -15,7 +15,7 @@ let mockIsLoading = false;
 let mockIsPending = false;
 let capturedOnSuccess;
 
-// ─── mocks de módulos ─────────────────────────────────────────────────────────
+// mocks de módulos
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockNavigate,
@@ -59,7 +59,7 @@ jest.mock('../../../ModalInfoGeracaoDocumento', () => ({
         ) : null,
 }));
 
-// ─── dados padrão ────────────────────────────────────────────────────────────
+// dados padrão
 const DEFAULT_PAA = { uuid: 'uuid-previa-retif-456', status: 'RETIFICACAO' };
 
 describe('BtnGerarPreviaRetificacao', () => {
@@ -72,7 +72,7 @@ describe('BtnGerarPreviaRetificacao', () => {
         capturedOnSuccess = undefined;
     });
 
-    // ── renderização ──────────────────────────────────────────────────────────
+    // renderização
     it('renderiza o botão com texto "Prévia"', () => {
         render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
         expect(screen.getByRole('button', { name: 'Prévia' })).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('BtnGerarPreviaRetificacao', () => {
         expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
     });
 
-    // ── estados desabilitados ─────────────────────────────────────────────────
+    // estados desabilitados
     it('botão fica desabilitado quando sem permissão (podeEditar=false)', () => {
         visoesService.getPermissoes.mockReturnValue(false);
         render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
@@ -128,7 +128,7 @@ describe('BtnGerarPreviaRetificacao', () => {
         expect(screen.getByRole('button', { name: 'Prévia' })).not.toBeDisabled();
     });
 
-    // ── interações de clique ──────────────────────────────────────────────────
+    // interações de clique
     it('clicar no botão chama mutate com o uuid do paa', () => {
         render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
         fireEvent.click(screen.getByRole('button', { name: 'Prévia' }));
@@ -145,7 +145,7 @@ describe('BtnGerarPreviaRetificacao', () => {
         expect(mockMutate).not.toHaveBeenCalled();
     });
 
-    // ── callback de sucesso ───────────────────────────────────────────────────
+    // callback de sucesso
     it('onSuccessGerarDocumentoRetificacao abre o modal e chama iniciarPolling', async () => {
         render(<BtnGerarPreviaRetificacao paa={DEFAULT_PAA} />);
         expect(screen.queryByTestId('modal-info-previa-retif')).not.toBeInTheDocument();

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/types.ts
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/components/BotoesGeracao/types.ts
@@ -1,0 +1,26 @@
+
+interface IBotaoDocumentoProps {
+    disabled: boolean
+    onClick: () => void,
+    title: string,
+    className?: string,
+}
+
+export interface IBotaoGerarDocumentoProps {
+    texto?: string,
+    botaoProps: IBotaoDocumentoProps
+}
+
+export interface IGerarDocumentoProps {
+    paa: {
+        uuid: string,
+        status: string,
+    }
+}
+
+export interface IStatusDocumentoPaa {
+    status?: string;
+    versao?: string;
+    retificacao?: boolean;
+    mensagem?: string;
+}

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetAtaPaaVigente.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetAtaPaaVigente.test.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useGetAtaPaaVigente } from '../useGetAtaPaaVigente';
+import { iniciarAtaPaa } from '../../../../../../../../services/escolas/AtasPaa.service';
+
+jest.mock('../../../../../../../../services/escolas/AtasPaa.service', () => ({
+    iniciarAtaPaa: jest.fn(),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe('useGetAtaPaaVigente', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna ataPaa, isLoading, isFetching, isError, error e refetch', async () => {
+        iniciarAtaPaa.mockResolvedValueOnce({ uuid: 'ata-uuid-1' });
+
+        const { result } = renderHook(() => useGetAtaPaaVigente('paa-uuid-1'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.ataPaa).toEqual({ uuid: 'ata-uuid-1' });
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('chama iniciarAtaPaa com o paaUuid correto', async () => {
+        iniciarAtaPaa.mockResolvedValueOnce({ uuid: 'ata-uuid-1' });
+
+        const { result } = renderHook(() => useGetAtaPaaVigente('paa-uuid-123'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(iniciarAtaPaa).toHaveBeenCalledWith('paa-uuid-123');
+    });
+
+    it('retorna ataPaa={} como valor padrão enquanto carrega', () => {
+        iniciarAtaPaa.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve({ uuid: 'ata' }), 500))
+        );
+
+        const { result } = renderHook(() => useGetAtaPaaVigente('paa-uuid-1'), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.ataPaa).toEqual({});
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.isFetching).toBe(true);
+    });
+
+    it('não executa a query quando paaUuid é undefined', () => {
+        const { result } = renderHook(() => useGetAtaPaaVigente(undefined), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.ataPaa).toEqual({});
+        expect(iniciarAtaPaa).not.toHaveBeenCalled();
+    });
+
+    it('não executa a query quando paaUuid é null', () => {
+        const { result } = renderHook(() => useGetAtaPaaVigente(null), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.ataPaa).toEqual({});
+        expect(iniciarAtaPaa).not.toHaveBeenCalled();
+    });
+
+    it('não executa a query quando paaUuid é string vazia', () => {
+        const { result } = renderHook(() => useGetAtaPaaVigente(''), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.ataPaa).toEqual({});
+        expect(iniciarAtaPaa).not.toHaveBeenCalled();
+    });
+
+    it('retorna isError=true e error quando a API falha', async () => {
+        const mockError = new Error('Erro na API');
+        iniciarAtaPaa.mockRejectedValueOnce(mockError);
+
+        const { result } = renderHook(() => useGetAtaPaaVigente('paa-uuid-1'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.ataPaa).toEqual({});
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error.message).toBe('Erro na API');
+    });
+
+    it('refaz a query quando paaUuid muda', async () => {
+        const data1 = { uuid: 'ata-1' };
+        const data2 = { uuid: 'ata-2' };
+        iniciarAtaPaa.mockResolvedValueOnce(data1).mockResolvedValueOnce(data2);
+
+        const { result, rerender } = renderHook(
+            ({ uuid }) => useGetAtaPaaVigente(uuid),
+            { wrapper: createWrapper(), initialProps: { uuid: 'paa-1' } }
+        );
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.ataPaa).toEqual(data1);
+
+        rerender({ uuid: 'paa-2' });
+
+        await waitFor(() => expect(result.current.ataPaa).toEqual(data2));
+        expect(iniciarAtaPaa).toHaveBeenCalledTimes(2);
+        expect(iniciarAtaPaa).toHaveBeenNthCalledWith(1, 'paa-1');
+        expect(iniciarAtaPaa).toHaveBeenNthCalledWith(2, 'paa-2');
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetObjetivosPaa.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetObjetivosPaa.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useGetObjetivosPaa } from '../useGetObjetivosPaa';
+import { getObjetivosPaa } from '../../../../../../../../services/escolas/Paa.service';
+
+jest.mock('../../../../../../../../services/escolas/Paa.service', () => ({
+    getObjetivosPaa: jest.fn(),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            // retryDelay:0 garante que a retentativa do hook (retry:1) ocorra sem aguardar o
+            // backoff exponencial padrão de 1 s, evitando estouro do timeout do waitFor
+            queries: { retry: false, retryDelay: 0 },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe('useGetObjetivosPaa', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna data, isLoading, isFetching, isError, error e refetch', async () => {
+        const mockData = [{ uuid: 'obj-1', descricao: 'Objetivo 1' }];
+        getObjetivosPaa.mockResolvedValueOnce(mockData);
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.data).toEqual(mockData);
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('chama getObjetivosPaa sem argumentos', async () => {
+        getObjetivosPaa.mockResolvedValueOnce([]);
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(getObjetivosPaa).toHaveBeenCalledTimes(1);
+        expect(getObjetivosPaa).toHaveBeenCalledWith();
+    });
+
+    it('retorna data=[] como valor padrão enquanto carrega', () => {
+        getObjetivosPaa.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve([]), 500))
+        );
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.data).toEqual([]);
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.isFetching).toBe(true);
+    });
+
+    it('executa a query automaticamente (enabled=true, sem parâmetros)', async () => {
+        getObjetivosPaa.mockResolvedValueOnce([{ uuid: 'obj-2' }]);
+
+        renderHook(() => useGetObjetivosPaa(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(getObjetivosPaa).toHaveBeenCalledTimes(1));
+    });
+
+    it('retorna isError=true e error quando a API falha', async () => {
+        const mockError = new Error('Erro na API');
+        // retry: 1 no hook exige rejeição em todas as tentativas
+        getObjetivosPaa.mockRejectedValue(mockError);
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.data).toEqual([]);
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error.message).toBe('Erro na API');
+    });
+
+    it('retorna lista de objetivos corretamente', async () => {
+        const mockData = [
+            { uuid: 'obj-1', descricao: 'Objetivo 1' },
+            { uuid: 'obj-2', descricao: 'Objetivo 2' },
+            { uuid: 'obj-3', descricao: 'Objetivo 3' },
+        ];
+        getObjetivosPaa.mockResolvedValueOnce(mockData);
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.data).toHaveLength(3);
+        expect(result.current.data).toEqual(mockData);
+    });
+
+    it('expõe refetch funcional', async () => {
+        const mockData = [{ uuid: 'obj-1' }];
+        getObjetivosPaa.mockResolvedValue(mockData);
+
+        const { result } = renderHook(() => useGetObjetivosPaa(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(typeof result.current.refetch).toBe('function');
+
+        result.current.refetch();
+        await waitFor(() => expect(getObjetivosPaa).toHaveBeenCalledTimes(2));
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetStatusGeracaoDocumentoPaa.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/useGetStatusGeracaoDocumentoPaa.test.js
@@ -1,0 +1,166 @@
+import React from 'react';
+import { waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useGetStatusGeracaoDocumentoPaa } from '../useGetStatusGeracaoDocumentoPaa';
+import { getStatusGeracaoDocumentoPaa } from '../../../../../../../../services/escolas/Paa.service';
+
+jest.mock('../../../../../../../../services/escolas/Paa.service', () => ({
+    getStatusGeracaoDocumentoPaa: jest.fn(),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe('useGetStatusGeracaoDocumentoPaa', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna isFetching, isError, error, data e refetch', async () => {
+        const mockStatus = { status: 'CONCLUIDO', versao: 'PREVIA' };
+        getStatusGeracaoDocumentoPaa.mockResolvedValueOnce(mockStatus);
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-1'),
+            { wrapper: createWrapper() }
+        );
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+        expect(result.current.data).toEqual(mockStatus);
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('chama getStatusGeracaoDocumentoPaa com o uuid correto', async () => {
+        getStatusGeracaoDocumentoPaa.mockResolvedValueOnce({ status: 'EM_PROCESSAMENTO' });
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-abc'),
+            { wrapper: createWrapper() }
+        );
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+        expect(getStatusGeracaoDocumentoPaa).toHaveBeenCalledWith('paa-uuid-abc');
+    });
+
+    it('não executa a query quando uuid é undefined', () => {
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa(undefined),
+            { wrapper: createWrapper() }
+        );
+
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.data).toBeUndefined();
+        expect(getStatusGeracaoDocumentoPaa).not.toHaveBeenCalled();
+    });
+
+    it('não executa a query quando uuid é null', () => {
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa(null),
+            { wrapper: createWrapper() }
+        );
+
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.data).toBeUndefined();
+        expect(getStatusGeracaoDocumentoPaa).not.toHaveBeenCalled();
+    });
+
+    it('não executa a query quando uuid é string vazia', () => {
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa(''),
+            { wrapper: createWrapper() }
+        );
+
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.data).toBeUndefined();
+        expect(getStatusGeracaoDocumentoPaa).not.toHaveBeenCalled();
+    });
+
+    it('retorna isError=true e error quando a API falha', async () => {
+        const mockError = new Error('Erro ao buscar status');
+        getStatusGeracaoDocumentoPaa.mockRejectedValueOnce(mockError);
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-1'),
+            { wrapper: createWrapper() }
+        );
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error.message).toBe('Erro ao buscar status');
+    });
+
+    it('retorna isFetching=true durante a requisição', () => {
+        getStatusGeracaoDocumentoPaa.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve({ status: 'EM_PROCESSAMENTO' }), 500))
+        );
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-1'),
+            { wrapper: createWrapper() }
+        );
+
+        expect(result.current.isFetching).toBe(true);
+    });
+
+    it('refaz a query quando uuid muda', async () => {
+        const status1 = { status: 'EM_PROCESSAMENTO' };
+        const status2 = { status: 'CONCLUIDO', versao: 'FINAL' };
+        getStatusGeracaoDocumentoPaa.mockResolvedValueOnce(status1).mockResolvedValueOnce(status2);
+
+        const { result, rerender } = renderHook(
+            ({ uuid }) => useGetStatusGeracaoDocumentoPaa(uuid),
+            { wrapper: createWrapper(), initialProps: { uuid: 'paa-uuid-1' } }
+        );
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+        expect(result.current.data).toEqual(status1);
+
+        rerender({ uuid: 'paa-uuid-2' });
+
+        await waitFor(() => expect(result.current.data).toEqual(status2));
+        expect(getStatusGeracaoDocumentoPaa).toHaveBeenCalledTimes(2);
+        expect(getStatusGeracaoDocumentoPaa).toHaveBeenNthCalledWith(1, 'paa-uuid-1');
+        expect(getStatusGeracaoDocumentoPaa).toHaveBeenNthCalledWith(2, 'paa-uuid-2');
+    });
+
+    it('retorna status EM_PROCESSAMENTO corretamente', async () => {
+        getStatusGeracaoDocumentoPaa.mockResolvedValueOnce({ status: 'EM_PROCESSAMENTO' });
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-1'),
+            { wrapper: createWrapper() }
+        );
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+        expect(result.current.data).toEqual({ status: 'EM_PROCESSAMENTO' });
+    });
+
+    it('retorna status CONCLUIDO com versao FINAL corretamente', async () => {
+        const mockStatus = { status: 'CONCLUIDO', versao: 'FINAL', mensagem: 'Documento disponível' };
+        getStatusGeracaoDocumentoPaa.mockResolvedValueOnce(mockStatus);
+
+        const { result } = renderHook(
+            () => useGetStatusGeracaoDocumentoPaa('paa-uuid-1'),
+            { wrapper: createWrapper() }
+        );
+
+        await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+        expect(result.current.data).toEqual(mockStatus);
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePollingStatusDocumento.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePollingStatusDocumento.test.js
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { usePollingStatusDocumento } from '../usePollingStatusDocumento';
 
-// ─── mock de useGetStatusGeracaoDocumentoPaa ──────────────────────────────────
+// mock de useGetStatusGeracaoDocumentoPaa
 const mockRefetch = jest.fn();
 let mockData = undefined;
 let mockIsFetching = false;
@@ -26,7 +26,7 @@ describe('usePollingStatusDocumento', () => {
         jest.useRealTimers();
     });
 
-    // ── shape retornada ───────────────────────────────────────────────────────
+    // shape retornada
     it('retorna statusDocumento, isLoadingStatusDocumento e iniciarPolling', () => {
         const { result } = renderHook(() =>
             usePollingStatusDocumento({ paaUuid: 'test-uuid' })
@@ -57,7 +57,7 @@ describe('usePollingStatusDocumento', () => {
         expect(result.current.isLoadingStatusDocumento).toBe(true);
     });
 
-    // ── efeito de status ─────────────────────────────────────────────────────
+    // efeito de status
     it('chama onConcluidoFinal quando status=CONCLUIDO e versao=FINAL', () => {
         mockData = { status: 'CONCLUIDO', versao: 'FINAL' };
         const onConcluidoFinal = jest.fn();
@@ -110,7 +110,7 @@ describe('usePollingStatusDocumento', () => {
         ).not.toThrow();
     });
 
-    // ── iniciarPolling ────────────────────────────────────────────────────────
+    // iniciarPolling
     it('iniciarPolling chama refetchStatusDoc imediatamente', async () => {
         const { result } = renderHook(() =>
             usePollingStatusDocumento({ paaUuid: 'test-uuid' })
@@ -183,7 +183,7 @@ describe('usePollingStatusDocumento', () => {
         expect(mockRefetch).toHaveBeenCalledTimes(3);
     });
 
-    // ── cleanup na desmontagem ────────────────────────────────────────────────
+    // cleanup na desmontagem
     it('cancela os timers ao desmontar o hook', async () => {
         jest.useFakeTimers();
 

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePollingStatusDocumento.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePollingStatusDocumento.test.js
@@ -1,0 +1,209 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePollingStatusDocumento } from '../usePollingStatusDocumento';
+
+// ─── mock de useGetStatusGeracaoDocumentoPaa ──────────────────────────────────
+const mockRefetch = jest.fn();
+let mockData = undefined;
+let mockIsFetching = false;
+
+jest.mock('../useGetStatusGeracaoDocumentoPaa', () => ({
+    useGetStatusGeracaoDocumentoPaa: () => ({
+        data: mockData,
+        isFetching: mockIsFetching,
+        refetch: mockRefetch,
+    }),
+}));
+
+describe('usePollingStatusDocumento', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockData = undefined;
+        mockIsFetching = false;
+        mockRefetch.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    // ── shape retornada ───────────────────────────────────────────────────────
+    it('retorna statusDocumento, isLoadingStatusDocumento e iniciarPolling', () => {
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        expect(result.current.statusDocumento).toBeUndefined();
+        expect(result.current.isLoadingStatusDocumento).toBe(false);
+        expect(typeof result.current.iniciarPolling).toBe('function');
+    });
+
+    it('expõe statusDocumento retornado pelo useGetStatusGeracaoDocumentoPaa', () => {
+        mockData = { status: 'CONCLUIDO', versao: 'PREVIA' };
+
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        expect(result.current.statusDocumento).toEqual({ status: 'CONCLUIDO', versao: 'PREVIA' });
+    });
+
+    it('expõe isLoadingStatusDocumento mapeado de isFetching', () => {
+        mockIsFetching = true;
+
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        expect(result.current.isLoadingStatusDocumento).toBe(true);
+    });
+
+    // ── efeito de status ─────────────────────────────────────────────────────
+    it('chama onConcluidoFinal quando status=CONCLUIDO e versao=FINAL', () => {
+        mockData = { status: 'CONCLUIDO', versao: 'FINAL' };
+        const onConcluidoFinal = jest.fn();
+
+        renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid', onConcluidoFinal })
+        );
+
+        expect(onConcluidoFinal).toHaveBeenCalledTimes(1);
+    });
+
+    it('não chama onConcluidoFinal quando versao não é FINAL', () => {
+        mockData = { status: 'CONCLUIDO', versao: 'PREVIA' };
+        const onConcluidoFinal = jest.fn();
+
+        renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid', onConcluidoFinal })
+        );
+
+        expect(onConcluidoFinal).not.toHaveBeenCalled();
+    });
+
+    it('não chama onConcluidoFinal quando status é EM_PROCESSAMENTO (mesmo com versao FINAL)', () => {
+        mockData = { status: 'EM_PROCESSAMENTO', versao: 'FINAL' };
+        const onConcluidoFinal = jest.fn();
+
+        renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid', onConcluidoFinal })
+        );
+
+        expect(onConcluidoFinal).not.toHaveBeenCalled();
+    });
+
+    it('não chama onConcluidoFinal quando statusDocumento é undefined', () => {
+        mockData = undefined;
+        const onConcluidoFinal = jest.fn();
+
+        renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid', onConcluidoFinal })
+        );
+
+        expect(onConcluidoFinal).not.toHaveBeenCalled();
+    });
+
+    it('funciona sem onConcluidoFinal — parâmetro é opcional', () => {
+        mockData = { status: 'CONCLUIDO', versao: 'FINAL' };
+
+        expect(() =>
+            renderHook(() => usePollingStatusDocumento({ paaUuid: 'test-uuid' }))
+        ).not.toThrow();
+    });
+
+    // ── iniciarPolling ────────────────────────────────────────────────────────
+    it('iniciarPolling chama refetchStatusDoc imediatamente', async () => {
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        await act(async () => {
+            await result.current.iniciarPolling();
+        });
+
+        expect(mockRefetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('iniciarPolling agenda setInterval que chama refetch repetidamente a cada 5 s', async () => {
+        jest.useFakeTimers();
+
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        await act(async () => {
+            await result.current.iniciarPolling();
+        });
+
+        // 1 chamada inicial (do refetch direto)
+        expect(mockRefetch).toHaveBeenCalledTimes(1);
+
+        // Dispara o setTimeout (2000 ms) que configura o setInterval
+        act(() => {
+            jest.advanceTimersByTime(2000);
+        });
+
+        // 1ª iteração do setInterval (5000 ms)
+        act(() => {
+            jest.advanceTimersByTime(5000);
+        });
+        expect(mockRefetch).toHaveBeenCalledTimes(2);
+
+        // 2ª iteração do setInterval
+        act(() => {
+            jest.advanceTimersByTime(5000);
+        });
+        expect(mockRefetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('novo iniciarPolling cancela o polling anterior antes de iniciar o novo', async () => {
+        jest.useFakeTimers();
+
+        const { result } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        // 1º polling
+        await act(async () => {
+            await result.current.iniciarPolling();
+        });
+
+        // 2º polling — deve cancelar o 1º
+        await act(async () => {
+            await result.current.iniciarPolling();
+        });
+
+        // 2 refetches (um de cada chamada a iniciarPolling)
+        expect(mockRefetch).toHaveBeenCalledTimes(2);
+
+        // Avança 2000 + 5000 ms: setInterval deve disparar apenas 1 vez (apenas do 2º polling)
+        act(() => {
+            jest.advanceTimersByTime(7000);
+        });
+
+        expect(mockRefetch).toHaveBeenCalledTimes(3);
+    });
+
+    // ── cleanup na desmontagem ────────────────────────────────────────────────
+    it('cancela os timers ao desmontar o hook', async () => {
+        jest.useFakeTimers();
+
+        const { result, unmount } = renderHook(() =>
+            usePollingStatusDocumento({ paaUuid: 'test-uuid' })
+        );
+
+        await act(async () => {
+            await result.current.iniciarPolling();
+        });
+
+        const callsAntesDesmontagem = mockRefetch.mock.calls.length;
+
+        unmount();
+
+        // Avança o tempo — refetch não deve ser chamado mais vezes após desmontagem
+        act(() => {
+            jest.advanceTimersByTime(15000);
+        });
+
+        expect(mockRefetch).toHaveBeenCalledTimes(callsAntesDesmontagem);
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePostPaaGeracaoDocumento.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePostPaaGeracaoDocumento.test.js
@@ -1,0 +1,788 @@
+import React from 'react';
+import { waitFor, renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+    usePostPaaGeracaoDocumentoPrevia,
+    usePostPaaGeracaoDocumentoFinal,
+    usePostPaaGeracaoDocumentoPreviaRetificacao,
+    usePostPaaGeracaoDocumentoFinalRetificacao,
+} from '../usePostPaaGeracaoDocumento';
+import {
+    postGerarDocumentoPreviaPaa,
+    postGerarDocumentoFinalPaa,
+    postGerarDocumentoPreviaRetificacaoPaa,
+    postGerarDocumentoFinalRetificacaoPaa,
+} from '../../../../../../../../services/escolas/Paa.service';
+import { toastCustom } from '../../../../../../../Globais/ToastCustom';
+
+jest.mock('../../../../../../../../services/escolas/Paa.service', () => ({
+    postGerarDocumentoPreviaPaa: jest.fn(),
+    postGerarDocumentoFinalPaa: jest.fn(),
+    postGerarDocumentoPreviaRetificacaoPaa: jest.fn(),
+    postGerarDocumentoFinalRetificacaoPaa: jest.fn(),
+}));
+
+jest.mock('../../../../../../../Globais/ToastCustom', () => ({
+    toastCustom: {
+        ToastCustomError: jest.fn(),
+    },
+}));
+
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+    mockConsoleError.mockRestore();
+});
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+// ── usePostPaaGeracaoDocumentoPreviaRetificacao ──────────────────────────────
+
+describe('usePostPaaGeracaoDocumentoPreviaRetificacao', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna objeto de mutação com mutate e isPending', () => {
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        expect(typeof result.current.mutate).toBe('function');
+        expect(result.current.isPending).toBe(false);
+    });
+
+    it('chama postGerarDocumentoPreviaRetificacaoPaa com o uuid correto', async () => {
+        postGerarDocumentoPreviaRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(postGerarDocumentoPreviaRetificacaoPaa).toHaveBeenCalledWith(
+            'uuid-previa-retif-123'
+        );
+    });
+
+    it('chama onSuccessGerarDocumentoRetificacao após sucesso', async () => {
+        postGerarDocumentoPreviaRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: onSuccess,
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('exibe toast com mensagem do servidor quando error.response.data.mensagem existe', async () => {
+        const error = { response: { data: { mensagem: 'Erro específico do servidor' } } };
+        postGerarDocumentoPreviaRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Erro específico do servidor'
+        );
+    });
+
+    it('exibe mensagem de fallback quando error.response.data existe mas sem mensagem', async () => {
+        const error = { response: { data: {} } };
+        postGerarDocumentoPreviaRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Falha ao gerar o documento prévia de retificação.'
+        );
+    });
+
+    it('exibe toast genérico quando não há error.response.data', async () => {
+        const error = new Error('Network Error');
+        postGerarDocumentoPreviaRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Ops! Houve um erro ao tentar gerar o documento prévia de retificação.'
+        );
+    });
+
+    it('registra o erro no console quando a mutação falha', async () => {
+        const error = new Error('Falha de rede');
+        postGerarDocumentoPreviaRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoPreviaRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            'Erro ao gerar documento prévia de retificação do PAA:',
+            error
+        );
+    });
+
+    it('funciona sem callback — padrão não causa erro', async () => {
+        postGerarDocumentoPreviaRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPreviaRetificacao({}),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-retif-123');
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+});
+
+// ── usePostPaaGeracaoDocumentoFinalRetificacao ───────────────────────────────
+
+describe('usePostPaaGeracaoDocumentoFinalRetificacao', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna objeto de mutação com mutate, mutateAsync e isPending', () => {
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        expect(typeof result.current.mutate).toBe('function');
+        expect(typeof result.current.mutateAsync).toBe('function');
+        expect(result.current.isPending).toBe(false);
+    });
+
+    it('chama postGerarDocumentoFinalRetificacaoPaa com uuid e payload corretos', async () => {
+        postGerarDocumentoFinalRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(postGerarDocumentoFinalRetificacaoPaa).toHaveBeenCalledWith(
+            'uuid-final-retif-456',
+            { confirmar: 0 }
+        );
+    });
+
+    it('chama onSuccessGerarDocumentoRetificacao após sucesso', async () => {
+        postGerarDocumentoFinalRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: onSuccess,
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('chama onErrorGerarDocumentoRetificacao quando error.response.data tem mensagem', async () => {
+        const errorData = { mensagem: 'Há pendências obrigatórias' };
+        const error = { response: { data: errorData } };
+        postGerarDocumentoFinalRetificacaoPaa.mockRejectedValueOnce(error);
+        const onError = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: onError,
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(onError).toHaveBeenCalledWith(errorData);
+        expect(toastCustom.ToastCustomError).not.toHaveBeenCalled();
+    });
+
+    it('chama onErrorGerarDocumentoRetificacao quando error.response.data tem confirmar', async () => {
+        const errorData = { confirmar: true, mensagem: 'Confirme para continuar' };
+        const error = { response: { data: errorData } };
+        postGerarDocumentoFinalRetificacaoPaa.mockRejectedValueOnce(error);
+        const onError = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: onError,
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(onError).toHaveBeenCalledWith(errorData);
+        expect(toastCustom.ToastCustomError).not.toHaveBeenCalled();
+    });
+
+    it('exibe toast genérico quando erro não tem response.data relevante', async () => {
+        const error = new Error('Network Error');
+        postGerarDocumentoFinalRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Ops! Houve um erro ao tentar gerar o documento final de retificação.'
+        );
+    });
+
+    it('registra o erro no console quando a mutação falha', async () => {
+        const error = new Error('Falha de rede');
+        postGerarDocumentoFinalRetificacaoPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            'Erro ao gerar documento final de retificaçãodo PAA:',
+            error
+        );
+    });
+
+    it('funciona sem callbacks — padrões não causam erro', async () => {
+        postGerarDocumentoFinalRetificacaoPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoFinalRetificacao({}),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-retif-456', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    it('suporta mutateAsync para uso com await', async () => {
+        postGerarDocumentoFinalRetificacaoPaa.mockResolvedValueOnce({ documento: 'gerado' });
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinalRetificacao({
+                    onSuccessGerarDocumentoRetificacao: jest.fn(),
+                    onErrorGerarDocumentoRetificacao: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        let resolved;
+        await act(async () => {
+            resolved = await result.current.mutateAsync({
+                uuid: 'uuid-final-retif-456',
+                payload: { confirmar: 1 },
+            });
+        });
+
+        expect(resolved).toEqual({ documento: 'gerado' });
+        expect(postGerarDocumentoFinalRetificacaoPaa).toHaveBeenCalledWith(
+            'uuid-final-retif-456',
+            { confirmar: 1 }
+        );
+    });
+});
+
+// ── usePostPaaGeracaoDocumentoPrevia ─────────────────────────────────────────
+
+describe('usePostPaaGeracaoDocumentoPrevia', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna objeto de mutação com mutate e isPending', () => {
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        expect(typeof result.current.mutate).toBe('function');
+        expect(result.current.isPending).toBe(false);
+    });
+
+    it('chama postGerarDocumentoPreviaPaa com o uuid correto', async () => {
+        postGerarDocumentoPreviaPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(postGerarDocumentoPreviaPaa).toHaveBeenCalledWith('uuid-previa-orig-111');
+    });
+
+    it('chama onSuccessGerarDocumento após sucesso', async () => {
+        postGerarDocumentoPreviaPaa.mockResolvedValueOnce({ ok: true });
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: onSuccess }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('exibe toast com mensagem do servidor quando error.response.data.mensagem existe', async () => {
+        const error = { response: { data: { mensagem: 'Erro específico do servidor' } } };
+        postGerarDocumentoPreviaPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Erro específico do servidor'
+        );
+    });
+
+    it('exibe mensagem de fallback quando error.response.data existe mas sem mensagem', async () => {
+        const error = { response: { data: {} } };
+        postGerarDocumentoPreviaPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Falha ao gerar o documento prévia.'
+        );
+    });
+
+    it('exibe toast genérico quando não há error.response.data', async () => {
+        const error = new Error('Network Error');
+        postGerarDocumentoPreviaPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Ops! Houve um erro ao tentar gerar o documento prévia.'
+        );
+    });
+
+    it('registra o erro no console quando a mutação falha', async () => {
+        const error = new Error('Falha de rede');
+        postGerarDocumentoPreviaPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({ onSuccessGerarDocumento: jest.fn() }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            'Erro ao gerar documento prévia do PAA:',
+            error
+        );
+    });
+
+    it('funciona sem callback — padrão não causa erro', async () => {
+        postGerarDocumentoPreviaPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoPrevia({}),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate('uuid-previa-orig-111');
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+});
+
+// ── usePostPaaGeracaoDocumentoFinal ──────────────────────────────────────────
+
+describe('usePostPaaGeracaoDocumentoFinal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retorna objeto de mutação com mutate, mutateAsync e isPending', () => {
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        expect(typeof result.current.mutate).toBe('function');
+        expect(typeof result.current.mutateAsync).toBe('function');
+        expect(result.current.isPending).toBe(false);
+    });
+
+    it('chama postGerarDocumentoFinalPaa com uuid e payload corretos', async () => {
+        postGerarDocumentoFinalPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(postGerarDocumentoFinalPaa).toHaveBeenCalledWith(
+            'uuid-final-orig-222',
+            { confirmar: 0 }
+        );
+    });
+
+    it('chama onSuccessGerarDocumento após sucesso', async () => {
+        postGerarDocumentoFinalPaa.mockResolvedValueOnce({ ok: true });
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: onSuccess,
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('chama onErrorGerarDocumento quando error.response.data tem mensagem', async () => {
+        const errorData = { mensagem: 'Há pendências obrigatórias' };
+        const error = { response: { data: errorData } };
+        postGerarDocumentoFinalPaa.mockRejectedValueOnce(error);
+        const onError = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: onError,
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(onError).toHaveBeenCalledWith(errorData);
+        expect(toastCustom.ToastCustomError).not.toHaveBeenCalled();
+    });
+
+    it('chama onErrorGerarDocumento quando error.response.data tem confirmar', async () => {
+        const errorData = { confirmar: true, mensagem: 'Confirme para continuar' };
+        const error = { response: { data: errorData } };
+        postGerarDocumentoFinalPaa.mockRejectedValueOnce(error);
+        const onError = jest.fn();
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: onError,
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(onError).toHaveBeenCalledWith(errorData);
+        expect(toastCustom.ToastCustomError).not.toHaveBeenCalled();
+    });
+
+    it('exibe toast genérico quando erro não tem response.data relevante', async () => {
+        const error = new Error('Network Error');
+        postGerarDocumentoFinalPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+            'Erro!',
+            'Ops! Houve um erro ao tentar gerar o documento final.'
+        );
+    });
+
+    it('registra o erro no console quando a mutação falha', async () => {
+        const error = new Error('Falha de rede');
+        postGerarDocumentoFinalPaa.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            'Erro ao gerar documento final do PAA:',
+            error
+        );
+    });
+
+    it('funciona sem callbacks — padrões não causam erro', async () => {
+        postGerarDocumentoFinalPaa.mockResolvedValueOnce({ ok: true });
+
+        const { result } = renderHook(
+            () => usePostPaaGeracaoDocumentoFinal({}),
+            { wrapper: createWrapper() }
+        );
+
+        act(() => {
+            result.current.mutate({ uuid: 'uuid-final-orig-222', payload: { confirmar: 0 } });
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    it('suporta mutateAsync para uso com await', async () => {
+        postGerarDocumentoFinalPaa.mockResolvedValueOnce({ documento: 'gerado' });
+
+        const { result } = renderHook(
+            () =>
+                usePostPaaGeracaoDocumentoFinal({
+                    onSuccessGerarDocumento: jest.fn(),
+                    onErrorGerarDocumento: jest.fn(),
+                }),
+            { wrapper: createWrapper() }
+        );
+
+        let resolved;
+        await act(async () => {
+            resolved = await result.current.mutateAsync({
+                uuid: 'uuid-final-orig-222',
+                payload: { confirmar: 1 },
+            });
+        });
+
+        expect(resolved).toEqual({ documento: 'gerado' });
+        expect(postGerarDocumentoFinalPaa).toHaveBeenCalledWith(
+            'uuid-final-orig-222',
+            { confirmar: 1 }
+        );
+    });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePostPaaGeracaoDocumento.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/__tests__/usePostPaaGeracaoDocumento.test.js
@@ -46,7 +46,7 @@ const createWrapper = () => {
     );
 };
 
-// ── usePostPaaGeracaoDocumentoPreviaRetificacao ──────────────────────────────
+// usePostPaaGeracaoDocumentoPreviaRetificacao
 
 describe('usePostPaaGeracaoDocumentoPreviaRetificacao', () => {
     beforeEach(() => {
@@ -219,7 +219,7 @@ describe('usePostPaaGeracaoDocumentoPreviaRetificacao', () => {
     });
 });
 
-// ── usePostPaaGeracaoDocumentoFinalRetificacao ───────────────────────────────
+// usePostPaaGeracaoDocumentoFinalRetificacao
 
 describe('usePostPaaGeracaoDocumentoFinalRetificacao', () => {
     beforeEach(() => {
@@ -428,7 +428,7 @@ describe('usePostPaaGeracaoDocumentoFinalRetificacao', () => {
     });
 });
 
-// ── usePostPaaGeracaoDocumentoPrevia ─────────────────────────────────────────
+// usePostPaaGeracaoDocumentoPrevia
 
 describe('usePostPaaGeracaoDocumentoPrevia', () => {
     beforeEach(() => {
@@ -578,7 +578,7 @@ describe('usePostPaaGeracaoDocumentoPrevia', () => {
     });
 });
 
-// ── usePostPaaGeracaoDocumentoFinal ──────────────────────────────────────────
+// usePostPaaGeracaoDocumentoFinal
 
 describe('usePostPaaGeracaoDocumentoFinal', () => {
     beforeEach(() => {

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/usePollingStatusDocumento.ts
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/usePollingStatusDocumento.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useGetStatusGeracaoDocumentoPaa } from "./useGetStatusGeracaoDocumentoPaa";
+import { IStatusDocumentoPaa } from "../components/BotoesGeracao/types";
+
+interface Options {
+    paaUuid: string;
+    onConcluidoFinal?: () => void;
+}
+
+interface Return {
+    statusDocumento: IStatusDocumentoPaa | undefined;
+    isLoadingStatusDocumento: boolean;
+    iniciarPolling: () => Promise<void>;
+}
+
+export const usePollingStatusDocumento = ({ paaUuid, onConcluidoFinal }: Options): Return => {
+    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const {
+        data: statusDocumento,
+        isFetching: isLoadingStatusDocumento,
+        refetch: refetchStatusDoc,
+    } = useGetStatusGeracaoDocumentoPaa(paaUuid) as {
+        data: IStatusDocumentoPaa | undefined;
+        isFetching: boolean;
+        refetch: () => Promise<unknown>;
+    };
+
+    const stopPolling = useCallback(() => {
+        clearTimeout(timeoutRef.current ?? undefined);
+        clearInterval(timerRef.current ?? undefined);
+        timeoutRef.current = null;
+        timerRef.current = null;
+    }, []);
+
+    useEffect(() => {
+        return () => stopPolling();
+    }, [stopPolling]);
+
+    useEffect(() => {
+        if (statusDocumento?.status && statusDocumento.status !== "EM_PROCESSAMENTO") {
+            stopPolling();
+        }
+        if (statusDocumento?.status === "CONCLUIDO" && statusDocumento?.versao === "FINAL") {
+            onConcluidoFinal?.();
+        }
+    }, [statusDocumento, stopPolling, onConcluidoFinal]);
+
+    const iniciarPolling = useCallback(async () => {
+        stopPolling();
+        await refetchStatusDoc();
+        timeoutRef.current = setTimeout(() => {
+            timerRef.current = setInterval(() => {
+                refetchStatusDoc();
+            }, 5000);
+        }, 2000);
+    }, [refetchStatusDoc, stopPolling]);
+
+    return { statusDocumento, isLoadingStatusDocumento, iniciarPolling };
+};

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/usePostPaaGeracaoDocumento.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/usePostPaaGeracaoDocumento.js
@@ -1,5 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postGerarDocumentoPreviaPaa, postGerarDocumentoFinalPaa } from "../../../../../../../services/escolas/Paa.service";
+import {
+  postGerarDocumentoPreviaPaa,
+  postGerarDocumentoFinalPaa,
+  postGerarDocumentoPreviaRetificacaoPaa,
+  postGerarDocumentoFinalRetificacaoPaa,
+} from "../../../../../../../services/escolas/Paa.service";
 import { toastCustom } from "../../../../../../Globais/ToastCustom";
 
 export const usePostPaaGeracaoDocumentoPrevia = ({
@@ -32,6 +37,37 @@ export const usePostPaaGeracaoDocumentoPrevia = ({
   return mutation;
 };
 
+export const usePostPaaGeracaoDocumentoPreviaRetificacao = ({
+  onSuccessGerarDocumentoRetificacao = () => {},
+}) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (uuid) => {
+      return await postGerarDocumentoPreviaRetificacaoPaa(uuid);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["paaVigente"] });
+      onSuccessGerarDocumentoRetificacao?.()
+    },
+    onError: (error) => {
+      if(error?.response?.data){
+        toastCustom.ToastCustomError(
+          "Erro!",
+          error?.response?.data?.mensagem ||
+          "Falha ao gerar o documento prévia de retificação.");
+      } else {
+        toastCustom.ToastCustomError(
+          "Erro!",
+          "Ops! Houve um erro ao tentar gerar o documento prévia de retificação.");
+      }
+      console.error("Erro ao gerar documento prévia de retificação do PAA:", error);
+    },
+  });
+
+  return mutation;
+};
+
 export const usePostPaaGeracaoDocumentoFinal = ({
   onSuccessGerarDocumento = () => {},
   onErrorGerarDocumento= () => {},
@@ -56,6 +92,37 @@ export const usePostPaaGeracaoDocumentoFinal = ({
         );
       }
       console.error("Erro ao gerar documento final do PAA:", error);
+
+    },
+  });
+
+  return mutation;
+};
+
+export const usePostPaaGeracaoDocumentoFinalRetificacao = ({
+  onSuccessGerarDocumentoRetificacao = () => {},
+  onErrorGerarDocumentoRetificacao= () => {},
+}) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({uuid, payload}) => {
+      return await postGerarDocumentoFinalRetificacaoPaa(uuid, payload);
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["paaVigente"] });
+      onSuccessGerarDocumentoRetificacao?.()
+    },
+    onError: (error) => {
+      if (error?.response?.data?.mensagem || error?.response?.data?.confirmar) {
+        /** Captura de validações */
+        onErrorGerarDocumentoRetificacao?.(error.response.data)
+      } else {
+        toastCustom.ToastCustomError(
+          "Erro!", "Ops! Houve um erro ao tentar gerar o documento final de retificação."
+        );
+      }
+      console.error("Erro ao gerar documento final de retificaçãodo PAA:", error);
 
     },
   });

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Space, Spin } from "antd";
 import { useNavigate } from "react-router-dom";
 import "./styles.css";
@@ -17,23 +17,16 @@ import Loading from "../../../../../../utils/Loading";
 import { TagRetificacao } from "../../../componentes/TagRetificacao";
 import {
   getDownloadArquivoPrevia,
+  getDownloadArquivoPreviaRetificacao,
   getDownloadArquivoFinal,
 } from "../../../../../../services/escolas/Paa.service";
 import { Tooltip as ReactTooltip } from "react-tooltip";
-
-import {
-  usePostPaaGeracaoDocumentoPrevia,
-  usePostPaaGeracaoDocumentoFinal,
-} from "./hooks/usePostPaaGeracaoDocumento";
-
 import { usePaaContext } from "../../../componentes/PaaContext";
-import {
-  ModalInfoGeracaoDocumentoPrevia,
-  ModalInfoGeracaoDocumentoFinal,
-  ModalConfirmaGeracaoFinal,
-  ModalInfoPendenciasGeracaoFinal,
-} from "./ModalInfoGeracaoDocumento";
 import { visoesService } from "../../../../../../services/visoes.service";
+import { BtnGerarFinalOriginal } from "./components/BotoesGeracao/BtnGerarFinalOriginal";
+import { BtnGerarPreviaOriginal } from "./components/BotoesGeracao/BtnGerarPreviaOriginal";
+import { BtnGerarFinalRetificacao } from "./components/BotoesGeracao/BtnGerarFinalRetificacao";
+import { BtnGerarPreviaRetificacao } from "./components/BotoesGeracao/BtnGerarPreviaRetificacao";
 
 const Relatorios = ({ initialExpandedSections }) => {
   const { paa, refetch } = usePaaContext();
@@ -61,89 +54,15 @@ const Relatorios = ({ initialExpandedSections }) => {
     paaVigente?.uuid,
   );
 
-  const timerRef = useRef(null);
-  const timeoutRef = useRef(null);
-
-  useEffect(() => {
-    return () => {
-      clearTimeout(timeoutRef.current);
-      clearInterval(timerRef.current);
-    };
-  }, []);
-
   useEffect(() => {
     if (!paaVigente?.uuid) return;
     refetch();
   }, [paaVigente, refetch]);
 
-  const [
-    openModalInfoGeracaoDocumentoPrevia,
-    setOpenModalInfoGeracaoDocumentoPrevia,
-  ] = useState(false);
-
-  const [pendenciasGeracaoFinal, setPendenciasGeracaoFinal] = useState("");
-
-  const [
-    openModalInfoGeracaoDocumentoFinal,
-    setOpenModalInfoGeracaoDocumentoFinal,
-  ] = useState(false);
-
-  const [openModalConfirmarGeracaoFinal, setOpenModalConfirmarGeracaoFinal] =
-    useState(false);
-
-  const [openModalValidacoesGeracaoFinal, setOpenModalValidacoesGeracaoFinal] =
-    useState(false);
-
-  const [gerandoDocFinal, setGerandoDocFinal] = useState(false);
-
   const {
     data: statusDocumento,
     isFetching: isLoadingStatusDocumento,
-    refetch: refetchStatusDoc,
   } = useGetStatusGeracaoDocumentoPaa(paaVigente?.uuid);
-
-  const verificaStatusAteConcluirGeracao = async () => {
-    await refetchStatusDoc();
-
-    timeoutRef.current = setTimeout(() => {
-      timerRef.current = setInterval(() => {
-        refetchStatusDoc();
-      }, 5000);
-    }, 2000);
-  };
-
-  useEffect(() => {
-    if (statusDocumento?.status !== "EM_PROCESSAMENTO") {
-      clearInterval(timerRef.current);
-    }
-    if (
-      paaVigente?.status !== "EM_RETIFICACAO" &&
-      statusDocumento?.status === "CONCLUIDO" &&
-      statusDocumento?.versao === "FINAL"
-    ) {
-      navigate("/paa-vigente-e-anteriores");
-    }
-  }, [statusDocumento, paaVigente?.status, navigate]);
-
-  const checkStatusGeracaoDocumentoPrevia = async () => {
-    setOpenModalInfoGeracaoDocumentoPrevia(true);
-    verificaStatusAteConcluirGeracao();
-  };
-
-  const checkStatusGeracaoDocumentoFinal = async () => {
-    // Habilitar se necessário a Modal de informação (semelhante à Geração de Prévia)
-    // setOpenModalInfoGeracaoDocumentoFinal(true);
-    verificaStatusAteConcluirGeracao();
-  };
-
-  const onErrorValidacoesPendentesDocumentoFinal = (data) => {
-    if (data?.confirmar) {
-      setOpenModalConfirmarGeracaoFinal(true);
-    } else {
-      setOpenModalValidacoesGeracaoFinal(true);
-      setPendenciasGeracaoFinal(data?.mensagem);
-    }
-  };
 
   const downloadVersaoPrevia = async () => {
     try {
@@ -163,9 +82,21 @@ const Relatorios = ({ initialExpandedSections }) => {
     } catch (e) {
       toastCustom.ToastCustomError(
         "Erro!",
-        "Erro ao efetuar o download Prévia!",
+        "Erro ao efetuar o download da versão final!",
       );
       console.error("Erro ao efetuar o download de versão Final", e);
+    }
+  };
+
+  const downloadVersaoPreviaRetificacao = async () => {
+    try {
+      await getDownloadArquivoPreviaRetificacao(paaVigente?.uuid);
+    } catch (e) {
+      toastCustom.ToastCustomError(
+        "Erro!",
+        "Erro ao efetuar o download da Prévia de Retificação!",
+      );
+      console.error("Erro ao efetuar o download de prévia de retificação", e);
     }
   };
 
@@ -173,57 +104,16 @@ const Relatorios = ({ initialExpandedSections }) => {
     if (statusDocumento?.versao === "FINAL") {
       downloadVersaoFinal();
     } else if (statusDocumento?.versao === "PREVIA") {
-      downloadVersaoPrevia();
+      if (statusDocumento?.retificacao) {
+        downloadVersaoPreviaRetificacao();
+      } else {
+        downloadVersaoPrevia();
+      }
     } else {
       toastCustom.ToastCustomError(
         "Erro!",
         "Versão de arquivo não identificada.",
       );
-    }
-  };
-
-  const mutationGerarDocumentoPrevia = usePostPaaGeracaoDocumentoPrevia({
-    onSuccessGerarDocumento: checkStatusGeracaoDocumentoPrevia,
-  });
-
-  const mutationGerarDocumentoFinal = usePostPaaGeracaoDocumentoFinal({
-    onSuccessGerarDocumento: checkStatusGeracaoDocumentoFinal,
-    onErrorGerarDocumento: onErrorValidacoesPendentesDocumentoFinal,
-  });
-
-  const handleGerarDocumentoPrevia = () => {
-    if (paaVigente?.uuid) {
-      mutationGerarDocumentoPrevia.mutate(paaVigente.uuid);
-    } else {
-      toastCustom.ToastCustomError(
-        "Erro!",
-        "PAA vigente não identificado para geração de prévia.",
-      );
-    }
-  };
-
-  const handleGerarDocumentoFinal = async (confirmar = 0) => {
-    if (!podeEditar) return;   
-    setOpenModalConfirmarGeracaoFinal(false);
-  
-    try {
-        setGerandoDocFinal(true);
-        if (paaVigente?.uuid) {
-            await mutationGerarDocumentoFinal.mutateAsync({
-                uuid: paaVigente.uuid,
-                payload: { confirmar },
-            });
-         
-        } else {
-            toastCustom.ToastCustomError(
-                "Erro!",
-                "PAA vigente não identificado para geração final.",
-            );
-        }       
-    
-    } catch(err) {} 
-    finally {
-       setGerandoDocFinal(false);
     }
   };
 
@@ -287,7 +177,7 @@ const Relatorios = ({ initialExpandedSections }) => {
     historicoAlteracoes?.texto_conclusao,
   ]);
 
-  const renderSecao = (secaoKey, config, podeEditar) => {
+  const renderSecao = (secaoKey, config) => {
     const isExpanded = expandedSections[secaoKey];
 
     return (
@@ -307,64 +197,6 @@ const Relatorios = ({ initialExpandedSections }) => {
       </div>
     );
   };
-
-  const botaoGeracaoPreviaDesabilitado = () => {
-    const informacoes_usuario = visoesService.getPermissoes(["custom_change_paa"])
-
-    const validacoes = [
-      statusDocumento?.status === "EM_PROCESSAMENTO",
-      statusDocumento?.status === "CONCLUIDO" &&
-        statusDocumento?.versao === "FINAL",
-    ];
-
-    if(!informacoes_usuario) return true
-    
-    return validacoes.includes(true);
-  };
-
-  const botaoGeracaoFinalDesabilitado = () => {
-    const validacoes = [
-      !podeEditar,
-      statusDocumento?.status === "EM_PROCESSAMENTO",
-      statusDocumento?.status === "CONCLUIDO" &&
-        statusDocumento?.versao === "FINAL",
-    ];
-    return validacoes.includes(true);
-  };
-
-  const planoAnualDocumentoFinalGerado =
-    statusDocumento?.status === "CONCLUIDO" &&
-    statusDocumento?.versao === "FINAL";
-
-  const botaoGerarAtaDesabilitado = () => {
-    // TODO: Remover: Desabilitar provisoriamente geração de Ata quando Paa está em retificação
-    // até a implementação de geração de documentos de retificação
-    if (paaVigente?.status === 'EM_RETIFICACAO' ) return true;
-    if (!podeEditar) return true;
-    if (!planoAnualDocumentoFinalGerado) return true;
-    if (!ataPaa?.uuid) return true;
-    if (!ataPaa?.completa) return true;
-    return false;
-  };
-
-  const mensagemTooltipGerarAta = () => {
-    // TODO: Remover: Desabilitar provisoriamente geração de Ata quando Paa está em retificação
-    // até a implementação de geração de documentos de retificação
-    if (paaVigente?.status === 'EM_RETIFICACAO' ) {
-      return "Geração de Ata bloqueada para PAA Em Retificação. Implementação Pendente.";
-    }
-    if (!podeEditar) return "Sem permissão para gerar ata.";
-    if (!planoAnualDocumentoFinalGerado) {
-      return "Gere o Plano Anual antes de gerar a ata";
-    }
-    if (!ataPaa?.uuid) return "Ata do PAA não encontrada.";
-    if (!ataPaa?.completa) {
-      return "Quando todos os dados estiverem preenchidos, a opção fica habilitada.";
-    }
-    return "";
-  };
-
-  const gerarAtaDisabled = botaoGerarAtaDesabilitado();
 
   return (
     <div className="relatorios-container">
@@ -428,21 +260,23 @@ const Relatorios = ({ initialExpandedSections }) => {
             
             <div className="documento-actions">
               <Space>
-                <button
-                  className="btn btn-outline-success"
-                  disabled={botaoGeracaoPreviaDesabilitado()}
-                  onClick={handleGerarDocumentoPrevia}
-                >
-                  Prévia
-                </button>
-               
-                <button
-                  className="btn btn-success"
-                  disabled={gerandoDocFinal || botaoGeracaoFinalDesabilitado()}
-                  onClick={() => handleGerarDocumentoFinal(0)}
-                >
-                  Gerar
-                </button>
+                {paaVigente?.uuid && (
+                  paaVigente.status === "EM_RETIFICACAO" ? (
+                      <>
+                        <BtnGerarPreviaRetificacao paa={paaVigente} />
+
+                        <BtnGerarFinalRetificacao paa={paaVigente} />
+
+                      </>
+                    ) : (
+                      <>
+                        <BtnGerarPreviaOriginal paa={paaVigente} />
+
+                        <BtnGerarFinalOriginal paa={paaVigente} />
+
+                      </>
+                    )
+                )}
 
                 <button
                   className="btn-dropdown"
@@ -477,7 +311,7 @@ const Relatorios = ({ initialExpandedSections }) => {
               {!isLoadingPaa &&
                 paaVigente?.uuid &&
                 Object.entries(secoesConfig).map(([secaoKey, config]) =>
-                  renderSecao(secaoKey, config, podeEditar),
+                  renderSecao(secaoKey, config),
                 )}
             </div>
           )}
@@ -486,7 +320,7 @@ const Relatorios = ({ initialExpandedSections }) => {
           <div className="documento-item">
             <div className="documento-info">
               <div className="documento-nome">
-                {paa.status === "EM_RETIFICACAO" ? "Ata de Retificação do PAA" : "Ata de Apresentação do PAA"}
+                {paaVigente?.status === "EM_RETIFICACAO" ? "Ata de Retificação do PAA" : "Ata de Apresentação do PAA"}
               </div>
             </div>
             <div className="documento-actions">
@@ -498,53 +332,25 @@ const Relatorios = ({ initialExpandedSections }) => {
                 >
                   Visualizar prévia da ata
                 </button>
+
+                {/* Apenas botão informativo */}
                 <button
-                  className={`btn ${podeEditar ? "btn-success" : "btn-secondary"}`}
+                  className="btn btn-success"
                   type="button"
-                  disabled={gerarAtaDisabled}
-                  {...(gerarAtaDisabled && {
-                    "data-tooltip-content": mensagemTooltipGerarAta(),
+                  disabled={true}
+                  {...{
+                    "data-tooltip-content": "Gere o Plano anual antes de gerar a Ata",
                     "data-tooltip-id": "tooltip-gerar-ata",
-                  })}
+                  }}
                 >
                   Gerar ata
                 </button>
               </Space>
             </div>
-            {gerarAtaDisabled && (
-              <ReactTooltip id="tooltip-gerar-ata" place="top" />
-            )}
+            <ReactTooltip id="tooltip-gerar-ata" place="top" />
           </div>
         </div>
       </div>
-
-      <ModalInfoGeracaoDocumentoPrevia
-        open={openModalInfoGeracaoDocumentoPrevia}
-        onClose={() => setOpenModalInfoGeracaoDocumentoPrevia(false)}
-      />
-
-      <ModalInfoGeracaoDocumentoFinal
-        open={openModalInfoGeracaoDocumentoFinal}
-        onClose={() => setOpenModalInfoGeracaoDocumentoFinal(false)}
-      />
-
-      <ModalConfirmaGeracaoFinal
-        open={openModalConfirmarGeracaoFinal}
-        onClose={() => {
-            setGerandoDocFinal(false);
-            setOpenModalConfirmarGeracaoFinal(false);
-        }}
-        onConfirm={() => handleGerarDocumentoFinal(1)}
-      />
-
-      <ModalInfoPendenciasGeracaoFinal
-        open={openModalValidacoesGeracaoFinal}
-        onClose={() => {
-            setGerandoDocFinal(false);
-            setOpenModalValidacoesGeracaoFinal(false)
-        }}
-        pendencias={pendenciasGeracaoFinal}
-      />
     </div>
   );
 };

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/BotaoRetificarPaa/BotaoRetificarPaa.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/BotaoRetificarPaa/BotaoRetificarPaa.js
@@ -57,7 +57,7 @@ export const BotaoRetificarPaa = ({paa, statusDocumento}) => {
     }
 
     return (
-        <>
+        <span>
             <Spin spinning={isLoading}>
                 <button
                     type="button"
@@ -76,6 +76,6 @@ export const BotaoRetificarPaa = ({paa, statusDocumento}) => {
                     isLoading={isLoading}
                 />
             </Spin>
-        </>
+        </span>
     );
 };

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
@@ -7,6 +7,7 @@ import {
 import { useDocumentoFinalPaa } from '../../../../../../hooks/Globais/useDocumentoFinalPaa';
 import { PaaSecaoPlanoEAta } from './PaaSecaoPlanoEAta/PaaSecaoPlanoEAta';
 import './PaaCard.scss';
+import { toastCustom } from '../../../../../../componentes/Globais/ToastCustom';
 
 export const PaaCard = ({ dados, onDadosAtualizados }) => {
   const original = dados?.original;
@@ -50,7 +51,14 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
 
   const onDownloadDocumento = useCallback(
     async (bloco) => {
-      await downloadDocumentoFinalPaa(paaUuid, { retificacao: bloco.status.retificacao });
+      try{
+        await downloadDocumentoFinalPaa(paaUuid, { retificacao: bloco.status.retificacao });
+      }catch (error) {
+        if (error.status === 404) {
+          toastCustom.ToastCustomError(
+                'Documento não encontrado', 'Não foi possível encontrar documento para visualização.');
+        }
+      }
     },
     [paaUuid]
   );

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/index.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/index.js
@@ -1,8 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { PaginasContainer } from '../../../../paginas/PaginasContainer';
 import BreadcrumbComponent from '../../../Globais/Breadcrumb';
 import { ASSOCIACAO_UUID } from '../../../../services/auth.service';
-import { visoesService } from '../../../../services/visoes.service';
 import Loading from '../../../../utils/Loading';
 import { usePaaVigenteEAnteriores } from './hooks/usePaaVigenteEAnteriores';
 import { PaaCardBarraTitulo } from './components/PaaCardBarraTitulo/PaaCardBarraTitulo';
@@ -45,12 +44,7 @@ export const PaaVigenteEAnteriores = () => {
     ? { mensagem: vigente.original.documento.status.mensagem }
     : undefined;
 
-  const PaaRetificacaoFeatureFlag = visoesService.featureFlagAtiva('paa-retificacao');
-
-  const exibirBotaoRetificar =
-    Boolean(vigente)
-    && PaaRetificacaoFeatureFlag
-    && (podeExibirBotaoRetificar(vigente) || vigente.esta_em_retificacao);
+  const exibirBotaoRetificar = useMemo(() => podeExibirBotaoRetificar(vigente));
 
   return (
     <PaginasContainer>

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/exibirBotaoRetificarPaa.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/exibirBotaoRetificarPaa.js
@@ -1,3 +1,4 @@
+import { visoesService } from "../../../../../services/visoes.service";
 /**
  * Em retificação, o botão "Retificar o PAA" (nova retificação sobre a atual) só deve aparecer
  * quando a ata de retificação já foi gerada com sucesso.
@@ -12,8 +13,16 @@ export function ataRetificacaoGerada(vigente) {
 
 export function podeExibirBotaoRetificar(vigente) {
   if (!vigente) return false;
-  if (vigente.esta_em_retificacao) {
-    return ataRetificacaoGerada(vigente);
-  }
-  return Boolean(vigente.pode_retificar);
+  const regras_podem_retificar = [
+    visoesService.featureFlagAtiva('paa-retificacao'),
+    vigente.pode_retificar,
+  ]
+  const regras_podem_continuar_retificacao = [
+    visoesService.featureFlagAtiva('paa-retificacao'),
+    vigente.esta_em_retificacao,
+    vigente?.retificacao?.documento?.status?.versao !== 'FINAL',
+  ]
+
+  return regras_podem_retificar.every((regra) => regra === true) ||
+          regras_podem_continuar_retificacao.every((regra) => regra === true);
 }

--- a/src/componentes/escolas/Paa/RetificacaoPaa/index.js
+++ b/src/componentes/escolas/Paa/RetificacaoPaa/index.js
@@ -1,11 +1,13 @@
-import { useCallback, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import PaaBase from "../componentes/PaaBase";
 import { useGetPaaRetificacao } from "../componentes/hooks/useGetPaaRetificacao";
 import { PaaContext } from "../componentes/PaaContext";
+import { toastCustom } from "../../../Globais/ToastCustom";
 
 export const RetificacaoPaa = () => {
   const { uuid_paa } = useParams();
+  const navigate = useNavigate();
 
   const { data: paa, refetch } = useGetPaaRetificacao(uuid_paa);
 
@@ -15,6 +17,15 @@ export const RetificacaoPaa = () => {
       { label: "PAA Vigente e Anteriores", active: true },
     ];
   }, []);
+
+  useEffect(() => {
+    if(paa?.tem_documento_final_concluido && paa.status === "EM_RETIFICACAO"){
+      toastCustom.ToastCustomError(
+        "Documento PAA de retificação já foi gerado!",
+        "Não é permitido realizar alterações neste momento.");
+      navigate("/paa-vigente-e-anteriores");
+    }
+  }, [paa?.tem_documento_final_concluido, paa?.status]);
 
   const renderizar = useCallback(() => {
     if (!uuid_paa) return <></>;

--- a/src/hooks/Globais/useDocumentoFinalPaa.js
+++ b/src/hooks/Globais/useDocumentoFinalPaa.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import api from '../../services/api';
 import { TOKEN_ALIAS } from '../../services/auth.service';
+import { toastCustom } from '../../componentes/Globais/ToastCustom';
 
 const authHeader = () => ({
     headers: {
@@ -34,6 +35,10 @@ export const useDocumentoFinalPaa = () => {
                 return window.URL.createObjectURL(blob);
             } catch (error) {
                 console.error('Erro ao visualizar o documento final do PAA:', error);
+                if (error.status === 404) {
+                    toastCustom.ToastCustomError(
+                        'Documento não encontrado', 'Não foi possível carregar o documento.');
+                }
                 return null;
             } finally {
                 setVisualizacaoEmAndamento(null);

--- a/src/services/escolas/Paa.service.js
+++ b/src/services/escolas/Paa.service.js
@@ -14,6 +14,10 @@ export const postGerarDocumentoFinalPaa = async (paa_uuid, payload={}) => {
   const result = await api.post(`/api/paa/${paa_uuid}/gerar-documento/`, payload, authHeader());
   return result.data;
 };
+export const postGerarDocumentoFinalRetificacaoPaa = async (paa_uuid, payload={}) => {
+  const result = await api.post(`/api/paa/${paa_uuid}/gerar-documento-retificacao/`, payload, authHeader());
+  return result.data;
+};
 export const getPaaRetificacao = async (paa_uuid) => {
   const result = await api.get(`/api/paa/${paa_uuid}/paa-retificacao/`, authHeader());
   return result.data;
@@ -29,6 +33,11 @@ export const postCancelarRetificacaoPaa = async (paa_uuid) => {
 };
 export const postGerarDocumentoPreviaPaa = async (paa_uuid) => {
   const result = await api.post(`/api/paa/${paa_uuid}/gerar-previa-documento/`, {}, authHeader());
+  return result.data;
+};
+
+export const postGerarDocumentoPreviaRetificacaoPaa = async (paa_uuid) => {
+  const result = await api.post(`/api/paa/${paa_uuid}/gerar-previa-retificacao/`, {}, authHeader());
   return result.data;
 };
 
@@ -48,6 +57,25 @@ export const getDownloadArquivoPrevia = async (paa_uuid) => {
             const link = document.createElement('a');
             link.href = url;
             link.setAttribute('download', 'Documento_Prévia_PAA.pdf');
+            document.body.appendChild(link);
+            link.click();
+        }).catch(error => {
+            return error.response;
+        })
+    )
+}
+
+export const getDownloadArquivoPreviaRetificacao = async (paa_uuid) => {
+    return ( await api.get(`/api/paa/${paa_uuid}/documento-previa/?retificacao=true`, {
+            responseType: 'blob',
+            timeout: 30000,
+            ...authHeader()
+        })
+        .then((response) => {
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', 'Documento_Prévia_Retificação_PAA.pdf');
             document.body.appendChild(link);
             link.click();
         }).catch(error => {

--- a/src/services/escolas/__tests__/Paa.test.js
+++ b/src/services/escolas/__tests__/Paa.test.js
@@ -15,11 +15,15 @@ import {
     getTextosPaaUe,
     patchTextosPaaUe,
     postGerarDocumentoFinalPaa,
+    postGerarDocumentoFinalRetificacaoPaa,
     getPaaRetificacao,
     postIniciarRetificacaoPaa,
+    postCancelarRetificacaoPaa,
     postGerarDocumentoPreviaPaa,
+    postGerarDocumentoPreviaRetificacaoPaa,
     getStatusGeracaoDocumentoPaa,
     getDownloadArquivoPrevia,
+    getDownloadArquivoPreviaRetificacao,
     getDownloadArquivoFinal,
     getPaa,
     patchPaa,
@@ -1004,6 +1008,98 @@ describe('Testes para funções de análise', () => {
             getAuthHeader()
         );
         expect(result).toEqual(mockData);
+    });
+
+    test('getPlanoAplicacao deve chamar a API corretamente', async () => {
+        api.get.mockResolvedValue({ data: mockData });
+        const paaUuid = 'paa-uuid';
+        const result = await getPlanoAplicacao(paaUuid);
+
+        expect(api.get).toHaveBeenCalledWith(
+            `api/paa/${paaUuid}/plano-aplicacao/`,
+            getAuthHeader()
+        );
+        expect(result).toEqual(mockData);
+    });
+
+    test('postGerarDocumentoFinalRetificacaoPaa deve chamar a API corretamente', async () => {
+        api.post.mockResolvedValue({ data: mockData });
+        const paa_uuid = 'paa-uuid';
+        const payload = { formato: 'pdf' };
+        const result = await postGerarDocumentoFinalRetificacaoPaa(paa_uuid, payload);
+
+        expect(api.post).toHaveBeenCalledWith(
+            `/api/paa/${paa_uuid}/gerar-documento-retificacao/`,
+            payload,
+            getAuthHeader()
+        );
+        expect(result).toEqual(mockData);
+    });
+
+    test('postGerarDocumentoFinalRetificacaoPaa deve usar payload vazio por padrão', async () => {
+        api.post.mockResolvedValue({ data: mockData });
+        await postGerarDocumentoFinalRetificacaoPaa('paa-uuid');
+
+        expect(api.post).toHaveBeenCalledWith(
+            `/api/paa/paa-uuid/gerar-documento-retificacao/`,
+            {},
+            getAuthHeader()
+        );
+    });
+
+    test('postCancelarRetificacaoPaa deve chamar a API corretamente', async () => {
+        api.post.mockResolvedValue({ data: mockData });
+        const paa_uuid = 'paa-uuid';
+        const result = await postCancelarRetificacaoPaa(paa_uuid);
+
+        expect(api.post).toHaveBeenCalledWith(
+            `/api/paa/${paa_uuid}/cancelar-retificacao/`,
+            {},
+            getAuthHeader()
+        );
+        expect(result).toEqual(mockData);
+    });
+
+    test('postGerarDocumentoPreviaRetificacaoPaa deve chamar a API corretamente', async () => {
+        api.post.mockResolvedValue({ data: mockData });
+        const paa_uuid = 'paa-uuid';
+        const result = await postGerarDocumentoPreviaRetificacaoPaa(paa_uuid);
+
+        expect(api.post).toHaveBeenCalledWith(
+            `/api/paa/${paa_uuid}/gerar-previa-retificacao/`,
+            {},
+            getAuthHeader()
+        );
+        expect(result).toEqual(mockData);
+    });
+
+    it('getDownloadArquivoPreviaRetificacao deve baixar o arquivo corretamente', async () => {
+        const mockBlob = new Blob(['content'], { type: 'application/pdf' });
+        api.get.mockResolvedValue({ data: mockBlob });
+        window.URL.createObjectURL = jest.fn(() => 'blob:previa-retificacao-url');
+        const mockLink = { setAttribute: jest.fn(), click: jest.fn(), href: '' };
+        jest.spyOn(document, 'createElement').mockReturnValue(mockLink);
+        jest.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+
+        await getDownloadArquivoPreviaRetificacao('paa-uuid');
+
+        expect(api.get).toHaveBeenCalledWith(
+            `/api/paa/paa-uuid/documento-previa/?retificacao=true`,
+            expect.objectContaining({ responseType: 'blob', timeout: 30000 })
+        );
+        expect(mockLink.setAttribute).toHaveBeenCalledWith('download', 'Documento_Prévia_Retificação_PAA.pdf');
+        expect(mockLink.click).toHaveBeenCalled();
+
+        jest.restoreAllMocks();
+    });
+
+    it('getDownloadArquivoPreviaRetificacao deve retornar erro quando a API falha', async () => {
+        const mockError = { response: { status: 500 } };
+        api.get.mockRejectedValue(mockError);
+
+        const result = await getDownloadArquivoPreviaRetificacao('paa-uuid');
+
+        expect(result).toEqual(mockError.response);
     });
 
 });


### PR DESCRIPTION

Esse PR:

- Adiciona Modal de Confirmação para Geração Final de Retificação
- Adiciona Modal de Info Pendências de geração Final de Retificação
- Adiciona hook/service de Geração de prévia de retificação
- Adiciona hook/service de Geração de final de retificação
- Adiciona service de prévia de retificação

Reestruturação de lógica de geração de documentos:
- Componentização e separação de lógica de botões com suas respectivas regras
  - BtnGerarFinalOriginal
  - BtnGerarPreviaOriginal
  - BtnGerarFinalRetificacao
  - BtnGerarPreviaRetificacao

- Ajustes e Inclusão de testes unitários

História [AB#145697](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145697)
