### PR TITLE
feature(145734): adiciona tipo da reunião na exibição da ata que foi escolhida na edição da ata

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtaElaboracao/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtaElaboracao/index.jsx
@@ -16,7 +16,7 @@ export const AtaElaboracao = memo((
             <>
                 <div className="col-12 mt-3">
                     <p style={{ color: "#42474A", fontWeight: 400, fontSize: "18px", textTransform: "uppercase" }}>
-                    Ata de Reunião Conjunta Ordinária/Extraordinária do Conselho de Escola e da Associação de Pais e Mestres
+                    Ata de Reunião Conjunta {getTipoReuniao()} do Conselho de Escola e da Associação de Pais e Mestres
                     da(o) {getNomeUnidadeEducacional()}
                     </p>
                 </div>

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtaRetificacao/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtaRetificacao/index.jsx
@@ -10,6 +10,7 @@ export const AtaRetificacao = memo(({
     getHoraInicio,
     getPeriodoPaaFormatado,
     getDataFormatada,
+    getTipoReuniao,
     dataReuniaoElaboracao,
     getNomePresidente,
     getTipoUnidadeComNome
@@ -18,7 +19,7 @@ export const AtaRetificacao = memo(({
         <>
             <div className="col-12 mt-3">
                 <p style={{ color: "#42474A", fontWeight: 400, fontSize: "18px", textTransform: "uppercase" }}>
-                    Ata da Reunião conjunta ordinária da Associação de {getNomeUnidadeEducacional()} para retificação
+                    Ata da Reunião conjunta {getTipoReuniao()} da Associação de {getNomeUnidadeEducacional()} para retificação
                     do Plano  Anual de Atividades da Associação.
                 </p>
                 </div>
@@ -26,7 +27,7 @@ export const AtaRetificacao = memo(({
                 <div className="col-12 mt-4">
                 <p> {/**Alterar as datas para a data da reunião de retificação */}
                     Aos {getDiaPorExtenso()} do mês de {getMesPorExtenso()} de {getAnoPorExtenso()}, na(o) {getLocalReuniao()},
-                    da Unidade Educacional {getNomeUnidade()}, às {getHoraInicio()}, realizou-se Reunião ordinária conjunta dos
+                    da Unidade Educacional {getNomeUnidade()}, às {getHoraInicio()}, realizou-se Reunião {getTipoReuniao()} conjunta dos
                     membros da Associação de {getTipoUnidadeComNome()} e Conselho de Escola, como determina o
                     inciso XIII do artigo 118, da Lei nº 14.660/2007.
                 </p>

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
@@ -95,6 +95,7 @@ export const VisualizacaoAtaPaa = () => {
             getHoraInicio={getHoraInicio}
             getPeriodoPaaFormatado={getPeriodoPaaFormatado}
             getDataFormatada={getDataFormatada}
+            getTipoReuniao={getTipoReuniao}
             dataReuniaoElaboracao={dataReuniaoElaboracao}
             getNomePresidente={getNomePresidente}
             getTipoUnidadeComNome={getTipoUnidadeComNome}


### PR DESCRIPTION

Esse PR:

- Adiciona tipo da reunião na exibição da ata que foi escolhida na edição da ata

Task [AB#149799](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149799)
