### PR TITLE
fix: ajusta exibição do secretário na visualização da prévia da ata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.41.0",
+  "version": "9.41.1",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
@@ -1,0 +1,97 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useVisualizacaoAtaPaa } from '../useVisualizacaoAtaPaa';
+import { getAtaPaa, getTabelasAtasPaa } from '../../../../../../../services/escolas/AtasPaa.service';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+  useLocation: () => ({
+    pathname: '/',
+    state: {},
+  }),
+  useParams: () => ({
+    uuid_paa: '123',
+  }),
+}));
+
+jest.mock('../../../../../../../services/escolas/AtasPaa.service', () => ({
+  getAtaPaa: jest.fn(),
+  getTabelasAtasPaa: jest.fn(),
+}));
+
+jest.mock('../../../../../../../services/escolas/PresentesAtaPaa.service', () => ({
+  getListaPresentesPaa: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock(
+  '../../../../../Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/hooks/useGetAtaPaaVigente',
+  () => ({
+    useGetAtaPaaVigente: () => ({
+      ataPaa: {
+        uuid: 'ata-123',
+      },
+    }),
+  })
+);
+
+jest.mock(
+  '../../../../../Paa/componentes/hooks/useGetPaa',
+  () => ({
+    useGetPaa: () => ({
+      data: {},
+    }),
+  })
+);
+
+jest.mock('../useGetPrioridadesAtaPaa', () => ({
+  useGetPrioridadesAtaPaa: () => ({
+    prioridadesAgrupadas: [],
+    isLoading: false,
+  }),
+}));
+
+jest.mock(
+  '../../../../../Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/hooks/useGetAtividadesEstatutarias',
+  () => ({
+    useGetAtividadesEstatutarias: () => ({
+      atividades: [],
+      isLoading: false,
+    }),
+  })
+);
+
+describe('useVisualizacaoAtaPaa', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getTabelasAtasPaa.mockResolvedValue({});
+  });
+
+  it('deve retornar o nome do secretário', async () => {
+    getAtaPaa.mockResolvedValue({
+      secretario_reuniao: 'João da Silva',
+    });
+
+    const { result } = renderHook(() => useVisualizacaoAtaPaa());
+
+    await waitFor(() => {
+      expect(
+        result.current.getNomeSecretarioReuniao()
+      ).toBe('João da Silva');
+    });
+  });
+
+  it('deve retornar placeholder quando não houver secretário', async () => {
+    getAtaPaa.mockResolvedValue({
+      secretario_reuniao: null,
+    });
+
+    const { result } = renderHook(() => useVisualizacaoAtaPaa());
+
+    await waitFor(() => {
+      expect(
+        result.current.getNomeSecretarioReuniao()
+      ).toBe('_____');
+    });
+  });
+});

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
@@ -295,12 +295,11 @@ export const useVisualizacaoAtaPaa = () => {
 
     const getNomeSecretarioReuniao = useMemo(() => {
         return () => {
-            const secretarioReuniao = listaCompletaParticipantes.find(p => 
-                p.secretario_da_reuniao
-            );
-            return secretarioReuniao && secretarioReuniao.nome ? secretarioReuniao.nome : "_____";
+            const secretarioReuniao = dadosAta.secretario_reuniao
+
+            return secretarioReuniao ? secretarioReuniao : "_____";
         };
-    }, [listaCompletaParticipantes]);
+    }, [dadosAta.secretario_reuniao]);
 
     const atualizarAlturaDocumento = useCallback(() => {
         if (referenciaDocumento.current) {

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
@@ -58,7 +58,6 @@ export const VisualizacaoAtaPaa = () => {
   const dataReuniaoElaboracao = paaRetificacao?.ata_elaboracao?.data_reuniao;
   
   return (
-    <>
       <div className="col-12 container-visualizacao-da-ata mb-5" ref={referenciaDocumento}>
         {alturaDocumento > 0 && <WatermarkPrevia alturaDocumento={alturaDocumento} icon="rascunho" />}
         <div className="col-12 mt-4">
@@ -162,6 +161,5 @@ export const VisualizacaoAtaPaa = () => {
           />
         )}
       </div>
-    </>
   );
 };


### PR DESCRIPTION

Esse PR:

- Ajusta exibição do secretário na visualização da prévia da ata

História [AB#148912](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148912)

