### PR TITLE
bugfix(151459): Correção na exibição de processos e listagem de períodos disponíveis por recurso.

### DIFF
--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/ProcessosSeiPrestacaoDeContas.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/ProcessosSeiPrestacaoDeContas.js
@@ -63,36 +63,17 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
 
     const premioExcelenciaAtivo = visoesService.featureFlagAtiva('premio-excelencia-processo-sei');
 
-    useEffect(() => {
-        if (recurso_uuid) {
-            const recurso = recursos_da_associacao?.find((item) => item.uuid === recurso_uuid);
-            if (recurso) {
-                recursoSelecionadoStorageService.setRecursoSelecionado(recurso);
-            }
-        }
-    }, [recurso_uuid, recursos_da_associacao]);
-
     const carregaProcessos = async () => {
-        let processos = await getProcessosAssociacao(associacaoUuid);
+        let processos = await getProcessosAssociacao(associacaoUuid, recurso_uuid);
         setProcessosList(processos)
     };
 
-    useEffect(() => {
-        carregaProcessos()
-        setLoading(false)
-    }, [recurso_uuid]);
-
     const carregaPeriodosDisponiveis = async () => {
-        let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, stateProcessoForm.ano, stateProcessoForm.uuid)
+        setLoadingPeriodos(true);
+        let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, stateProcessoForm.ano, stateProcessoForm.uuid, recurso_uuid)
         setPeriodosDisponiveis(periodosDisponiveis)
         setLoadingPeriodos(false);
     }
-
-    useEffect(() => {
-        if (associacaoUuid && stateProcessoForm && stateProcessoForm.ano && stateProcessoForm.ano.replaceAll("_","").length >= 4){
-            carregaPeriodosDisponiveis()
-        }
-    }, [associacaoUuid, stateProcessoForm]);
 
     const deleteProcesso = async () => {
         setLoading(true);
@@ -121,7 +102,6 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
     };
 
     const handleEditProcessoAction = (processo) => {
-        setLoadingPeriodos(true);
         let lista_uuids_periodos = []
         for(let i=0; i<=processo.periodos.length-1; i++){
             lista_uuids_periodos.push(processo.periodos[i].uuid)
@@ -160,6 +140,7 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
             'associacao': associacaoUuid,
             'numero_processo': stateProcessoForm.numero_processo,
             'ano': stateProcessoForm.ano,
+            'recurso': recurso_uuid,
         };
 
         if (visoesService.featureFlagAtiva('periodos-processo-sei')) {
@@ -228,30 +209,19 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
         }
     };
 
-    const handleChangesInProcessoForm = async (name, value) => {
-        // Limpando o campo Período quando alterar o campo Ano
-        if (name ==='ano'){
-
-            let lista_uuids_periodos_pre_selecao = []
-
-            if (associacaoUuid && value && value.replaceAll("_","").length >= 4){
-                let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, value, stateProcessoForm.uuid)
-                for(let i= 0; i<= periodosDisponiveis.length-1; i++){
-                    lista_uuids_periodos_pre_selecao.push(periodosDisponiveis[i].uuid)
-                }
-            }
+    const handleChangesInProcessoForm = (name, value) => {
+        if (name === 'ano') {
             setStateProcessoForm({
                 ...stateProcessoForm,
                 [name]: value,
-                periodos: lista_uuids_periodos_pre_selecao
+                periodos: []
             });
-        }else {
+        } else {
             setStateProcessoForm({
                 ...stateProcessoForm,
                 [name]: value
             });
         }
-
     };
 
     const handleChangeSelectPeriodos =  async (value) => {
@@ -306,6 +276,30 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
         }
     }
 
+    useEffect(() => {
+        carregaProcessos()
+        setLoading(false)
+    }, [recurso_uuid]);
+
+    useEffect(() => {
+        if (associacaoUuid && stateProcessoForm && stateProcessoForm.ano && stateProcessoForm.ano.replaceAll("_","").length >= 4){
+            carregaPeriodosDisponiveis()
+        }
+    }, [associacaoUuid, stateProcessoForm.ano]);
+
+    useEffect(() => {
+        if (periodosDisponiveis && periodosDisponiveis.length > 0 && stateProcessoForm.periodos.length === 0) {
+            let lista_uuids_periodos = []
+            for(let i = 0; i < periodosDisponiveis.length; i++){
+                lista_uuids_periodos.push(periodosDisponiveis[i].uuid)
+            }
+            setStateProcessoForm(prev => ({
+                ...prev,
+                periodos: lista_uuids_periodos
+            }));
+        }
+    }, [periodosDisponiveis]);
+
     return (
         <>
             {loading ? (
@@ -347,7 +341,8 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
                         </div>
                         <div className="row">
                             <div className="col-12">
-                                {processosList.length > 0 ? (<DataTable
+                                {processosList.length > 0 ? (
+                                    <DataTable
                                         value={processosList}
                                         className="mt-3 datatable-footer-coad"
                                         paginator={processosList.length > rowsPerPage}

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/TopoComBotoes.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/TopoComBotoes.js
@@ -1,9 +1,9 @@
 import React, {useCallback} from "react";
-import {Link, useParams} from "react-router-dom";
-import {visoesService} from "../../../../services/visoes.service"
+import {useParams, useNavigate} from "react-router-dom";
 
 export const TopoComBotoes = ({dadosDaAssociacao}) => {
     let {origem, periodo_uuid, conta_uuid} = useParams();
+    const navigate = useNavigate();
 
     const getPath = useCallback(() => {
         let path;
@@ -12,8 +12,9 @@ export const TopoComBotoes = ({dadosDaAssociacao}) => {
         } else if (origem === 'dre-relatorio-consolidado' && periodo_uuid && conta_uuid) {
             path = `/dre-relatorio-consolidado-dados-das-ues/${periodo_uuid}/${conta_uuid}/`;
         }
-        window.location.assign(path)
-    }, [origem, periodo_uuid, conta_uuid]);
+        // O recurso atual é mantido através do recursoSelecionadoStorageService
+        navigate(path);
+    }, [origem, periodo_uuid, conta_uuid, navigate]);
 
     return (
         <>


### PR DESCRIPTION
Este PR inclui:

- Passa uuid do recurso para filtragem de processos SEI;
- Passa uuid do recurso para filtrar períodos disponíveis;
- Na criação de processo, envia uuid do recurso (caso flag esteja inativa, o recurso não é enviado e o backend salva o processo com recurso legado);
- Refactor no código para evitar chamadas duplicadas na consulta de processos disponíveis;
- Correção de problema ao clicar no botão de "Voltar" dentro do detalhamento de associação a partir do recurso Prêmio e estava causando a troca de visão para o recurso PTRF e o redirecionamento para a tela de "Acompanhamento de PC". Agora ao clicar no botão "Voltar", o usuário é redirecionado a tela anterior, ou seja, a tela de listagem de associações.

Bug: [AB#151459](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151459)
Tarefa: [AB#151885](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151885)