### PR TITLE
feat(148838): Parametrização de repasses por recurso em abas.

### DIFF
--- a/src/componentes/Globais/ArquivosDeCarga/__tests__/index.test.js
+++ b/src/componentes/Globais/ArquivosDeCarga/__tests__/index.test.js
@@ -64,13 +64,23 @@ jest.mock("../../../../services/visoes.service", () => ({
 }));
 
 jest.mock("../../../../context/RecursoSelecionado", () => ({
-  useRecursoSelecionadoContext: jest.fn(() => ({ recursoSelecionado: null })),
+  useRecursoSelecionadoContext: jest.fn(() => ({ 
+    recursoSelecionado: null,
+    recursos: [],
+    isLoading: false,
+    setSelectedRecurso: jest.fn(),
+  })),
 }));
 
 describe("Renderiza Tipos de Carga existentes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useRecursoSelecionadoContext.mockReturnValue({ recursoSelecionado: null });
+    useRecursoSelecionadoContext.mockReturnValue({ 
+      recursoSelecionado: null,
+      recursos: [],
+      isLoading: false,
+      setSelectedRecurso: jest.fn(),
+    });
   });
 
   it("renderiza CARGA_ASSOCIACOES", async () => {
@@ -149,7 +159,7 @@ describe("Renderiza Tipos de Carga existentes", () => {
         </Routes>
       </MemoryRouter>
     );
-    expect(await screen.findByText("Cargas de repasses previstos")).toBeInTheDocument();
+    expect(await screen.findByText("Repasses")).toBeInTheDocument();
   });
 
   it("renderiza REPASSE_REALIZADO", async () => {
@@ -163,7 +173,7 @@ describe("Renderiza Tipos de Carga existentes", () => {
       </MemoryRouter>
     );
 
-    const elemento = await screen.findByText("Cargas de repasses realizados");
+    const elemento = await screen.findByText("Repasses");
     expect(elemento).toBeInTheDocument();
   });
 
@@ -172,7 +182,12 @@ describe("Renderiza Tipos de Carga existentes", () => {
 describe("ArquivosDeCarga Componente", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useRecursoSelecionadoContext.mockReturnValue({ recursoSelecionado: null });
+    useRecursoSelecionadoContext.mockReturnValue({ 
+      recursoSelecionado: null,
+      recursos: [],
+      isLoading: false,
+      setSelectedRecurso: jest.fn(),
+    });
   });
   
   test("Carrega os elementos na página", async () => {
@@ -313,7 +328,12 @@ describe("ArquivosDeCarga Componente", () => {
 describe("Listagem de Arquivos Carga", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useRecursoSelecionadoContext.mockReturnValue({ recursoSelecionado: null });
+    useRecursoSelecionadoContext.mockReturnValue({ 
+      recursoSelecionado: null,
+      recursos: [],
+      isLoading: false,
+      setSelectedRecurso: jest.fn(),
+    });
     RetornaSeTemPermissaoEdicaoPainelParametrizacoes.mockReturnValue(true);
     getTabelaArquivosDeCarga.mockResolvedValue(tabelaArquivos);
     getArquivosDeCargaFiltros.mockResolvedValue(listaArquivos);
@@ -344,7 +364,12 @@ describe("Listagem de Arquivos Carga", () => {
 describe("Ações dos botões", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useRecursoSelecionadoContext.mockReturnValue({ recursoSelecionado: null });
+    useRecursoSelecionadoContext.mockReturnValue({ 
+      recursoSelecionado: null,
+      recursos: [],
+      isLoading: false,
+      setSelectedRecurso: jest.fn(),
+    });
     RetornaSeTemPermissaoEdicaoPainelParametrizacoes.mockReturnValue(true);
     getTabelaArquivosDeCarga.mockResolvedValue(tabelaArquivos);
     getArquivosDeCargaFiltros.mockResolvedValue(listaArquivos);
@@ -457,7 +482,7 @@ describe("Ações dos botões", () => {
         const botaoAcao = Array.from(botoes).filter(btn => btn.textContent.trim() === "Editar")[0];
         fireEvent.click(botaoAcao);
 
-        expect(screen.getByText('Editar conta de associação')).toBeInTheDocument;
+        expect(screen.getByText('Editar conta de associação')).toBeInTheDocument();
 
         const botaoSalvarEnviar = screen.getByText('Salvar e enviar')
         expect(botaoSalvarEnviar).toBeInTheDocument()
@@ -470,7 +495,7 @@ describe("Ações dos botões", () => {
   test("Botão de Ação Editar REPASSE PREVISTO", async () => {
     // Testar Edição quando a condição
     useParams.mockReturnValue({ tipo_de_carga: "REPASSE_PREVISTO" });
-    getArquivosDeCargaFiltros.mockReturnValue(listaArquivos);
+    getArquivosDeCargaFiltros.mockResolvedValue(listaArquivos);
     render(
       <MemoryRouter initialEntries={["/parametro-arquivos-de-carga/REPASSE_PREVISTO"]}>
         <Routes>

--- a/src/componentes/Globais/ArquivosDeCarga/index.js
+++ b/src/componentes/Globais/ArquivosDeCarga/index.js
@@ -44,6 +44,8 @@ const ArquivosDeCarga = () => {
 
   const url_params = useParams();
   const is_acoes_associacoes = url_params.tipo_de_carga === "CARGA_ACOES_ASSOCIACOES";
+  const is_repasse_previsto = url_params.tipo_de_carga === "REPASSE_PREVISTO";
+  const is_repasse_realizado = url_params.tipo_de_carga === "REPASSE_REALIZADO";
   const dadosDeOrigem = useMemo(() => {
     let obj = {
       titulo: "",
@@ -71,11 +73,12 @@ const ArquivosDeCarga = () => {
         titulo: "Ações das Associações",
         titulo_modal: "ações das associações",
         acesso_permitido: true,
+        url_go_back: "/parametro-acoes-associacoes/",
         UrlsMenuInterno: [
           {
             label: "Cargas de arquivo",
             url: "parametro-arquivos-de-carga",
-            origem: "CARGA_ACOES_ASSOCIACOES",
+            origem: "CARGA_ACOES_ASSOCIACOES"
           },
         ],
       };
@@ -149,8 +152,8 @@ const ArquivosDeCarga = () => {
         titulo: "Repasses",
         titulo_modal: "repasse previsto",
         acesso_permitido: true,
+        url_go_back: "/parametro-repasse/",
         UrlsMenuInterno: [
-          { label: "Repasses", url: "parametro-repasse" },
           {
             label: "Cargas de repasses previstos",
             url: "parametro-arquivos-de-carga",
@@ -163,13 +166,14 @@ const ArquivosDeCarga = () => {
           },
         ],
       };
-    } else if (url_params.tipo_de_carga === "REPASSE_REALIZADO") {
+    } 
+    else if (url_params.tipo_de_carga === "REPASSE_REALIZADO") {
       obj = {
         titulo: "Repasses",
         titulo_modal: "repasse realizado",
         acesso_permitido: true,
+        url_go_back: "/parametro-repasse/",
         UrlsMenuInterno: [
-          { label: "Repasses", url: "parametro-repasse" },
           {
             label: "Cargas de repasses previstos",
             url: "parametro-arquivos-de-carga",
@@ -709,12 +713,14 @@ const ArquivosDeCarga = () => {
             <h1 className="titulo-itens-painel mt-5">{dadosDeOrigem.titulo}</h1>
             <div className="page-content-inner">
               {
-                is_acoes_associacoes ? (
+                is_acoes_associacoes || is_repasse_previsto || is_repasse_realizado ? (
                   <AbasPorRecurso
                     extra_abas={dadosDeOrigem.UrlsMenuInterno}
                     tab_initial_active="extra-tab-0"
                     extra_handle_click_tab_recurso={() => {
-                      navigate("/parametro-acoes-associacoes/");
+                      if (dadosDeOrigem.url_go_back) {
+                        navigate(dadosDeOrigem.url_go_back);
+                      }
                     }}
                   />
                 ) : (
@@ -723,7 +729,6 @@ const ArquivosDeCarga = () => {
                   />
                 )
               }
-
               
               <BotoesTopo
                 setShowModalForm={setShowModalForm}

--- a/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/__tests__/index.test.js
+++ b/src/componentes/Globais/ExibeAcertosEmLancamentosEDocumentosPorConta/AcertosLancamentos/__tests__/index.test.js
@@ -510,6 +510,7 @@ describe('AcertosLancamentos', () => {
     });
 
     it('chama carregaAcertosLancamentos ao clicar numa aba diferente', async () => {
+      jest.setTimeout(15000);
       setupDefaultMocks(mockContasMultiplas);
       meapcservice.getAnaliseDreUsuarioLogado.mockReturnValue({
         conferencia_de_lancamentos: {
@@ -518,6 +519,7 @@ describe('AcertosLancamentos', () => {
           paginacao_atual: 0
         }
       });
+      getLancamentosAjustes.mockResolvedValue({});
 
       renderComponent();
       await waitForTable();
@@ -535,7 +537,7 @@ describe('AcertosLancamentos', () => {
           null,
           null
         );
-      });
+      }, { timeout: 5000 });
     });
   });
 

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/UrlsMenuInterno.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/UrlsMenuInterno.js
@@ -1,5 +1,4 @@
 export const UrlsMenuInterno = [
-    {label: "Repasses", url: "parametro-repasse"},
     {label: "Carga de repasses previstos", url: 'parametro-arquivos-de-carga', origem:'REPASSE_PREVISTO'},
     {label: "Carga de repasses realizados", url: 'parametro-arquivos-de-carga', origem:'REPASSE_REALIZADO'},
 ];

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__fixtures__/mockData.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__fixtures__/mockData.js
@@ -314,6 +314,9 @@ export const mockRepasses = {
                 "valor_custeio": true,
                 "valor_livre": true,
                 "campos_de_realizacao": false
+            },
+            "recurso": {
+                "uuid": "3fa4d2b5-0e3f-4a1c-8e2a-5c9e3f4b2a1d"
             }
         },
         {
@@ -460,6 +463,9 @@ export const mockRepasses = {
                 "valor_custeio": true,
                 "valor_livre": true,
                 "campos_de_realizacao": false
+            },
+            "recurso": {
+                "uuid": "5e8a3c4d-2f1e-4b3a-9e5c-6d7f8a9b0c1d"
             }
         },
         {

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/Filtros.test.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/Filtros.test.js
@@ -90,14 +90,34 @@ describe("Filtros Componentes", () => {
 
         expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
         expect(mockSetFirstPage).toHaveBeenCalledWith(0);
-        expect(mockSetFilter).toHaveBeenCalledWith(mockInitialFilter);
+        expect(mockSetFilter).toHaveBeenCalled();
+        const filterCall = mockSetFilter.mock.calls[0][0];
+        const result = filterCall({});
+        expect(result).toMatchObject({
+            search: '',
+            periodo: '',
+            conta: '',
+            acao: '',
+            status: ''
+        });
+
+        jest.clearAllMocks();
 
         const limparBtn = screen.getByRole("button", { name: "Limpar"});
         fireEvent.click(limparBtn);
 
         expect(mockSetCurrentPage).toHaveBeenCalledWith(1);
         expect(mockSetFirstPage).toHaveBeenCalledWith(0);
-        expect(mockSetFilter).toHaveBeenCalledWith(mockInitialFilter);
+        expect(mockSetFilter).toHaveBeenCalled();
+        const filterCall2 = mockSetFilter.mock.calls[0][0];
+        const result2 = filterCall2({});
+        expect(result2).toMatchObject({
+            search: '',
+            periodo: '',
+            conta: '',
+            acao: '',
+            status: ''
+        });
     });
 
 });

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/index.test.js
@@ -24,6 +24,10 @@ jest.mock("../components/Paginacao", () => ({
     Paginacao: () => <div>Paginacao</div>,
 }));
 
+jest.mock("../../../componentes/AbasPorRecurso", () => ({
+    AbasPorRecurso: () => <div>AbasPorRecurso</div>,
+}));
+
 describe("Carrega página de Repasses", () => {
     const renderComponent = (()=>{
         return render(
@@ -43,6 +47,7 @@ describe("Carrega página de Repasses", () => {
     it('Deve renderizar os componentes filhos corretamente', () => {
         renderComponent();
 
+        expect(screen.getByText('AbasPorRecurso')).toBeInTheDocument();
         expect(screen.getByText('TopoComBotoes')).toBeInTheDocument();
         expect(screen.getByText('Filtros')).toBeInTheDocument();
         expect(screen.getByText('Lista')).toBeInTheDocument();

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/useGet.test.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/useGet.test.js
@@ -24,7 +24,17 @@ describe("useGetRepasses", () => {
         return renderHook(() => useGetRepasses(), {
             wrapper: ({ children }) => (
                 <QueryClientProvider client={queryClient}>
-                    <RepassesContext.Provider value={{}}>
+                    <RepassesContext.Provider value={{
+                        filter: {
+                            search: '',
+                            periodo: '',
+                            conta: '',
+                            acao: '',
+                            status: '',
+                            recurso_uuid: 'test-recurso-id'
+                        },
+                        currentPage: 1
+                    }}>
                         {children}
                     </RepassesContext.Provider>
                 </QueryClientProvider>

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/useGetTabelasPorAssociacao.test.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/__tests__/useGetTabelasPorAssociacao.test.js
@@ -21,7 +21,7 @@ describe("useGetTabelasPorAssociacao", () => {
     });
 
     const renderCustomHook = () => {
-        return renderHook(() => useGetTabelasPorAssociacao(), {
+        return renderHook(() => useGetTabelasPorAssociacao({ filters: { recurso_uuid: 'test-recurso-id' } }), {
             wrapper: ({ children }) => (
                 <QueryClientProvider client={queryClient}>
                     <RepassesContext.Provider value={{stateFormModal: {associacao: 'test-id'}}}>

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Filtros.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Filtros.js
@@ -1,12 +1,15 @@
-import React, {useContext, useState} from "react";
+import React, {useContext, useState, useEffect} from "react";
 import { RepassesContext } from "../context/Repasse";
 import { useGetTabelasRepasse } from "../hooks/useGetTabelasRepasse";
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
+import Loading from "../../../../../../utils/Loading";
 
 export const Filtros = () => {
-    const {setFilter, initialFilter, setCurrentPage, setFirstPage} = useContext(RepassesContext);
+    const {filter, setFilter, initialFilter, setCurrentPage, setFirstPage} = useContext(RepassesContext);
     const [formFilter, setFormFilter] = useState(initialFilter);
+    const { selectedRecurso } = useAbasPorRecursoContext();
 
-    const { data: tabelas } = useGetTabelasRepasse();
+    const { data: tabelas, isLoading } = useGetTabelasRepasse({ filters: filter });
 
     const handleChangeFormFilter = (name, value) => {
         setFormFilter({
@@ -15,18 +18,44 @@ export const Filtros = () => {
         });
     };
 
-    const handleSubmitFormFilter = () => {
-        setCurrentPage(1)
-        setFirstPage(0)
-        setFilter(formFilter);
-    };
+    const handleSubmitFiltros = (event) => {
+        event.preventDefault();
 
-    const clearFilter = () => {
         setCurrentPage(1)
         setFirstPage(0)
+        setFilter(prevState => ({
+            ...formFilter,
+            recurso_uuid: prevState?.recurso_uuid
+        }));
+    }
+
+    const handleClearFilters = () => {
+        setCurrentPage(1)
+        setFirstPage(0)
+        setFormFilter(prevState => ({
+            ...initialFilter,
+            recurso_uuid: prevState?.recurso_uuid
+        }));
+        setFilter(prevState => ({
+            ...initialFilter,
+            recurso_uuid: prevState?.recurso_uuid
+        }));
+    }
+
+    useEffect(() => {
         setFormFilter(initialFilter);
-        setFilter(initialFilter);
-    };
+    }, [selectedRecurso])
+
+    if (isLoading) {
+        return (
+            <Loading
+                corGrafico="black"
+                corFonte="dark"
+                marginTop="0"
+                marginBottom="0"
+            />
+        );
+    }
     
     return (
         <>
@@ -114,7 +143,7 @@ export const Filtros = () => {
                     <div className="from-group col-md-3">
                         <div className="d-flex bd-highlight justify-content-end mt-4">
                             <button 
-                                onClick={clearFilter}
+                                onClick={handleClearFilters}
                                 type="button" 
                                 className="btn btn-outline-success mt-2 mr-2"
                             >
@@ -122,7 +151,7 @@ export const Filtros = () => {
                             </button>
 
                             <button 
-                                onClick={handleSubmitFormFilter}
+                                onClick={handleSubmitFiltros}
                                 type="button" 
                                 className="btn btn-success mt-2"
                             >

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Lista.js
@@ -79,8 +79,10 @@ export const Lista = () => {
             carga_origem: rowData.carga_origem,
             id_linha_carga: rowData.carga_origem_linha_id,
             id: rowData.id,
-            campos_editaveis: rowData.campos_editaveis
+            campos_editaveis: rowData.campos_editaveis,            
+            recurso: rowData.recurso.uuid
         });
+
         setShowModalForm(true)
     };
 
@@ -99,6 +101,7 @@ export const Lista = () => {
             valor_capital: round(trataNumericos(values.valor_capital), 2),
             valor_custeio: round(trataNumericos(values.valor_custeio), 2),
             valor_livre: round(trataNumericos(values.valor_livre), 2),
+            recurso: values.recurso,
         };
 
         if(!values.uuid){
@@ -175,7 +178,7 @@ export const Lista = () => {
         <>
             {results && results.length > 0 ? (
                     <>
-                    <p className='mb-0'>Exibindo <span className='total'>{count}</span> repasses</p>
+                    {/* <p className='mb-0'>Exibindo <span className='total'>{count}</span> repasses</p> */}
                     <div className="mt-2">
                         <DataTable
                             value={results}

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Lista.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Lista.js
@@ -10,12 +10,13 @@ import { usePostRepasse } from "../hooks/usePostRepasse";
 import { usePatchRepasse } from "../hooks/usePatchRepasse";
 import { useDeleteRepasse } from "../hooks/useDeleteRepasse";
 
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
+
 import { round, trataNumericos } from "../../../../../../utils/ValidacoesAdicionaisFormularios";
 
 import Loading from "../../../../../../utils/Loading";
 import { ModalForm } from "./ModalForm";
 import { ModalConfirmacaoExclusao } from "./ModalConfirmacaoExclusao";
-
 import { EditIconButton } from "../../../../../Globais/UI/Button";
 
 export const Lista = () => {
@@ -25,21 +26,25 @@ export const Lista = () => {
 
     const { mutationPost } = usePostRepasse();
     const { mutationPatch } = usePatchRepasse();
-    const { mutationDelete } = useDeleteRepasse()
+    const { mutationDelete } = useDeleteRepasse();
 
     // Este trecho é responsável pelo auto complete de unidades
     const [todasAsAssociacoesAutoComplete, setTodasAsAssociacoesAutoComplete] = useState([]);
     const [loadingAssociacoes, setLoadingAssociacoes] = useState(true);
 
+    const { selectedRecurso } = useAbasPorRecursoContext();
+
     const fetchAssociacoes = async () => {
-        let todas_associacoes = await getAssociacoes();
+        let todas_associacoes = await getAssociacoes(selectedRecurso.uuid);
         setLoadingAssociacoes(false);
         setTodasAsAssociacoesAutoComplete(todas_associacoes);
     };
 
     useEffect(() => {
-        fetchAssociacoes();
-    }, [])
+        if (selectedRecurso) {
+            fetchAssociacoes();
+        }
+    }, [selectedRecurso])
     // Fim trecho auto complete de unidades
 
     // Necessária pela paginação

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/ModalForm.js
@@ -13,12 +13,15 @@ import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../../Pa
 import { YupSchemaRepasse } from "../YupSchemaRepasse";
 import AutoCompleteAssociacoes from "./AutoCompleteAssociacoes";
 
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
+
 export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete, loadingAssociacoes}) => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
-    const {showModalForm, setShowModalForm, stateFormModal, bloquearBtnSalvarForm, setShowModalConfirmacaoExclusao, setStateFormModal} = useContext(RepassesContext)
+    const { filter, showModalForm, setShowModalForm, stateFormModal, bloquearBtnSalvarForm, setShowModalConfirmacaoExclusao, setStateFormModal} = useContext(RepassesContext)
     
-    const { data: tabelas } = useGetTabelasRepasse();
-    const { data: tabelas_por_associacao, isFetching: isFetchingTabelaPorAssociacao } = useGetTabelasPorAssociacao();
+    const { data: tabelas } = useGetTabelasRepasse({filters: filter});
+    const { data: tabelas_por_associacao, isFetching: isFetchingTabelaPorAssociacao } = useGetTabelasPorAssociacao({ filters: filter });
+    const { recursos } = useRecursoSelecionadoContext();
 
     const campo_editavel = (campo) => {
         if(!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES){
@@ -55,6 +58,31 @@ export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete
                                     ? 
                                         <div className='form-group col-md-12'>
                                             <p className='text-right mb-0'>* Preenchimento obrigatório</p>
+
+                                            <div className='mb-3'>
+                                                <label htmlFor="recurso">Recurso *</label>
+                                                <select
+                                                    data-qa="input-recurso"
+                                                    value={stateFormModal.recurso ? stateFormModal.recurso : ""}
+                                                    disabled
+                                                    name="recurso"
+                                                    id="recurso"
+                                                    className="form-control"
+                                                    required
+                                                >
+                                                    <option data-qa="option-recurso-vazio" value=''>Selecione um recurso</option>
+                                                    {recursos?.map((recurso) =>
+                                                        <option
+                                                            data-qa={`option-recurso-${recurso.uuid}`}
+                                                            key={recurso.uuid}
+                                                            value={recurso.uuid}
+                                                        >
+                                                            {recurso.nome}
+                                                        </option>
+                                                    )}
+                                                </select>
+                                            </div>
+                                            
                                             <label htmlFor="unidade_educacional">Unidade Educacional *</label>
                                             <input
                                                 value={values.nome_unidade}
@@ -69,14 +97,41 @@ export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete
                                     :
                                         <div className="form-group col-md-12">
                                             <p className='text-right mb-0'>* Preenchimento obrigatório</p>
+
+                                            <div className='mb-3'>
+                                                <label htmlFor="recurso">Recurso *</label>
+                                                <select
+                                                    data-qa="input-recurso"
+                                                    value={stateFormModal.recurso ? stateFormModal.recurso : ""}
+                                                    disabled
+                                                    name="recurso"
+                                                    id="recurso"
+                                                    className="form-control"
+                                                    required
+                                                >
+                                                    <option data-qa="option-recurso-vazio" value=''>Selecione um recurso</option>
+                                                    {recursos?.map((recurso) =>
+                                                        <option
+                                                            data-qa={`option-recurso-${recurso.uuid}`}
+                                                            key={recurso.uuid}
+                                                            value={recurso.uuid}
+                                                        >
+                                                            {recurso.nome}
+                                                        </option>
+                                                    )}
+                                                </select>
+                                            </div>
+
                                             <label htmlFor="unidade_educacional">Unidade Educacional *{loadingAssociacoes && <img alt="" src={Spinner} style={{height: "22px"}}/>}</label>
-                                            <AutoCompleteAssociacoes
-                                                todasAsAssociacoesAutoComplete={todasAsAssociacoesAutoComplete}
-                                                setFieldValue={setFieldValue}
-                                                disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-                                                loadingAssociacoes={loadingAssociacoes}
-                                                
-                                            />
+                                            <div style={{marginLeft: '16px'}}>
+                                                <AutoCompleteAssociacoes
+                                                    todasAsAssociacoesAutoComplete={todasAsAssociacoesAutoComplete}
+                                                    setFieldValue={setFieldValue}
+                                                    disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
+                                                    loadingAssociacoes={loadingAssociacoes}
+                                                    
+                                                />
+                                            </div>
                                             {props.touched.associacao && props.errors.associacao && <span className="span_erro text-danger mt-1"> {props.errors.associacao}</span>}
                                         </div>
                                     }  
@@ -324,11 +379,11 @@ export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete
                                             </div>
                                         </div>
 
-                                        <div className="form-row">
+                                        {/* <div className="form-row">
                                             <div className="form-group col-md-12">
                                                 <p className="mb-0">Uuid: <span>{values.uuid}</span></p>
                                             </div>
-                                        </div>
+                                        </div> */}
 
                                         <div className="form-row">
                                             <div className="form-group col-md-12">

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/ModalForm.js
@@ -15,6 +15,9 @@ import AutoCompleteAssociacoes from "./AutoCompleteAssociacoes";
 
 import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+
 export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete, loadingAssociacoes}) => {
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const { filter, showModalForm, setShowModalForm, stateFormModal, bloquearBtnSalvarForm, setShowModalConfirmacaoExclusao, setStateFormModal} = useContext(RepassesContext)
@@ -404,6 +407,7 @@ export const ModalForm = ({handleSubmitFormModal, todasAsAssociacoesAutoComplete
                                                         className="btn btn btn-danger mt-2 mr-2"
                                                         disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
                                                     >
+                                                        <FontAwesomeIcon icon={faXmark} style={{ marginRight: "8px", color: "white", fontWeight: "bold" }} />
                                                         Excluir
                                                     </button>
                                                 }

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Paginacao.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/Paginacao.js
@@ -20,7 +20,7 @@ export const Paginacao = () => {
             {!isLoading && data.results && data.results.length > 0 ? (
                     <Paginator
                         first={firstPage}
-                        rows={20}
+                        rows={10}
                         totalRecords={count}
                         template="PrevPageLink PageLinks NextPageLink"
                         onPageChange={onPageChange}

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/TopoComBotoes.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/components/TopoComBotoes.js
@@ -1,24 +1,33 @@
 import React, {useContext} from "react";
 import { RepassesContext } from "../context/Repasse";
 import { RetornaSeTemPermissaoEdicaoPainelParametrizacoes } from "../../../../Parametrizacoes/RetornaSeTemPermissaoEdicaoPainelParametrizacoes";
+import { useAbasPorRecursoContext } from "../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext";
+import { IconButton } from "../../../../../Globais/UI/Button";
 
 export const TopoComBotoes = () => {
+    const { selectedRecurso } = useAbasPorRecursoContext();
+
     const TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES = RetornaSeTemPermissaoEdicaoPainelParametrizacoes()
     const {setShowModalForm, setStateFormModal, initialStateFormModal} = useContext(RepassesContext)
 
     return(
-        <div className="d-flex bd-highlight justify-content-end pb-4 mt-2">
-            <button 
+        <div className="d-flex justify-content-between align-items-end mb-4">
+            <div>
+                <h5 className="font-weight-bold">{selectedRecurso?.nome}</h5>
+                <p className="m-0">Confira abaixo as ações das associações do {selectedRecurso?.nome_exibicao}.</p>
+            </div>
+
+            <IconButton 
+                icon="faPlus"
+                iconProps={{ style: {fontSize: '15px', marginRight: "5", color:"#fff"} }}
+                label="Adicionar repasse previsto"
                 onClick={()=>{
-                    setStateFormModal(initialStateFormModal);
+                    setStateFormModal({ ...initialStateFormModal, recurso: selectedRecurso?.uuid || "", });
                     setShowModalForm(true);
                 }}
-                type="button" 
-                className="btn btn-success"
+                variant="success"
                 disabled={!TEM_PERMISSAO_EDICAO_PAINEL_PARAMETRIZACOES}
-            >
-                + Adicionar repasse previsto
-            </button>
+            />
         </div>
     )
 

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/context/Repasse.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/context/Repasse.js
@@ -1,6 +1,10 @@
-import React, { createContext, useMemo, useState } from 'react';
+import React, { createContext, useMemo, useState, useEffect } from 'react';
+import { useAbasPorRecursoContext } from '../../../componentes/AbasPorRecurso/hooks/useAbasPorRecursoContext';
 
 const initialFilter = {
+    page: 1,
+    is_required_recurso_uuid: true,
+    recurso_uuid: '',
     search: '',
     periodo: '',
     conta: '',
@@ -27,7 +31,7 @@ const initialStateFormModal = {
     id: '',
     campos_editaveis: {
         campos_de_realizacao: false
-    }
+    },
 };
 
 export const RepassesContext = createContext({
@@ -53,6 +57,7 @@ export const RepassesContext = createContext({
 })
 
 export const RepassesProvider = ({children}) => {
+    const { selectedRecurso } = useAbasPorRecursoContext();
 
     const [filter, setFilter] = useState(initialFilter);
 
@@ -65,6 +70,17 @@ export const RepassesProvider = ({children}) => {
     const [showModalConfirmacaoExclusao, setShowModalConfirmacaoExclusao] = useState(false);
 
     const [bloquearBtnSalvarForm, setBloquearBtnSalvarForm] = useState(false);
+
+    useEffect(() => {
+        const initialFilterWithRecursoUuid = {
+            ...initialFilter,
+            recurso_uuid: selectedRecurso?.uuid || '',
+            page: 1,
+        };
+        setFilter(initialFilterWithRecursoUuid);
+        setCurrentPage(1);
+        setFirstPage(1);
+    }, [selectedRecurso]);
 
     const contextValue = useMemo(() => {
         return {

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetRepasses.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetRepasses.js
@@ -13,6 +13,7 @@ export const useGetRepasses = () => {
         keepPreviousData: true,
         staleTime: 5000, // 5 segundos
         refetchOnWindowFocus: true, // Caso saia da aba e voltar ele refaz a requisição
+        enabled: filter.recurso_uuid !== '', // Evita requisição quando recurso_uuid está vazio
     });
 
     const totalRepasses = useMemo(() => data.length, [data]);

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasPorAssociacao.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasPorAssociacao.js
@@ -4,12 +4,14 @@ import { getTabelasRepassePorAssociacao } from "../../../../../../services/sme/P
 import { RepassesContext } from "../context/Repasse";
 
 
-export const useGetTabelasPorAssociacao = () => {
+export const useGetTabelasPorAssociacao = ({ filters }) => {
     const {stateFormModal} = useContext(RepassesContext)
 
     const { isFetching, isError, data, refetch } = useQuery({
-        queryKey: ['tabelas-repasse-associacao-list', stateFormModal.associacao],
-        queryFn: ()=> getTabelasRepassePorAssociacao(stateFormModal.associacao),
+        queryKey: ['tabelas-repasse-associacao-list', stateFormModal.associacao, filters?.recurso_uuid],
+        queryFn: () => {
+            return getTabelasRepassePorAssociacao(stateFormModal.associacao, filters?.recurso_uuid);
+        },
         keepPreviousData: true,
         enabled: !!stateFormModal.associacao,
         staleTime: 1000 * 60 * 1 // 1 minutos

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
@@ -1,12 +1,11 @@
 import { getTabelasRepasse } from "../../../../../../services/sme/Parametrizacoes.service";
 import {useQuery} from "@tanstack/react-query";
 
-
-export const useGetTabelasRepasse = () => {
+export const useGetTabelasRepasse = ({ filters }) => {
 
     const { isFetching, isError, data, refetch } = useQuery({
-        queryKey: ['tabelas-repasse-list'],
-        queryFn: ()=> getTabelasRepasse(),
+        queryKey: ['tabelas-repasse-list', filters?.recurso_uuid],
+        queryFn: () => getTabelasRepasse(filters?.recurso_uuid),
         keepPreviousData: true,
     });
 

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
@@ -9,6 +9,7 @@ export const useGetTabelasRepasse = ({ filters }) => {
         keepPreviousData: true,
         staleTime: 1000 * 60 * 60, // 1 hora - dados permanecem frescos por 1 hora
         refetchOnWindowFocus: false, // Não refaz requisição ao voltar à aba
+        enabled: filters.recurso_uuid !== '', // Evita requisição quando recurso_uuid está vazio
     });
 
     return {isLoading: isFetching, isError, data, refetch}

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/hooks/useGetTabelasRepasse.js
@@ -7,6 +7,8 @@ export const useGetTabelasRepasse = ({ filters }) => {
         queryKey: ['tabelas-repasse-list', filters?.recurso_uuid],
         queryFn: () => getTabelasRepasse(filters?.recurso_uuid),
         keepPreviousData: true,
+        staleTime: 1000 * 60 * 60, // 1 hora - dados permanecem frescos por 1 hora
+        refetchOnWindowFocus: false, // Não refaz requisição ao voltar à aba
     });
 
     return {isLoading: isFetching, isError, data, refetch}

--- a/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/index.js
+++ b/src/componentes/sme/Parametrizacoes/Receitas/ParametrizacoesRepasses/index.js
@@ -1,14 +1,14 @@
-import React, {useCallback, useEffect, useMemo, useState} from "react";
+import React from "react";
 import { RepassesProvider } from "./context/Repasse";
 
 import { PaginasContainer } from "../../../../../paginas/PaginasContainer";
 import {UrlsMenuInterno} from "./UrlsMenuInterno";
-import { MenuInterno } from "../../../../Globais/MenuInterno";
 
 import { TopoComBotoes } from "./components/TopoComBotoes";
 import { Lista } from "./components/Lista";
 import { Filtros } from "./components/Filtros";
 import { Paginacao } from "./components/Paginacao";
+import { AbasPorRecurso } from "../../componentes/AbasPorRecurso";
 
 
 export const ParametrizacoesRepasses = () => {
@@ -17,8 +17,8 @@ export const ParametrizacoesRepasses = () => {
             <PaginasContainer>
                 <h1 className="titulo-itens-painel mt-5">Repasses</h1>
                 <div className="page-content-inner">
-                    <MenuInterno
-                        caminhos_menu_interno={UrlsMenuInterno}
+                    <AbasPorRecurso
+                        extra_abas={UrlsMenuInterno}
                     />
 
                     <TopoComBotoes/>

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -1054,7 +1054,7 @@ export const deleteMotivoEstorno = async (motivo_uuid) => {
 // Repasses
 
 export const getRepasses = async (filter, currentPage) => {
-  const { search, periodo, conta, acao, status } = filter;
+  const { search, periodo, conta, acao, status, recurso_uuid } = filter;
   return (
     await api.get(`/api/repasses/`, {
       ...authHeader(),
@@ -1064,23 +1064,31 @@ export const getRepasses = async (filter, currentPage) => {
         conta: conta,
         acao: acao,
         status: status,
-        page_size: 20,
+        page_size: 10,
         page: currentPage,
+        recurso_uuid: recurso_uuid
       },
     })
   ).data;
 };
 
-export const getTabelasRepasse = async () => {
-  return (await api.get(`/api/repasses/tabelas/`, authHeader())).data;
+export const getTabelasRepasse = async (recurso_uuid) => {
+  console.log('recurso_uuid', recurso_uuid)
+  let url = `/api/repasses/tabelas/`;
+  if (recurso_uuid) {
+    url += `?recurso_uuid=${recurso_uuid}`;
+  }
+  return (await api.get(url, authHeader())).data;
 };
 
-export const getTabelasRepassePorAssociacao = async (associacao_uuid) => {
+export const getTabelasRepassePorAssociacao = async (associacao_uuid, recurso_uuid) => {
+  let url = `/api/repasses/tabelas-por-associacao/?associacao_uuid=${associacao_uuid}`;
+  if (recurso_uuid) {
+    url += `&recurso_uuid=${recurso_uuid}`;
+  }
+  
   return (
-    await api.get(
-      `/api/repasses/tabelas-por-associacao/?associacao_uuid=${associacao_uuid}`,
-      authHeader()
-    )
+    await api.get(url, authHeader())
   ).data;
 };
 

--- a/src/services/sme/Parametrizacoes.service.js
+++ b/src/services/sme/Parametrizacoes.service.js
@@ -450,6 +450,7 @@ export const deleteTag = async (tag_uuid) => {
 export const getAssociacoes = async (recurso_uuid = '') => {
   return (await api.get(`/api/associacoes/`, {...authHeader(), params: { recurso_uuid }})).data;
 };
+
 export const getParametrizacoesAssociacoes = async (
   page,
   tipo_unidade,

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -1632,7 +1632,7 @@ describe('Testes para funções de análise', () => {
             conta: filter.conta,
             acao: filter.acao,
             status: filter.status,
-            page_size: 20,
+            page_size: 10,
             page: currentPage,
         };
         expect(api.get).toHaveBeenCalledWith(`/api/repasses/`, {


### PR DESCRIPTION
Este PR inclui:

- Separação de repasses em abas por recurso juntamente com abas de cargas de arquivos;
- Filtros e modal exibem apenas períodos, ações e contas pertencentes ao recurso da aba selecionada;
- Ao mudar de abas, os filtros são resetados;
- Exibição do recurso selecionado bloqueado nos modais de adição e edição de Repasse;
- Paginação de 10 registros por página;
- Correção no tamanho do input de associação no modal de adição de novo Repasse para padronização com os demais campos;
- Filtros são exibidos apenas quando os dados do recurso são totalmente carregados;
- Remoção da exibição do uuid no modal de edição de Repasse;
- Validação e correção de testes unitários;

História: [AB#148838](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/148838)
Tarefa: [AB#149760](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/149760)