### PR TITLE
feat(145799): Altera validação de digitação máscara cnpj

### DIFF
--- a/src/utils/ValidacoesAdicionaisFormularios.js
+++ b/src/utils/ValidacoesAdicionaisFormularios.js
@@ -511,11 +511,11 @@ const calculaDvCnpj = (base12) => {
 export const cpfMaskContitional = (value) => {
   const cpfCnpj = value.replace(/[^A-Za-z0-9]+/g, "").toUpperCase();
 
-  if (cpfCnpj.length <= 11) {
-    return [/\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, '-', /\d/, /\d/];
+  if (cpfCnpj.length > 11 || /[A-Za-z]/.test(cpfCnpj)) {
+    return CNPJ_MASK;
   }
 
-  return CNPJ_MASK;
+  return [/\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, '-', /\d/, /\d/];
 };
 
 export const processoIncorporacaoMask = (value) => {

--- a/src/utils/__tests__/ValidacoesAdicionaisFormularios.test.js
+++ b/src/utils/__tests__/ValidacoesAdicionaisFormularios.test.js
@@ -430,6 +430,16 @@ describe("Máscaras de CPF/CNPJ", () => {
         ]);
     });
 
+    test("Aplica máscara de CNPJ ao digitar letra manualmente", () => {
+        expect(cpfMaskContitional("AB123")).toEqual([
+        /[A-Za-z0-9]/, /[A-Za-z0-9]/, '.',
+        /[A-Za-z0-9]/, /[A-Za-z0-9]/, /[A-Za-z0-9]/, '.',
+        /[A-Za-z0-9]/, /[A-Za-z0-9]/, /[A-Za-z0-9]/, '/',
+        /[A-Za-z0-9]/, /[A-Za-z0-9]/, /[A-Za-z0-9]/, /[A-Za-z0-9]/, '-',
+        /\d/, /\d/
+        ]);
+    });
+
     test("Aplica máscara de processo incorporação", () => {
         expect(processoIncorporacaoMask("12345678000195")).toEqual([
         /\d/, /\d/, /\d/, /\d/, '.', /\d/, /\d/, /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, /\d/, '-', /\d/


### PR DESCRIPTION
Esse PR:

- Altera a validação de digitação para permitir letras nas máscaras de CNPJ.

História: [AB#145799](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145799)