### PR TITLE
Refactor/149732 alterar exibicao abas recuros com filtros

### DIFF
--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/__tests__/Filtros.test.js
@@ -51,7 +51,7 @@ describe('Filtros', () => {
     expect(input.value).toBe('Teste');
   });
 
-  test('Deve chamar setFilter, setCurrentPage e setFirstPage com os valores corretos quando o botão "Filtrar" é clicado', () => {
+  test('Deve chamar setFilter com os valores corretos quando o botão "Filtrar" é clicado', () => {
     renderComponent();
     const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
@@ -60,14 +60,17 @@ describe('Filtros', () => {
     fireEvent.click(filtrarButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: 'Teste', recurso: '123' });
-    expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
-    expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
-    expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
-    expect(mockSetFirstPage).toHaveBeenCalledWith(0);
+
+    const updater = mockSetFilter.mock.calls[0][0];
+    
+    expect(typeof updater).toBe('function');
+    expect(updater({ recurso: '123' })).toEqual({
+      motivo: 'Teste',
+      recurso: '123',
+    });
   });
 
-  test('Deve chamar setFilter, setCurrentPage e setFirstPage com o valor inicial quando o botão "Limpar" é clicado', () => {
+  test('Deve chamar setFilter com o valor inicial quando o botão "Limpar" é clicado', () => {
     renderComponent();
     const input = screen.getByPlaceholderText('Digite o motivo de aprovação de PC com ressalvas');
     fireEvent.change(input, { target: { name: 'motivo', value: 'Teste' } });
@@ -76,11 +79,14 @@ describe('Filtros', () => {
     fireEvent.click(limparButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    expect(mockSetFilter).toHaveBeenCalledWith({ motivo: '', recurso: '123' });
-    expect(mockSetCurrentPage).toHaveBeenCalledTimes(1);
-    expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
-    expect(mockSetFirstPage).toHaveBeenCalledTimes(1);
-    expect(mockSetFirstPage).toHaveBeenCalledWith(0);
+
+    const updater = mockSetFilter.mock.calls[0][0];
+    
+    expect(typeof updater).toBe('function');
+    expect(updater({ recurso: '123' })).toEqual({
+      ...initialFilter,
+      recurso: '123',
+    });
     expect(input.value).toBe("");
   });
 

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Filtros.js
@@ -1,19 +1,16 @@
-import React, {useContext, useState, useEffect} from "react";
-import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
+import React, { useState, useEffect} from "react";
 import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
+import { useMotivosAprovacaoPcRessalvaContext } from "../hooks/useMotivoAprovacaoComRessalvaContext"
 
 export const Filtros = () => {
-
-    const {setFilter, initialFilter, setCurrentPage, setFirstPage} = useContext(MotivosAprovacaoPcRessalvaContext)
     const { selectedRecurso } = useAbasPorRecursoContext();
-    const [formFilter, setFormFilter] = useState({...initialFilter, recurso: selectedRecurso ? selectedRecurso.uuid : ''});
+    const { setFilter, initialFilter } = useMotivosAprovacaoPcRessalvaContext();
+
+    const [formFilter, setFormFilter] = useState(initialFilter);
 
     // Atualiza o formFilter quando o recurso selecionado muda
     useEffect(() => {
-        setFormFilter(prevFilter => ({
-            ...prevFilter,
-            recurso: selectedRecurso ? selectedRecurso.uuid : ''
-        }));
+        setFormFilter(initialFilter);
     }, [selectedRecurso]);
 
     const handleChangeFormFilter = (name, value) => {
@@ -23,63 +20,58 @@ export const Filtros = () => {
         });
     };
 
-    const handleSubmitFormFilter = () => {
-        setCurrentPage(1)
-        setFirstPage(0)
-        setFilter({
+    const handleSubmitFormFilter = (e) => {
+        e.preventDefault();
+
+        setFilter(prevState => ({
             ...formFilter,
-            recurso: selectedRecurso ? selectedRecurso.uuid : ''
-        });
+            recurso: prevState?.recurso ?? '',
+        }));
     };
 
     const clearFilter = () => {
-        setCurrentPage(1)
-        setFirstPage(0)
-        const resetFormFilter = {...initialFilter, recurso: selectedRecurso ? selectedRecurso.uuid : ''};
-        setFormFilter(resetFormFilter);
-        setFilter(resetFormFilter);
+        setFormFilter(initialFilter);
+        setFilter(prevState => ({
+            ...initialFilter,
+            recurso: prevState?.recurso ?? '',
+        }));
     };
     
     return (
-        <>
-            <div className="mb-4">
-                <h4 className="font-weight-bold mb-0">Refine sua busca</h4>
-                <p>
-                    Utilize o filtro por referência para localizar motivos de aprovação com ressalvas específicos.
-                </p>
+        <div className="d-flex bd-highlight align-items-end mt-2">
+            <div className="flex-grow-1 bd-highlight mr-4">
+                <form id="form-filtros-motivos-aprovacao-ressalva-pc" onSubmit={handleSubmitFormFilter}>
+                    <label htmlFor="motivo">Filtrar por motivo de aprovação de PC com ressalvas</label>
+                    <input
+                        value={formFilter.motivo}
+                        onChange={(e) => handleChangeFormFilter(e.target.name, e.target.value)}
+                        name='motivo'
+                        id="motivo"
+                        type="text"
+                        className="form-control"
+                        placeholder='Digite o motivo de aprovação de PC com ressalvas'
+                    />
+                </form>
             </div>
-            <div className="d-flex bd-highlight align-items-end mt-2">
-                <div className="p-2 flex-grow-1 bd-highlight">
-                    <form>
-                        <label htmlFor="motivo">Filtrar por motivo de aprovação de PC com ressalvas</label>
-                        <input
-                            value={formFilter.motivo}
-                            onChange={(e) => handleChangeFormFilter(e.target.name, e.target.value)}
-                            name='motivo'
-                            id="motivo"
-                            type="text"
-                            className="form-control"
-                            placeholder='Digite o motivo de aprovação de PC com ressalvas'
-                        />
-                    </form>
-                </div>
-                <div className="pt-2 pb-2 pr-0 pl-2 bd-highlight">
-                    <button
-                        onClick={clearFilter}
-                        className="btn btn-outline-success"
-                    >
-                        Limpar
-                    </button>
-                </div>
-                <div className="p-2 bd-highlight">
-                    <button
-                        onClick={handleSubmitFormFilter}
-                        className="btn btn-success"
-                    >
-                        Filtrar
-                    </button>
-                </div>
+
+
+            <div className="bd-highlight d-flex align-items-end">
+                <button
+                    type="button"
+                    onClick={clearFilter}
+                    className="btn btn-outline-success mr-2"
+                >
+                    Limpar
+                </button>
+
+                <button
+                    type="submit"
+                    form="form-filtros-motivos-aprovacao-ressalva-pc"
+                    className="btn btn-success"
+                >
+                    Filtrar
+                </button>
             </div>
-        </>
+        </div>
     )
 }

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Lista.js
@@ -1,12 +1,8 @@
-import React, { useContext } from "react";
+import React from "react";
 import { Column } from "primereact/column";
 import { DataTable } from "primereact/datatable";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tooltip as ReactTooltip } from "react-tooltip";
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
 import { useGetMotivosAprovacaoPcRessalva } from "../hooks/useGetMotivosAprovacaoPcRessalva";
 import Loading from "../../../../../../utils/Loading";
-import { MotivosAprovacaoPcRessalvaContext } from '../context/MotivosAprovacaoPcRessalva';
 import { usePostMotivoAprovacaoPcRessalva } from '../hooks/usePostMotivoAprovacaoPcRessalva';
 import { usePatchMotivoAprovacaoPcRessalva } from '../hooks/usePatchMotivoAprovacaoPcRessalva';
 import { useDeleteMotivoAprovacaoPcRessalva } from '../hooks/useDeleteMotivoAprovacaoPcRessalva';
@@ -15,10 +11,11 @@ import {MsgImgCentralizada} from "../../../../../Globais/Mensagens/MsgImgCentral
 import Img404 from "../../../../../../assets/img/img-404.svg";
 import { EditIconButton } from "../../../../../Globais/UI/Button";
 import { ModalConfirmarExclusao } from "../../../../../Globais/ModalAntDesign/ModalConfirmarExclusao";
+import { useMotivosAprovacaoPcRessalvaContext } from "../hooks/useMotivoAprovacaoComRessalvaContext";
 
 export const Lista = () => {
 
-  const { showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao, setShowModalForm, stateFormModal, setStateFormModal, setBloquearBtnSalvarForm } = useContext(MotivosAprovacaoPcRessalvaContext)
+  const { showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao, setShowModalForm, stateFormModal, setStateFormModal, setBloquearBtnSalvarForm } = useMotivosAprovacaoPcRessalvaContext();
   const { isLoading, data } = useGetMotivosAprovacaoPcRessalva()
   const { mutationPost } = usePostMotivoAprovacaoPcRessalva()
   const { mutationPatch } = usePatchMotivoAprovacaoPcRessalva()
@@ -80,26 +77,24 @@ export const Lista = () => {
     );
   }
   return (
-    <>
+    <div className="mt-4">
       {results && results.length > 0 ? (
-          <div className="p-2">
-              <DataTable
-                  value={results}
-                  className='tabela-lista-motivos-aprovacao-pc-ressalva'
-                  data-qa='tabela-lista-motivos-aprovacao-pc-ressalva'
-              >
-                  <Column
-                      field="motivo"
-                      header="Motivos de PC aprovada com ressalva"
-                  />
-                  <Column
-                      field="acao"
-                      header="Ação"
-                      body={acoesTemplate}
-                      style={{width: '10%', textAlign: "center",}}
-                  />
-              </DataTable>
-          </div>
+            <DataTable
+                value={results}
+                className='tabela-lista-motivos-aprovacao-pc-ressalva'
+                data-qa='tabela-lista-motivos-aprovacao-pc-ressalva'
+            >
+                <Column
+                    field="motivo"
+                    header="Motivos de PC aprovada com ressalva"
+                />
+                <Column
+                    field="acao"
+                    header="Ação"
+                    body={acoesTemplate}
+                    style={{width: '10%', textAlign: "center",}}
+                />
+            </DataTable>
       ) :
       <MsgImgCentralizada
             data-qa="imagem-lista-sem-motivos-pagamento-antecipado"
@@ -126,6 +121,6 @@ export const Lista = () => {
                 bodyText="Deseja realmente excluir este motivo de aprovação de PC com ressalva?"
             />
         </section>
-    </>
+    </div>
   )
 }

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Paginacao.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/components/Paginacao.js
@@ -1,18 +1,23 @@
-import React, {useContext} from "react";
+import React from "react";
 import {Paginator} from 'primereact/paginator';
 import { useGetMotivosAprovacaoPcRessalva } from "../hooks/useGetMotivosAprovacaoPcRessalva";
-import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPcRessalva";
+import { useMotivosAprovacaoPcRessalvaContext } from "../hooks/useMotivoAprovacaoComRessalvaContext";
 
 
 export const Paginacao = () => {
     const {isLoading, data, totalMotivosAprovacaoPcRessalva} = useGetMotivosAprovacaoPcRessalva()
     const {count} = data
-    const {setCurrentPage, firstPage,setFirstPage} = useContext(MotivosAprovacaoPcRessalvaContext)
+    const { filter, setFilter } = useMotivosAprovacaoPcRessalvaContext();
 
+    const firstPage = (filter.page - 1) * filter.page_size;
 
     const onPageChange = (event) => {
-        setCurrentPage(event.page + 1)
-        setFirstPage(event.first)
+        const currentPage = event.page + 1;
+        
+        setFilter({
+            ...filter,
+            page: currentPage,
+        })
     };
 
     return (
@@ -20,7 +25,7 @@ export const Paginacao = () => {
             {!isLoading && totalMotivosAprovacaoPcRessalva ? (
                     <Paginator
                         first={firstPage}
-                        rows={10}
+                        rows={filter.page_size}
                         totalRecords={count}
                         template="PrevPageLink PageLinks NextPageLink"
                         onPageChange={onPageChange}

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/context/MotivosAprovacaoPcRessalva.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/context/MotivosAprovacaoPcRessalva.js
@@ -4,6 +4,9 @@ import { useAbasPorRecursoContext } from '../../../componentes/AbasPorRecurso/ho
 const initialFilter = {
     motivo: '',
     recurso: '',
+    page: 1,
+    page_size: 10,
+    is_required_recurso_uuid: true,
 };
 
 const initialStateFormModal = {
@@ -17,11 +20,6 @@ export const MotivosAprovacaoPcRessalvaContext = createContext({
     initialFilter: initialFilter,
     filter: initialFilter,
     setFilter: () => {},
-
-    currentPage: 1,
-    setCurrentPage: () => {},
-    firstPage: 0,
-    setFirstPage: () => {},
 
     showModalForm: false,
     setShowModalForm: () => {},
@@ -41,9 +39,6 @@ export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
 
     const [filter, setFilter] = useState(initialFilter);
 
-    const [currentPage, setCurrentPage] = useState(1);
-    const [firstPage, setFirstPage] = useState(1);
-
     const [showModalForm, setShowModalForm] = useState(false);
     const [stateFormModal, setStateFormModal] = useState(initialStateFormModal);
 
@@ -53,13 +48,10 @@ export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
 
     // Monitora mudanças no recurso selecionado e atualiza o filtro
     useEffect(() => {
-        setFilter(prevFilter => ({
-            ...prevFilter,
+        setFilter({
+            ...initialFilter,
             recurso: selectedRecurso ? selectedRecurso.uuid : ''
-        }));
-        // Reseta para a primeira página quando muda de aba
-        setCurrentPage(1);
-        setFirstPage(0);
+        });
     }, [selectedRecurso]);
 
     const contextValue = useMemo(() => {
@@ -67,10 +59,6 @@ export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
             initialFilter,
             filter,
             setFilter,
-            currentPage,
-            setCurrentPage,
-            firstPage,
-            setFirstPage,
             showModalForm,
             setShowModalForm,
             initialStateFormModal,
@@ -81,7 +69,7 @@ export const MotivosAprovacaoPcRessalvaProvider = ({children}) => {
             bloquearBtnSalvarForm,
             setBloquearBtnSalvarForm,
         };
-    }, [filter, currentPage, firstPage, showModalForm, stateFormModal, showModalConfirmacaoExclusao, bloquearBtnSalvarForm]);
+    }, [filter, showModalForm, stateFormModal, showModalConfirmacaoExclusao, bloquearBtnSalvarForm]);
 
     return (
         <MotivosAprovacaoPcRessalvaContext.Provider value={contextValue}>

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/hooks/useGetMotivosAprovacaoPcRessalva.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/hooks/useGetMotivosAprovacaoPcRessalva.js
@@ -5,11 +5,17 @@ import { MotivosAprovacaoPcRessalvaContext } from "../context/MotivosAprovacaoPc
 
 export const useGetMotivosAprovacaoPcRessalva = () => {
 
-    const {filter, currentPage} = useContext(MotivosAprovacaoPcRessalvaContext)
+    const {filter} = useContext(MotivosAprovacaoPcRessalvaContext)
 
     const { isFetching, isError, data = {count: 0, results: []}, error, refetch } = useQuery({
-        queryKey: ['motivos-aprovacao-pc-ressalva', filter, currentPage],
-        queryFn: ()=> getMotivosAprovacaoPcRessalva(filter, currentPage),
+        queryKey: ['motivos-aprovacao-pc-ressalva', filter],
+        queryFn: ()=> {
+            if (filter?.is_required_recurso_uuid && !filter?.recurso) {
+                return {count: 0, results: []}
+            }
+
+            return getMotivosAprovacaoPcRessalva(filter, filter.page)
+        },
         keepPreviousData: true,
         staleTime: 5000, // 5 segundos
         refetchOnWindowFocus: true, // Caso saia da aba e voltar ele refaz a requisição

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/hooks/useMotivoAprovacaoComRessalvaContext.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/hooks/useMotivoAprovacaoComRessalvaContext.js
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { MotivosAprovacaoPcRessalvaContext } from '../context/MotivosAprovacaoPcRessalva';
+
+/**
+ * Hook para acessar o contexto de Motivos de Aprovação de PC com Ressalvas
+ * Facilita o acesso às propriedades e funções do contexto
+ * @returns {Object} - Retorna o contexto de Motivos de Aprovação de PC com Ressalvas
+ */
+export const useMotivosAprovacaoPcRessalvaContext = () => {
+  const context = useContext(MotivosAprovacaoPcRessalvaContext);
+  
+  if (!context) {
+    throw new Error('useMotivosAprovacaoPcRessalvaContext deve ser usado dentro de um MotivosAprovacaoPcRessalvaProvider');
+  }
+  
+  return context;
+};

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/index.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosAprovacaoPcRessalva/index.js
@@ -17,11 +17,14 @@ export const ParametrizacoesMotivosAprovacaoPcRessalva = () => {
             <PaginasContainer>
                 <h1 className="titulo-itens-painel mt-5">Motivos de aprovação de PC com ressalvas</h1>
                 <div className="page-content-inner">
-                    <Filtros/>
                     <AbasPorRecurso />
+
                     <TopoComBotoes/>
-                    {/* <ExibicaoQuantidade/> */}
+
+                    <Filtros/>
+                    
                     <Lista/>
+                    
                     <Paginacao/>
                 </div>
             </PaginasContainer>

--- a/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Dre/MotivosReprovacaoPc/__tests__/Filtros.test.js
@@ -74,8 +74,7 @@ describe('Filtros', () => {
     fireEvent.click(limparButton);
 
     expect(mockSetFilter).toHaveBeenCalledTimes(1);
-    // expect(mockSetFilter).toHaveBeenCalledWith((prevState) => ({...initialFilter, recurso_uuid: prevState.recurso_uuid}));
-
+    
     const updater = mockSetFilter.mock.calls[0][0];
     
     expect(typeof updater).toBe('function');

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -1243,18 +1243,19 @@ export const deleteMotivoDevolucaoTesouro = async (
 // Motivos de Aprovação de PC com ressalva
 export const getMotivosAprovacaoPcRessalva = async (filter, currentPage) => {
   const { motivo, recurso } = filter;
-  let url = `/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=${10}`;
-  if (recurso) {
-    url += `&recurso_uuid=${recurso}`;
-  }
+  const motivoTrimmed = motivo.trim();
+
+  let url = "/api/motivos-aprovacao-ressalva-parametrizacao/";
+
   return (
     await api.get(
       url,
       {
         ...authHeader(),
         params: {
-          motivo: motivo,
-          recurso: recurso,
+          page_size: 10,
+          motivo: motivoTrimmed,
+          recurso_uuid: recurso,
           page: currentPage,
         },
       }

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -1809,8 +1809,9 @@ describe('Testes para funções de análise', () => {
         const expectedParams = {
             motivo: filter.motivo,
             page: currentPage,
+            page_size: 10,
         };
-        expect(api.get).toHaveBeenCalledWith(`/api/motivos-aprovacao-ressalva-parametrizacao/?page_size=10`, {
+        expect(api.get).toHaveBeenCalledWith(`/api/motivos-aprovacao-ressalva-parametrizacao/`, {
             ...authHeader(),
             params: expectedParams,
         });


### PR DESCRIPTION
Este PR inclui:

- Altera exibição do componente abas por recurso e os filtros na tela de motivos de aprovação com ressalva;
- Limpa filtro ao mudar de recurso;
- Realiza ajustes em testes unitários;

História: [AB#149732](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149732)
Tarefa: [AB#149742](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149742)