### PR TITLE
feat(143252): Inverte ordem dos botões limpar e filtrar de comissões.

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Dre/Comissoes/components/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/Comissoes/components/Filtros.js
@@ -143,19 +143,19 @@ export const Filtros = ({ stateFiltros, handleChangeFiltros, handleSubmitFiltros
             </div>
             <div className="d-flex justify-content-end mt-3">
                 <button
-                    type="submit"
-                    form="form-filtros-motivos-reprovacao-pc"
-                    className="btn btn-success mr-2"
-                >
-                    Filtrar
-                </button>
-                
-                <button
                     type="button"
                     onClick={clearFilter}
                     className="btn btn-outline-success mr-3"
                 >
                     Limpar
+                </button>
+                
+                <button
+                    type="submit"
+                    form="form-filtros-motivos-reprovacao-pc"
+                    className="btn btn-success mr-2"
+                >
+                    Filtrar
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Este PR inclui:

- Altera ordem de exibição dos botões filtrar e cancelar em parametrizações de comissões.

História: [AB#143252](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/143252)
Tarefa: [AB#148901](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148901)