### PR TITLE
feat(145697): Ajusta mensagem de retorno de retificação sem edições

### DIFF
--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetAtividadesEstatutarias.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetAtividadesEstatutarias.test.js
@@ -1,0 +1,725 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  getAtividadesEstatutariasDisponiveis,
+  getAtividadesEstatutariasPrevistas,
+} from "../../../../../../../../../services/escolas/Paa.service";
+import { useGetAtividadesEstatutarias } from "../useGetAtividadesEstatutarias";
+
+jest.mock("../../../../../../../../../services/escolas/Paa.service", () => ({
+  getAtividadesEstatutariasDisponiveis: jest.fn(),
+  getAtividadesEstatutariasPrevistas: jest.fn(),
+}));
+
+const PAA_UUID = "paa-uuid-abc";
+
+const makeDisponivel = (overrides = {}) => ({
+  uuid: "disp-1",
+  nome: "Atividade Disponível",
+  tipo_label: "Reunião",
+  tipo: "reuniao",
+  ano: 2024,
+  mes: 3,
+  mes_label: "Março",
+  status: "pendente",
+  status_label: "Pendente",
+  paa: "paa-uuid-abc",
+  alteracao: null,
+  ...overrides,
+});
+
+const makePrevista = (overrides = {}) => ({
+  uuid: "vinculo-1",
+  atividade_estatutaria: {
+    uuid: "disp-1",
+    nome: "Atividade Prevista",
+    tipo_label: "Reunião",
+    tipo: "reuniao",
+    mes: 3,
+    mes_label: "Março",
+    status: "concluida",
+    status_label: "Concluída",
+    paa: "paa-uuid-abc",
+  },
+  data: "2024-03-15",
+  alteracao: null,
+  ...overrides,
+});
+
+describe("useGetAtividadesEstatutarias", () => {
+  let queryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  describe("comportamento geral da query", () => {
+    it("não executa a query quando PAA não está no localStorage", () => {
+      renderHook(() => useGetAtividadesEstatutarias(), { wrapper });
+
+      expect(getAtividadesEstatutariasDisponiveis).not.toHaveBeenCalled();
+      expect(getAtividadesEstatutariasPrevistas).not.toHaveBeenCalled();
+    });
+
+    it("não executa a query quando PAA está vazio no localStorage", () => {
+      localStorage.setItem("PAA", "");
+
+      renderHook(() => useGetAtividadesEstatutarias(), { wrapper });
+
+      expect(getAtividadesEstatutariasDisponiveis).not.toHaveBeenCalled();
+    });
+
+    it("chama ambos os serviços com o paaUuid do localStorage", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      renderHook(() => useGetAtividadesEstatutarias(), { wrapper });
+
+      await waitFor(() =>
+        expect(getAtividadesEstatutariasDisponiveis).toHaveBeenCalledWith(PAA_UUID)
+      );
+      expect(getAtividadesEstatutariasPrevistas).toHaveBeenCalledWith(PAA_UUID);
+    });
+
+    it("retorna isLoading true enquanto a requisição está em andamento", () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockReturnValue(new Promise(() => {}));
+      getAtividadesEstatutariasPrevistas.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("retorna isError true quando a API falha", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockRejectedValueOnce(
+        new Error("Erro ao buscar disponíveis")
+      );
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+
+    it("retorna atividades vazia e quantidade 0 quando não há dados", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.atividades).toEqual([]);
+      expect(result.current.quantidade).toBe(0);
+    });
+
+    it("expõe a função refetch", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(typeof result.current.refetch).toBe("function");
+    });
+  });
+
+  describe("toArray — formatos de payload aceitos", () => {
+    it("aceita payload com `results` (formato paginado)", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel();
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce({
+        results: [disp],
+      });
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+    });
+
+    it("aceita payload como array direto", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel();
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+    });
+
+    it("retorna array vazio para payload null", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce(null);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce(null);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.atividades).toEqual([]);
+    });
+
+    it("retorna array vazio para payload que não é array nem tem results", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce({
+        data: "formato-desconhecido",
+      });
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce({ count: 0 });
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.atividades).toEqual([]);
+    });
+  });
+
+  describe("normalizaDisponivel", () => {
+    it("mapeia campos corretamente para atividade disponível com paa", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ paa: "paa-uuid-abc" });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.uuid).toBe("disp-1");
+      expect(atividade.atividadeEstatutariaUuid).toBe("disp-1");
+      expect(atividade.descricao).toBe("Atividade Disponível");
+      expect(atividade.tipoAtividade).toBe("Reunião");
+      expect(atividade.tipoAtividadeKey).toBe("reuniao");
+      expect(atividade.mes).toBe(3);
+      expect(atividade.mesLabel).toBe("Março");
+      expect(atividade.status).toBe("pendente");
+      expect(atividade.statusLabel).toBe("Pendente");
+      expect(atividade.isGlobal).toBe(false);
+      expect(atividade.origem).toBe("local");
+      expect(atividade.isNovo).toBe(false);
+      expect(atividade.emEdicao).toBe(false);
+      expect(atividade.vinculoUuid).toBeNull();
+      expect(atividade.data).toBe("");
+    });
+
+    it("marca isGlobal=true e origem=global quando paa é falsy", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ paa: null });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.isGlobal).toBe(true);
+      expect(atividade.origem).toBe("global");
+    });
+
+    it("usa string vazia para campos ausentes (nome, tipo_label, mes_label, status_label)", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = { uuid: "disp-sem-campos", paa: null };
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.descricao).toBe("");
+      expect(atividade.tipoAtividade).toBe("");
+      expect(atividade.mesLabel).toBe("");
+      expect(atividade.statusLabel).toBe("");
+      expect(atividade.ano).toBe("");
+      expect(atividade.mes).toBe("");
+      expect(atividade.status).toBeNull();
+    });
+  });
+
+  describe("normalizaPrevista", () => {
+    it("mapeia campos de atividade_estatutaria corretamente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = makePrevista();
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.atividadeEstatutariaUuid).toBe("disp-1");
+      expect(atividade.vinculoUuid).toBe("vinculo-1");
+      expect(atividade.data).toBe("2024-03-15");
+      expect(atividade.isGlobal).toBe(false);
+      expect(atividade.origem).toBe("local");
+      expect(atividade.isNovo).toBe(false);
+      expect(atividade.emEdicao).toBe(false);
+    });
+
+    it("marca isGlobal=true quando atividade_estatutaria.paa é falsy", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = makePrevista({
+        atividade_estatutaria: {
+          uuid: "ativ-global",
+          paa: null,
+          nome: "Global",
+          tipo_label: "",
+          tipo: "",
+          mes: 1,
+          mes_label: "Janeiro",
+          status: null,
+          status_label: "",
+        },
+      });
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].isGlobal).toBe(true);
+      expect(result.current.atividades[0].origem).toBe("global");
+    });
+
+    it("usa uuid da prevista quando não há atividade_estatutaria (isGlobal=false)", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-direto",
+        descricao: "Prevista Direta",
+        tipo_label: "Workshop",
+        tipo: "workshop",
+        mes: 5,
+        mes_label: "Maio",
+        status: null,
+        status_label: "",
+        data: "2024-05-10",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.uuid).toBe("prev-direto");
+      expect(atividade.atividadeEstatutariaUuid).toBe("prev-direto");
+      expect(atividade.vinculoUuid).toBe("prev-direto");
+      expect(atividade.isGlobal).toBe(false);
+    });
+
+    it("usa data_prevista quando data está ausente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-data-prevista",
+        data_prevista: "2024-07-20",
+        mes_label: "Julho",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].data).toBe("2024-07-20");
+    });
+
+    it("usa dataPrevista quando data e data_prevista estão ausentes", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-dataPrevista",
+        dataPrevista: "2024-08-10",
+        mes_label: "Agosto",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].data).toBe("2024-08-10");
+    });
+
+    it("usa nome quando descricao está ausente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-nome",
+        nome: "Atividade pelo Nome",
+        mes_label: "Setembro",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].descricao).toBe("Atividade pelo Nome");
+    });
+
+    it("usa descricao_atividade quando descricao e nome estão ausentes", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-descricao-atividade",
+        descricao_atividade: "Atividade por descricao_atividade",
+        mes_label: "Outubro",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].descricao).toBe("Atividade por descricao_atividade");
+    });
+
+    it("usa tipoAtividade quando tipo_label está ausente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-tipo-atividade",
+        tipoAtividade: "Palestra",
+        mes_label: "Novembro",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].tipoAtividade).toBe("Palestra");
+    });
+
+    it("usa tipoAtividadeKey quando tipo está ausente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = {
+        uuid: "prev-tipo-key",
+        tipoAtividadeKey: "palestra",
+        mes_label: "Dezembro",
+        alteracao: null,
+      };
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].tipoAtividadeKey).toBe("palestra");
+    });
+  });
+
+  describe("mergeAtividades — lógica de mesclagem", () => {
+    it("mescla disponível com prevista correspondente pelo uuid", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ uuid: "disp-1" });
+      const prev = makePrevista();
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.uuid).toBe("disp-1");
+      expect(atividade.vinculoUuid).toBe("vinculo-1");
+      expect(atividade.data).toBe("2024-03-15");
+    });
+
+    it("mantém disponível sem prevista correspondente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ uuid: "disp-sem-prevista" });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].uuid).toBe("disp-sem-prevista");
+      expect(result.current.atividades[0].vinculoUuid).toBeNull();
+    });
+
+    it("adiciona prevista órfã que não tem disponível correspondente", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([]);
+      const prev = makePrevista();
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].vinculoUuid).toBe("vinculo-1");
+    });
+
+    it("resultado contém disponíveis + previstas órfãs sem duplicatas", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp1 = makeDisponivel({ uuid: "disp-1" });
+      const disp2 = makeDisponivel({ uuid: "disp-2", nome: "Atividade 2" });
+      const prev1 = makePrevista();
+      const prev2 = makePrevista({
+        uuid: "vinculo-orfao",
+        atividade_estatutaria: {
+          uuid: "orfao-1",
+          paa: "paa-uuid-abc",
+          nome: "Órfã",
+          tipo_label: "",
+          tipo: "",
+          mes: 6,
+          mes_label: "Junho",
+          status: null,
+          status_label: "",
+        },
+        data: "2024-06-01",
+      });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp1, disp2]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev1, prev2]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(3));
+
+      const uuids = result.current.atividades.map((a) => a.uuid);
+      expect(uuids).toContain("disp-1");
+      expect(uuids).toContain("disp-2");
+      expect(uuids).toContain("orfao-1");
+    });
+
+    it("usa campos do disponível como fallback quando campos da prevista são vazios", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({
+        uuid: "disp-fallback",
+        nome: "Descrição do Disp",
+        tipo_label: "Tipo Disp",
+        tipo: "tipo_disp_key",
+        mes_label: "Fevereiro",
+        status_label: "Status Disp",
+      });
+      const prev = makePrevista({
+        atividade_estatutaria: {
+          uuid: "disp-fallback",
+          paa: "paa-uuid-abc",
+          nome: "",
+          tipo_label: "",
+          tipo: "",
+          mes: 2,
+          mes_label: "",
+          status: null,
+          status_label: "",
+        },
+        data: "",
+      });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      const atividade = result.current.atividades[0];
+      expect(atividade.descricao).toBe("Descrição do Disp");
+      expect(atividade.tipoAtividade).toBe("Tipo Disp");
+      expect(atividade.tipoAtividadeKey).toBe("tipo_disp_key");
+      expect(atividade.mesLabel).toBe("Fevereiro");
+      expect(atividade.statusLabel).toBe("Status Disp");
+    });
+
+    it("retorna quantidade igual ao número de atividades mescladas", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disponiveis = [
+        makeDisponivel({ uuid: "d1" }),
+        makeDisponivel({ uuid: "d2", nome: "D2" }),
+        makeDisponivel({ uuid: "d3", nome: "D3" }),
+      ];
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce(disponiveis);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(3));
+
+      expect(result.current.atividades).toHaveLength(3);
+    });
+  });
+
+  describe("montarMesAno", () => {
+    it("constrói mesAno no formato 'MesLabel/Ano' quando há data válida", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ uuid: "disp-1", mes_label: "Março" });
+      const prev = makePrevista({ data: "2024-03-15" });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].mesAno).toBe("Março/2024");
+    });
+
+    it("usa só o mesLabel quando não há data", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({
+        uuid: "disp-sem-prevista",
+        mes_label: "Abril",
+      });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].mesAno).toBe("Abril");
+    });
+
+    it("retorna string vazia quando não há mesLabel nem data", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = { uuid: "disp-vazio", paa: null };
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].mesAno).toBe("");
+    });
+
+    it("usa só o mesLabel quando a data é inválida (NaN no getFullYear)", async () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      const disp = makeDisponivel({ uuid: "disp-1", mes_label: "Maio" });
+      const prev = makePrevista({
+        data: "data-invalida",
+        atividade_estatutaria: {
+          uuid: "disp-1",
+          paa: "paa-uuid-abc",
+          nome: "Atividade Prevista",
+          tipo_label: "Reunião",
+          tipo: "reuniao",
+          mes: 5,
+          mes_label: "",
+          status: "concluida",
+          status_label: "Concluída",
+        },
+      });
+      getAtividadesEstatutariasDisponiveis.mockResolvedValueOnce([disp]);
+      getAtividadesEstatutariasPrevistas.mockResolvedValueOnce([prev]);
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.quantidade).toBe(1));
+
+      expect(result.current.atividades[0].mesAno).toBe("Maio");
+    });
+  });
+
+  describe("atividades no estado inicial (sem dado ainda)", () => {
+    it("retorna atividades=[] e quantidade=0 antes da query completar", () => {
+      localStorage.setItem("PAA", PAA_UUID);
+      getAtividadesEstatutariasDisponiveis.mockReturnValue(new Promise(() => {}));
+      getAtividadesEstatutariasPrevistas.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useGetAtividadesEstatutarias(), {
+        wrapper,
+      });
+
+      expect(result.current.atividades).toEqual([]);
+      expect(result.current.quantidade).toBe(0);
+    });
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetAtividadesEstatutariasTabelas.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetAtividadesEstatutariasTabelas.test.js
@@ -1,0 +1,119 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getAtividadesEstatutariasTabelas } from "../../../../../../../../../services/sme/Parametrizacoes.service";
+import { useGetAtividadesEstatutariasTabelas } from "../useGetAtividadesEstatutariasTabelas";
+
+jest.mock("../../../../../../../../../services/sme/Parametrizacoes.service", () => ({
+  getAtividadesEstatutariasTabelas: jest.fn(),
+}));
+
+const mockTabelas = [
+  { uuid: "tabela-1", nome: "Tipo A" },
+  { uuid: "tabela-2", nome: "Tipo B" },
+];
+
+describe("useGetAtividadesEstatutariasTabelas", () => {
+  let queryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("retorna os dados corretamente após requisição bem-sucedida", async () => {
+    getAtividadesEstatutariasTabelas.mockResolvedValueOnce(mockTabelas);
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockTabelas));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("chama getAtividadesEstatutariasTabelas uma vez ao montar", async () => {
+    getAtividadesEstatutariasTabelas.mockResolvedValueOnce(mockTabelas);
+
+    renderHook(() => useGetAtividadesEstatutariasTabelas(), { wrapper });
+
+    await waitFor(() =>
+      expect(getAtividadesEstatutariasTabelas).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  it("retorna isLoading true enquanto a requisição está em andamento", () => {
+    getAtividadesEstatutariasTabelas.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+  });
+
+  it("retorna isError true quando a API falha", async () => {
+    const mockError = new Error("Erro na API");
+    getAtividadesEstatutariasTabelas.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("expõe a função refetch", async () => {
+    getAtividadesEstatutariasTabelas.mockResolvedValueOnce(mockTabelas);
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockTabelas));
+
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("refetch recarrega os dados chamando o serviço novamente", async () => {
+    const mockTabelasAtualizadas = [{ uuid: "tabela-3", nome: "Tipo C" }];
+    getAtividadesEstatutariasTabelas
+      .mockResolvedValueOnce(mockTabelas)
+      .mockResolvedValueOnce(mockTabelasAtualizadas);
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockTabelas));
+
+    result.current.refetch();
+
+    await waitFor(() =>
+      expect(getAtividadesEstatutariasTabelas).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it("utiliza keepPreviousData — dados permanecem acessíveis durante refetch", async () => {
+    getAtividadesEstatutariasTabelas.mockResolvedValue(mockTabelas);
+
+    const { result } = renderHook(() => useGetAtividadesEstatutariasTabelas(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockTabelas));
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toEqual(mockTabelas);
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetRecursosPropriosPrevistos.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/__tests__/useGetRecursosPropriosPrevistos.test.js
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getRecursosPropriosPrevistos } from "../../../../../../../../../services/escolas/Paa.service";
+import { useGetRecursosPropriosPrevistos } from "../useGetRecursosPropriosPrevistos";
+
+jest.mock("../../../../../../../../../services/escolas/Paa.service", () => ({
+  getRecursosPropriosPrevistos: jest.fn(),
+}));
+
+const PAA_UUID = "paa-uuid-123";
+
+const mockRecursos = [
+  { uuid: "recurso-1", descricao: "Recurso A", valor: 1000 },
+  { uuid: "recurso-2", descricao: "Recurso B", valor: 2000 },
+];
+
+describe("useGetRecursosPropriosPrevistos", () => {
+  let queryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("retorna os dados corretamente após requisição bem-sucedida", async () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    getRecursosPropriosPrevistos.mockResolvedValueOnce(mockRecursos);
+
+    const { result } = renderHook(() => useGetRecursosPropriosPrevistos(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockRecursos));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("chama getRecursosPropriosPrevistos com o paaUuid lido do localStorage", async () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    getRecursosPropriosPrevistos.mockResolvedValueOnce(mockRecursos);
+
+    renderHook(() => useGetRecursosPropriosPrevistos(), { wrapper });
+
+    await waitFor(() =>
+      expect(getRecursosPropriosPrevistos).toHaveBeenCalledWith(PAA_UUID)
+    );
+  });
+
+  it("retorna isLoading true enquanto a requisição está em andamento", () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    getRecursosPropriosPrevistos.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGetRecursosPropriosPrevistos(), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+  });
+
+  it("retorna isError true e error preenchido quando a API falha", async () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    const mockError = new Error("Erro na API");
+    getRecursosPropriosPrevistos.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useGetRecursosPropriosPrevistos(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("não executa a query quando PAA não está no localStorage", () => {
+    renderHook(() => useGetRecursosPropriosPrevistos(), { wrapper });
+
+    expect(getRecursosPropriosPrevistos).not.toHaveBeenCalled();
+  });
+
+  it("não executa a query quando PAA está vazio no localStorage", () => {
+    localStorage.setItem("PAA", "");
+
+    renderHook(() => useGetRecursosPropriosPrevistos(), { wrapper });
+
+    expect(getRecursosPropriosPrevistos).not.toHaveBeenCalled();
+  });
+
+  it("expõe a função refetch", async () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    getRecursosPropriosPrevistos.mockResolvedValueOnce(mockRecursos);
+
+    const { result } = renderHook(() => useGetRecursosPropriosPrevistos(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockRecursos));
+
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("refetch recarrega os dados chamando o serviço novamente", async () => {
+    localStorage.setItem("PAA", PAA_UUID);
+    const mockRecursosAtualizados = [{ uuid: "recurso-3", descricao: "Recurso C", valor: 3000 }];
+    getRecursosPropriosPrevistos
+      .mockResolvedValueOnce(mockRecursos)
+      .mockResolvedValueOnce(mockRecursosAtualizados);
+
+    const { result } = renderHook(() => useGetRecursosPropriosPrevistos(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockRecursos));
+
+    result.current.refetch();
+
+    await waitFor(() =>
+      expect(getRecursosPropriosPrevistos).toHaveBeenCalledTimes(2)
+    );
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/ModalInfoGeracaoDocumento.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/ModalInfoGeracaoDocumento.js
@@ -165,7 +165,7 @@ export const ModalInfoPendenciasGeracaoFinalRetificacao = memo(({ open, onClose,
                             {pendencia.includes('introdução') ? 'Introdução' : ''}
                             {pendencia.includes('objetivo') ? 'Objetivos' : ''}
                             {pendencia.includes('conclusão') ? 'Conclusão' : ''}
-                            {pendencia.includes('Nenhuma alteração encontrada') ? 'Retificação sem alterações' : ''}
+                            {pendencia.includes('Nenhuma alteração encontrada') ? 'Não foram realizadas as edições da retificação.' : ''}
                         </li>
                     ))}
                 </ul>

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoAplicacao/hooks/__tests__/useGetPlanoAplicacao.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoAplicacao/hooks/__tests__/useGetPlanoAplicacao.test.js
@@ -1,0 +1,120 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useGetPlanoAplicacao } from "../useGetPlanoAplicacao";
+import { getPlanoAplicacao } from "../../../../../../../../../services/escolas/Paa.service";
+
+jest.mock("../../../../../../../../../services/escolas/Paa.service", () => ({
+  getPlanoAplicacao: jest.fn(),
+}));
+
+describe("useGetPlanoAplicacao", () => {
+  let queryClient;
+  let wrapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    });
+
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  describe("quando paaUuid não é fornecido", () => {
+    it("não deve chamar getPlanoAplicacao com undefined", () => {
+      renderHook(() => useGetPlanoAplicacao(undefined), { wrapper });
+      expect(getPlanoAplicacao).not.toHaveBeenCalled();
+    });
+
+    it("não deve chamar getPlanoAplicacao com string vazia", () => {
+      renderHook(() => useGetPlanoAplicacao(""), { wrapper });
+      expect(getPlanoAplicacao).not.toHaveBeenCalled();
+    });
+
+    it("não deve chamar getPlanoAplicacao com null", () => {
+      renderHook(() => useGetPlanoAplicacao(null), { wrapper });
+      expect(getPlanoAplicacao).not.toHaveBeenCalled();
+    });
+
+    it("deve retornar isLoading como false quando desabilitado", () => {
+      const { result } = renderHook(() => useGetPlanoAplicacao(undefined), { wrapper });
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("deve retornar data como undefined quando desabilitado", () => {
+      const { result } = renderHook(() => useGetPlanoAplicacao(undefined), { wrapper });
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+
+  describe("quando paaUuid é fornecido", () => {
+    const paaUuid = "paa-uuid-123";
+
+    it("deve chamar getPlanoAplicacao com o uuid correto", async () => {
+      getPlanoAplicacao.mockResolvedValueOnce({ uuid: paaUuid, atividades: [] });
+
+      renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(getPlanoAplicacao).toHaveBeenCalledWith(paaUuid));
+    });
+
+    it("deve retornar os dados após consulta bem-sucedida", async () => {
+      const mockData = { uuid: paaUuid, atividades: [{ id: 1 }] };
+      getPlanoAplicacao.mockResolvedValueOnce(mockData);
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.data).toEqual(mockData);
+    });
+
+    it("deve retornar isSuccess como true após consulta bem-sucedida", async () => {
+      getPlanoAplicacao.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    it("deve retornar isError como true quando a consulta falha", async () => {
+      getPlanoAplicacao.mockRejectedValueOnce(new Error("Falha na API"));
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    it("deve expor o objeto error quando a consulta falha", async () => {
+      const mockError = new Error("Erro de rede");
+      getPlanoAplicacao.mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBeDefined();
+    });
+
+    it("deve expor refetch como função", async () => {
+      getPlanoAplicacao.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      expect(typeof result.current.refetch).toBe("function");
+    });
+
+    it("deve deixar de carregar após sucesso", async () => {
+      getPlanoAplicacao.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useGetPlanoAplicacao(paaUuid), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+    });
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoAplicacao/hooks/__tests__/useGetPrioridadesRelatorio.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoAplicacao/hooks/__tests__/useGetPrioridadesRelatorio.test.js
@@ -1,0 +1,255 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useGetPrioridadesRelatorio } from "../useGetPrioridadesRelatorio";
+import { getPrioridadesRelatorio } from "../../../../../../../../../services/escolas/Paa.service";
+import { parseMoneyCentsBRL } from "../../../../../../../../../utils/money";
+
+jest.mock("../../../../../../../../../services/escolas/Paa.service", () => ({
+  getPrioridadesRelatorio: jest.fn(),
+}));
+
+jest.mock("../../../../../../../../../utils/money", () => ({
+  parseMoneyCentsBRL: jest.fn(),
+}));
+
+describe("useGetPrioridadesRelatorio", () => {
+  let queryClient;
+  let wrapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    parseMoneyCentsBRL.mockImplementation((value) => {
+      const clean = value.replace(/[^\d]/g, "");
+      const float = Number.parseFloat(clean) / 100;
+      return Number.isNaN(float) ? null : float;
+    });
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    });
+
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  describe("chamada ao serviço", () => {
+    it("deve chamar getPrioridadesRelatorio com os filtros fornecidos", async () => {
+      const filtros = { periodo: "2024-01", associacao: "uuid-abc" };
+      getPrioridadesRelatorio.mockResolvedValueOnce([]);
+
+      renderHook(() => useGetPrioridadesRelatorio(filtros), { wrapper });
+
+      await waitFor(() =>
+        expect(getPrioridadesRelatorio).toHaveBeenCalledWith(filtros)
+      );
+    });
+
+    it("deve chamar getPrioridadesRelatorio com objeto vazio quando filtros não são fornecidos", async () => {
+      getPrioridadesRelatorio.mockResolvedValueOnce([]);
+
+      renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() =>
+        expect(getPrioridadesRelatorio).toHaveBeenCalledWith({})
+      );
+    });
+
+    it("deve expor refetch como função", () => {
+      getPrioridadesRelatorio.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      expect(typeof result.current.refetch).toBe("function");
+    });
+
+    it("deve retornar isError como true quando a consulta falha", async () => {
+      getPrioridadesRelatorio.mockRejectedValueOnce(new Error("Erro de rede"));
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe("prioridades — formato de resposta", () => {
+    it("deve retornar prioridades como array vazio quando data é undefined", () => {
+      getPrioridadesRelatorio.mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      expect(result.current.prioridades).toEqual([]);
+    });
+
+    it("deve retornar prioridades mapeadas quando data é um array simples", async () => {
+      const item = { id: 1, acao_associacao_objeto: { nome: "Ação A" }, valor_total: 100 };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("Ação A");
+    });
+
+    it("deve retornar prioridades mapeadas quando data tem formato paginado (results)", async () => {
+      const item = { id: 2, acao_associacao_objeto: { nome: "Ação B" }, valor_total: 200 };
+      getPrioridadesRelatorio.mockResolvedValueOnce({ results: [item], count: 1 });
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("Ação B");
+    });
+  });
+
+  describe("mapPrioridade — campo acao", () => {
+    it("deve usar acao_associacao_objeto.nome como acao", async () => {
+      const item = {
+        acao_associacao_objeto: { nome: "PTRF" },
+        acao_pdde_objeto: { nome: "PDDE" },
+        valor_total: 0,
+      };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("PTRF");
+    });
+
+    it("deve usar acao_pdde_objeto.nome quando acao_associacao_objeto não existe", async () => {
+      const item = { acao_pdde_objeto: { nome: "PDDE Acessibilidade" }, valor_total: 0 };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("PDDE Acessibilidade");
+    });
+
+    it("deve retornar 'Recursos Próprios' quando recurso é RECURSO_PROPRIO", async () => {
+      const item = { recurso: "RECURSO_PROPRIO", valor_total: 0 };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("Recursos Próprios");
+    });
+
+    it("deve retornar string vazia quando não há nenhuma fonte de acao", async () => {
+      const item = { recurso: "OUTRO", valor_total: 0 };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].acao).toBe("");
+    });
+  });
+
+  describe("mapPrioridade — campo valor_total", () => {
+    it("deve retornar valor_total diretamente quando já é number", async () => {
+      const item = { valor_total: 150.75, acao_associacao_objeto: { nome: "X" } };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].valor_total).toBe(150.75);
+      expect(parseMoneyCentsBRL).not.toHaveBeenCalled();
+    });
+
+    it("deve parsear valor_total via parseMoneyCentsBRL quando é string", async () => {
+      parseMoneyCentsBRL.mockReturnValueOnce(99.99);
+      const item = { valor_total: "R$ 99,99", acao_associacao_objeto: { nome: "X" } };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(parseMoneyCentsBRL).toHaveBeenCalledWith("R$ 99,99");
+      expect(result.current.prioridades[0].valor_total).toBe(99.99);
+    });
+
+    it("deve usar Number(valor_total) como fallback quando parseMoneyCentsBRL retorna null", async () => {
+      parseMoneyCentsBRL.mockReturnValueOnce(null);
+      const item = { valor_total: "42.5", acao_associacao_objeto: { nome: "X" } };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].valor_total).toBe(42.5);
+    });
+
+    it("deve retornar null quando valor_total é null", async () => {
+      const item = { valor_total: null, acao_associacao_objeto: { nome: "X" } };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].valor_total).toBeNull();
+    });
+
+    it("deve retornar null quando valor_total é undefined", async () => {
+      const item = { acao_associacao_objeto: { nome: "X" } };
+      getPrioridadesRelatorio.mockResolvedValueOnce([item]);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.prioridades[0].valor_total).toBeNull();
+    });
+  });
+
+  describe("quantidade", () => {
+    it("deve usar count da resposta paginada quando disponível", async () => {
+      const items = [{ valor_total: 0, acao_associacao_objeto: { nome: "A" } }];
+      getPrioridadesRelatorio.mockResolvedValueOnce({ results: items, count: 50 });
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(1));
+
+      expect(result.current.quantidade).toBe(50);
+    });
+
+    it("deve usar o length de prioridades quando count não existe", async () => {
+      const items = [
+        { valor_total: 0, acao_associacao_objeto: { nome: "A" } },
+        { valor_total: 0, acao_pdde_objeto: { nome: "B" } },
+      ];
+      getPrioridadesRelatorio.mockResolvedValueOnce(items);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      await waitFor(() => expect(result.current.prioridades).toHaveLength(2));
+
+      expect(result.current.quantidade).toBe(2);
+    });
+
+    it("deve retornar quantidade 0 quando não há dados", () => {
+      getPrioridadesRelatorio.mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useGetPrioridadesRelatorio(), { wrapper });
+
+      expect(result.current.quantidade).toBe(0);
+    });
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/hooks/__tests__/useGetPlanoOrcamentario.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/PlanoOrcamentario/hooks/__tests__/useGetPlanoOrcamentario.test.js
@@ -1,0 +1,139 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getPlanoOrcamentario } from "../../../../../../../../../services/escolas/Paa.service";
+import { useGetPlanoOrcamentario } from "../useGetPlanoOrcamentario";
+
+jest.mock("../../../../../../../../../services/escolas/Paa.service", () => ({
+  getPlanoOrcamentario: jest.fn(),
+}));
+
+const mockResponse = {
+  uuid: "paa-uuid-1",
+  atividades: [{ uuid: "ativ-1", nome: "Atividade Teste" }],
+};
+
+describe("useGetPlanoOrcamentario", () => {
+  let queryClient;
+  const paaUuid = "paa-uuid-1";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+  });
+
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("retorna os dados corretamente após requisição bem-sucedida", async () => {
+    getPlanoOrcamentario.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("chama getPlanoOrcamentario com o paaUuid correto", async () => {
+    getPlanoOrcamentario.mockResolvedValueOnce(mockResponse);
+
+    renderHook(() => useGetPlanoOrcamentario(paaUuid), { wrapper });
+
+    await waitFor(() =>
+      expect(getPlanoOrcamentario).toHaveBeenCalledWith(paaUuid)
+    );
+  });
+
+  it("retorna data como objeto vazio no estado inicial", () => {
+    getPlanoOrcamentario.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    expect(result.current.data).toEqual({});
+  });
+
+  it("retorna isLoading true enquanto a requisição está em andamento", () => {
+    getPlanoOrcamentario.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+  });
+
+  it("retorna isError true e error preenchido quando a API falha", async () => {
+    const mockError = new Error("Erro na API");
+    getPlanoOrcamentario.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.data).toEqual({});
+  });
+
+  it("não executa a query quando paaUuid é undefined", () => {
+    renderHook(() => useGetPlanoOrcamentario(undefined), { wrapper });
+
+    expect(getPlanoOrcamentario).not.toHaveBeenCalled();
+  });
+
+  it("não executa a query quando paaUuid é string vazia", () => {
+    renderHook(() => useGetPlanoOrcamentario(""), { wrapper });
+
+    expect(getPlanoOrcamentario).not.toHaveBeenCalled();
+  });
+
+  it("não executa a query quando options.enabled é false", () => {
+    renderHook(
+      () => useGetPlanoOrcamentario(paaUuid, { enabled: false }),
+      { wrapper }
+    );
+
+    expect(getPlanoOrcamentario).not.toHaveBeenCalled();
+  });
+
+  it("expõe a função refetch", async () => {
+    getPlanoOrcamentario.mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse));
+
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("refetch recarrega os dados chamando o serviço novamente", async () => {
+    const mockResponseUpdated = { uuid: "paa-uuid-1", atividades: [] };
+    getPlanoOrcamentario
+      .mockResolvedValueOnce(mockResponse)
+      .mockResolvedValueOnce(mockResponseUpdated);
+
+    const { result } = renderHook(() => useGetPlanoOrcamentario(paaUuid), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockResponse));
+
+    result.current.refetch();
+
+    await waitFor(() => expect(getPlanoOrcamentario).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/ModalInfoGeracaoDocumento.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/ModalInfoGeracaoDocumento.test.js
@@ -5,7 +5,9 @@ import {
     ModalInfoGeracaoDocumentoPrevia,
     ModalInfoGeracaoDocumentoFinal,
     ModalConfirmaGeracaoFinal,
-    ModalInfoPendenciasGeracaoFinal
+    ModalConfirmaGeracaoFinalRetificacao,
+    ModalInfoPendenciasGeracaoFinal,
+    ModalInfoPendenciasGeracaoFinalRetificacao,
 } from '../ModalInfoGeracaoDocumento';
 
 // Mock do componente ModalFormBodyText
@@ -410,5 +412,240 @@ describe('ModalInfoPendenciasGeracaoFinal', () => {
 
         expect(screen.getByText('Prioridades sem ação e/ou valor total')).toBeInTheDocument();
         expect(screen.getByText('Objetivos')).toBeInTheDocument();
+    });
+});
+
+describe('ModalConfirmaGeracaoFinalRetificacao', () => {
+    const mockOnClose = jest.fn();
+    const mockOnConfirm = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('deve renderizar o modal quando open é true', () => {
+        render(
+            <ModalConfirmaGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                onConfirm={mockOnConfirm}
+            />
+        );
+
+        expect(screen.getByTestId('modal-form-body-text')).toBeInTheDocument();
+        expect(screen.getByTestId('modal-title')).toHaveTextContent('Retificação do PAA');
+    });
+
+    it('não deve renderizar o modal quando open é false', () => {
+        render(
+            <ModalConfirmaGeracaoFinalRetificacao
+                open={false}
+                onClose={mockOnClose}
+                onConfirm={mockOnConfirm}
+            />
+        );
+
+        expect(screen.queryByTestId('modal-form-body-text')).not.toBeInTheDocument();
+    });
+
+    it('deve exibir a mensagem de aviso sobre conclusão', () => {
+        render(
+            <ModalConfirmaGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                onConfirm={mockOnConfirm}
+            />
+        );
+
+        expect(screen.getByText(/Após a conclusão do PAA, não será possível realizar edições/i)).toBeInTheDocument();
+    });
+
+    it('deve chamar onClose ao clicar no botão Cancelar', () => {
+        render(
+            <ModalConfirmaGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                onConfirm={mockOnConfirm}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
+        expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('deve chamar onConfirm ao clicar no botão Continuar', () => {
+        render(
+            <ModalConfirmaGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                onConfirm={mockOnConfirm}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /continuar/i }));
+
+        expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+        expect(mockOnClose).not.toHaveBeenCalled();
+    });
+});
+
+describe('ModalInfoPendenciasGeracaoFinalRetificacao', () => {
+    const mockOnClose = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('deve renderizar o modal quando open é true', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta introdução"
+            />
+        );
+
+        expect(screen.getByTestId('modal-form-body-text')).toBeInTheDocument();
+        expect(screen.getByTestId('modal-title')).toHaveTextContent('Pendências para geração do PAA em retificação');
+    });
+
+    it('não deve renderizar o modal quando open é false', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={false}
+                onClose={mockOnClose}
+                pendencias=""
+            />
+        );
+
+        expect(screen.queryByTestId('modal-form-body-text')).not.toBeInTheDocument();
+    });
+
+    it('deve exibir mensagem sobre preenchimento de seções quando há pendências', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta introdução"
+            />
+        );
+
+        expect(screen.getByText(/É necessário preenchimento nas seguintes seções/i)).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de Prioridades com saldo corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Prioridades - há recurso com saldo."
+            />
+        );
+
+        expect(screen.getByText('Prioridades - há recurso com saldo')).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de Prioridades sem ação corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Prioridades sem ação"
+            />
+        );
+
+        expect(screen.getByText('Prioridades sem ação e/ou valor total')).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de introdução corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta introdução"
+            />
+        );
+
+        expect(screen.getByText('Introdução')).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de objetivo corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta objetivo"
+            />
+        );
+
+        expect(screen.getByText('Objetivos')).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de conclusão corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta conclusão"
+            />
+        );
+
+        expect(screen.getByText('Conclusão')).toBeInTheDocument();
+    });
+
+    it('deve renderizar pendência de Nenhuma alteração encontrada corretamente', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Nenhuma alteração encontrada"
+            />
+        );
+
+        expect(screen.getByText('Não foram realizadas as edições da retificação.')).toBeInTheDocument();
+    });
+
+    it('deve renderizar múltiplas pendências separadas por quebra de linha', () => {
+        const pendencias = 'Falta introdução\nFalta objetivo\nNenhuma alteração encontrada';
+
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias={pendencias}
+            />
+        );
+
+        expect(screen.getByText('Introdução')).toBeInTheDocument();
+        expect(screen.getByText('Objetivos')).toBeInTheDocument();
+        expect(screen.getByText('Não foram realizadas as edições da retificação.')).toBeInTheDocument();
+    });
+
+    it('deve lidar com pendencias undefined', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias={undefined}
+            />
+        );
+
+        expect(screen.getByTestId('modal-form-body-text')).toBeInTheDocument();
+    });
+
+    it('deve chamar onClose ao clicar no botão Ok', () => {
+        render(
+            <ModalInfoPendenciasGeracaoFinalRetificacao
+                open={true}
+                onClose={mockOnClose}
+                pendencias="Falta introdução"
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /ok/i }));
+
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/RelSecaoComponentes.test.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/__tests__/RelSecaoComponentes.test.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RelSecaoComponentes } from "../RelSecaoComponentes";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("../styles.css", () => ({}));
+
+describe("RelSecaoComponentes", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  test("renderiza os três componentes de seção", () => {
+    render(<RelSecaoComponentes />);
+
+    expect(screen.getByText("Plano de Aplicação")).toBeInTheDocument();
+    expect(screen.getByText("Plano Orçamentário")).toBeInTheDocument();
+    expect(screen.getByText("Atividades Previstas")).toBeInTheDocument();
+  });
+
+  test("renderiza os botões de ação corretos", () => {
+    render(<RelSecaoComponentes />);
+
+    const botoes = screen.getAllByRole("button");
+    expect(botoes).toHaveLength(3);
+    expect(botoes[0]).toHaveTextContent("Visualizar");
+    expect(botoes[1]).toHaveTextContent("Visualizar");
+    expect(botoes[2]).toHaveTextContent("Editar");
+  });
+
+  test("navega para rota do Plano de Aplicação ao clicar", () => {
+    render(<RelSecaoComponentes />);
+
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/relatorios-componentes/plano-aplicacao");
+  });
+
+  test("navega para rota do Plano Orçamentário ao clicar", () => {
+    render(<RelSecaoComponentes />);
+
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/relatorios-componentes/plano-orcamentario");
+  });
+
+  test("navega para rota de Atividades Previstas ao clicar", () => {
+    render(<RelSecaoComponentes />);
+
+    fireEvent.click(screen.getAllByRole("button")[2]);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/relatorios-componentes/atividades-previstas");
+  });
+
+  test("último item possui classe sem-borda", () => {
+    const { container } = render(<RelSecaoComponentes />);
+
+    const itens = container.querySelectorAll(".componentes-secao-item");
+    expect(itens[2]).toHaveClass("sem-borda");
+    expect(itens[0]).not.toHaveClass("sem-borda");
+    expect(itens[1]).not.toHaveClass("sem-borda");
+  });
+
+  test("botões com variante secundaria possuem classe btn-outline-success", () => {
+    const { container } = render(<RelSecaoComponentes />);
+
+    const botoes = container.querySelectorAll(".componentes-secao-botao");
+    botoes.forEach((botao) => {
+      expect(botao).toHaveClass("btn-outline-success");
+    });
+  });
+});


### PR DESCRIPTION

Esse PR:

- Ajusta a mensagem de retorno quando, na tentativa de gerar documento de retificação, não há nenhum alteração encontrada

História [AB#145697](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145697)
