### PR TITLE
bugfix(151459): Correção na exibição de processos e listagem de períodos disponíveis por recurso.

### DIFF
--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/ProcessosSeiPrestacaoDeContas.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/ProcessosSeiPrestacaoDeContas.js
@@ -63,36 +63,17 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
 
     const premioExcelenciaAtivo = visoesService.featureFlagAtiva('premio-excelencia-processo-sei');
 
-    useEffect(() => {
-        if (recurso_uuid) {
-            const recurso = recursos_da_associacao?.find((item) => item.uuid === recurso_uuid);
-            if (recurso) {
-                recursoSelecionadoStorageService.setRecursoSelecionado(recurso);
-            }
-        }
-    }, [recurso_uuid, recursos_da_associacao]);
-
     const carregaProcessos = async () => {
-        let processos = await getProcessosAssociacao(associacaoUuid);
+        let processos = await getProcessosAssociacao(associacaoUuid, recurso_uuid);
         setProcessosList(processos)
     };
 
-    useEffect(() => {
-        carregaProcessos()
-        setLoading(false)
-    }, [recurso_uuid]);
-
     const carregaPeriodosDisponiveis = async () => {
-        let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, stateProcessoForm.ano, stateProcessoForm.uuid)
+        setLoadingPeriodos(true);
+        let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, stateProcessoForm.ano, stateProcessoForm.uuid, recurso_uuid)
         setPeriodosDisponiveis(periodosDisponiveis)
         setLoadingPeriodos(false);
     }
-
-    useEffect(() => {
-        if (associacaoUuid && stateProcessoForm && stateProcessoForm.ano && stateProcessoForm.ano.replaceAll("_","").length >= 4){
-            carregaPeriodosDisponiveis()
-        }
-    }, [associacaoUuid, stateProcessoForm]);
 
     const deleteProcesso = async () => {
         setLoading(true);
@@ -121,7 +102,6 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
     };
 
     const handleEditProcessoAction = (processo) => {
-        setLoadingPeriodos(true);
         let lista_uuids_periodos = []
         for(let i=0; i<=processo.periodos.length-1; i++){
             lista_uuids_periodos.push(processo.periodos[i].uuid)
@@ -160,6 +140,7 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
             'associacao': associacaoUuid,
             'numero_processo': stateProcessoForm.numero_processo,
             'ano': stateProcessoForm.ano,
+            'recurso': recurso_uuid,
         };
 
         if (visoesService.featureFlagAtiva('periodos-processo-sei')) {
@@ -228,30 +209,19 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
         }
     };
 
-    const handleChangesInProcessoForm = async (name, value) => {
-        // Limpando o campo Período quando alterar o campo Ano
-        if (name ==='ano'){
-
-            let lista_uuids_periodos_pre_selecao = []
-
-            if (associacaoUuid && value && value.replaceAll("_","").length >= 4){
-                let periodosDisponiveis = await getPeriodosDisponiveis(associacaoUuid, value, stateProcessoForm.uuid)
-                for(let i= 0; i<= periodosDisponiveis.length-1; i++){
-                    lista_uuids_periodos_pre_selecao.push(periodosDisponiveis[i].uuid)
-                }
-            }
+    const handleChangesInProcessoForm = (name, value) => {
+        if (name === 'ano') {
             setStateProcessoForm({
                 ...stateProcessoForm,
                 [name]: value,
-                periodos: lista_uuids_periodos_pre_selecao
+                periodos: []
             });
-        }else {
+        } else {
             setStateProcessoForm({
                 ...stateProcessoForm,
                 [name]: value
             });
         }
-
     };
 
     const handleChangeSelectPeriodos =  async (value) => {
@@ -306,6 +276,30 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
         }
     }
 
+    useEffect(() => {
+        carregaProcessos()
+        setLoading(false)
+    }, [recurso_uuid]);
+
+    useEffect(() => {
+        if (associacaoUuid && stateProcessoForm && stateProcessoForm.ano && stateProcessoForm.ano.replaceAll("_","").length >= 4){
+            carregaPeriodosDisponiveis()
+        }
+    }, [associacaoUuid, stateProcessoForm.ano]);
+
+    useEffect(() => {
+        if (periodosDisponiveis && periodosDisponiveis.length > 0 && stateProcessoForm.periodos.length === 0) {
+            let lista_uuids_periodos = []
+            for(let i = 0; i < periodosDisponiveis.length; i++){
+                lista_uuids_periodos.push(periodosDisponiveis[i].uuid)
+            }
+            setStateProcessoForm(prev => ({
+                ...prev,
+                periodos: lista_uuids_periodos
+            }));
+        }
+    }, [periodosDisponiveis]);
+
     return (
         <>
             {loading ? (
@@ -347,7 +341,8 @@ export const ProcessosSeiPrestacaoDeContas = ({dadosDaAssociacao, recurso_uuid, 
                         </div>
                         <div className="row">
                             <div className="col-12">
-                                {processosList.length > 0 ? (<DataTable
+                                {processosList.length > 0 ? (
+                                    <DataTable
                                         value={processosList}
                                         className="mt-3 datatable-footer-coad"
                                         paginator={processosList.length > rowsPerPage}

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/TopoComBotoes.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/TopoComBotoes.js
@@ -1,9 +1,9 @@
 import React, {useCallback} from "react";
-import {Link, useParams} from "react-router-dom";
-import {visoesService} from "../../../../services/visoes.service"
+import {useParams, useNavigate} from "react-router-dom";
 
 export const TopoComBotoes = ({dadosDaAssociacao}) => {
     let {origem, periodo_uuid, conta_uuid} = useParams();
+    const navigate = useNavigate();
 
     const getPath = useCallback(() => {
         let path;
@@ -12,8 +12,9 @@ export const TopoComBotoes = ({dadosDaAssociacao}) => {
         } else if (origem === 'dre-relatorio-consolidado' && periodo_uuid && conta_uuid) {
             path = `/dre-relatorio-consolidado-dados-das-ues/${periodo_uuid}/${conta_uuid}/`;
         }
-        window.location.assign(path)
-    }, [origem, periodo_uuid, conta_uuid]);
+        // O recurso atual é mantido através do recursoSelecionadoStorageService
+        navigate(path);
+    }, [origem, periodo_uuid, conta_uuid, navigate]);
 
     return (
         <>

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,9 +1,13 @@
 import React from "react";
 import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../../../utils/TextoDocumentoConsolidadoPC";
 
 export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia, ehRetificacao, motivoRetificacao}) => {
-
     const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda);
+    const texto_publicacao = texto_documento_consolidado_pc.texto_artigo_a();
+    const texto_emissao = texto_documento_consolidado_pc.texto_emissao();
 
     const getTexto = (ehRetificacao) => {
         const baseLegal = "conforme incisos III e IV do art. 34 da Portaria SME nº 6.634/2021"
@@ -34,9 +38,9 @@ export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCo
             <p className="titulo-texto-dinamico-superior mb-2">{retornaTituloCorpoAta()} {retornaDadosAtaFormatado("numero_ata")}</p>
             {ehPrevia() &&
                 <p className="texto-atencao">
-                    Atenção! Essa é uma versão prévia da ata. As informações aqui exibidas podem ser alteradas até a
-                    publicação do consolidado das PCs. A ata final só poderá ser gerada após a publicação do
-                    consolidado.
+                    {`Atenção! Essa é uma versão prévia da ata. As informações aqui exibidas podem ser alteradas até ${texto_publicacao}
+                    do Consolidado das PCs. A ata final só poderá ser ${texto_emissao} do
+                    Consolidado das PCs.`}
                 </p>
             }
 

--- a/src/componentes/dres/RelatorioConsolidado/BlocoPublicacaoParcial.js
+++ b/src/componentes/dres/RelatorioConsolidado/BlocoPublicacaoParcial.js
@@ -7,7 +7,8 @@ import PreviaDocumentos from "./PreviaDocumento";
 import {AtaParecerTecnico} from "./AtaParecerTecnico";
 import Lauda from "./Lauda";
 
-const BlocoPublicacaoParcial = ({ 
+const BlocoPublicacaoParcial = ({
+    isShowLauda, 
     consolidadoDre,
     publicarConsolidadoDre,
     podeGerarPrevia,
@@ -42,7 +43,6 @@ const BlocoPublicacaoParcial = ({
     }, [consolidadoDre])
 
     return (
-        <>
             <div className='mt-3'>
                 <PublicarDocumentos
                     publicarConsolidadoDre={publicarConsolidadoDre}
@@ -73,11 +73,13 @@ const BlocoPublicacaoParcial = ({
                     podeGerarPreviaRetificacao={podeGerarPreviaRetificacao(consolidadoDre)}
                     podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
                 />
-                <Lauda
-                    consolidadoDre={consolidadoDre}
-                />
+                {
+                    isShowLauda &&
+                    <Lauda
+                        consolidadoDre={consolidadoDre}
+                    />
+                }
             </div>
-        </>
     )
 }
 

--- a/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/InfoRefiticacaoRelatorio.js
+++ b/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/InfoRefiticacaoRelatorio.js
@@ -1,14 +1,19 @@
 import React, {memo} from "react";
 import useDataTemplate from "../../../../hooks/Globais/useDataTemplate";
 import IconeEditarRetificacao from "../BlocoRetificacao/IconeEditarRetificacao";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 const dataTemplate = useDataTemplate()
 
 const InfoRetificacaoRelatorio = ({consolidadoDre}) => {
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const text_possessive = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda).possessivo();
+
     return(
         <>
-            {consolidadoDre && consolidadoDre.data_publicacao &&
+            {consolidadoDre?.data_publicacao &&
                 <div className='mb-0 fonte-12 fonte-normal'>
-                    <strong>Data da publicação:</strong> {dataTemplate(null, null, consolidadoDre.data_publicacao)}
+                    <strong>Data {text_possessive}:</strong> {dataTemplate(null, null, consolidadoDre.data_publicacao)}
                     <IconeEditarRetificacao
                         consolidadoDre={consolidadoDre}
                     />

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/BotaoMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/BotaoMarcarPublicacaoNoDiarioOficial.js
@@ -1,30 +1,44 @@
 import React, {memo, useState} from "react";
 import {ModalMarcarPublicacaoNoDiarioOficial} from "../ModalMarcarPublicacaoNoDiarioOficial";
 import {visoesService} from "../../../../services/visoes.service";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 const BotaoMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao}) => {
-    const [showModalMarcarPublicacaoNoDiarioOficial, setShowModalMarcarPublicacaoNoDiarioOficial] = useState(false)
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const [showModalMarcarPublicacaoNoDiarioOficial, setShowModalMarcarPublicacaoNoDiarioOficial] = useState(false)    
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda)
+
+    const texto_publicacao = texto_documento_consolidado_pc.texto_acao();
+    const texto_publicacao_modal = texto_documento_consolidado_pc.texto_titulo_publicacao_modal();
+    const texto_aplicada = texto_documento_consolidado_pc.texto_pagina_publicacao();
+
+    const texto_info = `Informar ${texto_publicacao}`;
+    const texto_info_modal = `Informar ${texto_publicacao_modal}.`;
+
     return (
         <>
-            {consolidadoDre && consolidadoDre.ja_publicado && !consolidadoDre.data_publicacao &&
+            {consolidadoDre?.ja_publicado && !consolidadoDre.data_publicacao &&
                 <div className="p-2 bd-highlight">
                     <button
                         onClick={() => setShowModalMarcarPublicacaoNoDiarioOficial(true)}
                         className="btn btn-outline-success"
                         disabled={!visoesService.getPermissoes(['change_relatorio_consolidado_dre'])}
                     >
-                        Informar publicação
+                        {texto_info}
                     </button>
                 </div>
             }
             <section>
                 <ModalMarcarPublicacaoNoDiarioOficial
-                    titulo='Informar publicação'
+                    titulo={texto_info_modal}
                     show={showModalMarcarPublicacaoNoDiarioOficial}
                     handleClose={() => setShowModalMarcarPublicacaoNoDiarioOficial(false)}
                     consolidadoDre={consolidadoDre}
                     carregaConsolidadosDreJaPublicadosProximaPublicacao={carregaConsolidadosDreJaPublicadosProximaPublicacao}
-                    textoMsg='Data e página da publicação informada com sucesso.'
+                    textoMsg={`Data ${texto_aplicada} com sucesso.`}
                     textoBotaoSalvar='Informar'
                 />
             </section>

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/FormMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/FormMarcarPublicacaoNoDiarioOficial.js
@@ -9,10 +9,26 @@ import {
 } from "../../../../services/dres/RelatorioConsolidado.service";
 import {toastCustom} from "../../../Globais/ToastCustom";
 import ModalConfirmDesmarcarPublicacaoNoDiarioOficial from "../ModalConfirmDesmarcarPublicacaoNoDiarioOficial";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao, handleClose, textoMsg, textoBotaoSalvar}) => {
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const habilita_exibicao_de_lauda = recursoSelecionado?.habilita_exibicao_de_lauda;
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(habilita_exibicao_de_lauda)
+
+    const text_normal_remover = texto_documento_consolidado_pc.texto_remover_publicacao();
+    const text_removido = texto_documento_consolidado_pc.texto_removido();
+    const text_possessive = texto_documento_consolidado_pc.possessivo();
+    const text_aplicada = texto_documento_consolidado_pc.texto_publicacao_aplicada();
+    const texto_publicacao = texto_documento_consolidado_pc.texto_input_label();
+
+    const texto_info = `Selecione a data ${texto_publicacao}.`;
 
     const initialState = {
+        habilita_exibicao_de_lauda,
         data_publicacao: consolidadoDre.data_publicacao,
         pagina_publicacao: consolidadoDre.pagina_publicacao,
     }
@@ -26,13 +42,11 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
             pagina_publicacao: values.pagina_publicacao,
         }
         try {
-            let marcado = await postMarcarComoPublicadoNoDiarioOficial(payload)
+            await postMarcarComoPublicadoNoDiarioOficial(payload)
             handleClose()
-            toastCustom.ToastCustomSuccess('Data e página da publicação aplicadas com sucesso.', `${textoMsg}`)
-            console.log("Relatório marcado como publicado no Diário Oficial com sucesso! ", marcado)
+            toastCustom.ToastCustomSuccess(`Data ${text_aplicada} com sucesso.`, `${textoMsg}`)
             await carregaConsolidadosDreJaPublicadosProximaPublicacao()
-        }catch (e) {
-            console.log("Erro ao marcar como publicado no Diário Oficial!")
+        } catch {
             handleClose()
         }
     }, [carregaConsolidadosDreJaPublicadosProximaPublicacao, consolidadoDre.uuid, handleClose, textoMsg])
@@ -41,26 +55,30 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
         const payload ={
             consolidado_dre: consolidadoDre.uuid,
         }
+
         try {
-            let desmarcado = await postDesmarcarComoPublicadoNoDiarioOficial(payload)
+            await postDesmarcarComoPublicadoNoDiarioOficial(payload)
             handleClose()
             setShowModalConfirmDesmarcarPublicacaoNoDiarioOficial(false)
-            toastCustom.ToastCustomSuccess('Informação da publicação removida com sucesso.', `Data e página da publicação removidas com sucesso.`)
-            console.log("Relatório desmarcado como publicado no Diário Oficial com sucesso! ", desmarcado)
+            toastCustom.ToastCustomSuccess(`Informação ${text_possessive} removida com sucesso.`, `Data ${text_removido}`)
             await carregaConsolidadosDreJaPublicadosProximaPublicacao()
-        }catch (e) {
-            console.log("Erro ao desmarcar como publicado no Diário Oficial!")
+        } catch {
             handleClose()
             setShowModalConfirmDesmarcarPublicacaoNoDiarioOficial(false)
         }
     }
 
     const verificaSeHabilitaBotaoExclusao = () =>{
-        return consolidadoDre
-            && consolidadoDre.data_publicacao
-            && consolidadoDre.pagina_publicacao
-            && consolidadoDre.status_sme !== 'EM_ANALISE'
-            && consolidadoDre.permite_excluir_data_e_pagina_publicacao
+        let hasPublicationPage = true;
+
+        if (habilita_exibicao_de_lauda) {
+            hasPublicationPage = consolidadoDre?.pagina_publicacao
+        }
+
+        return hasPublicationPage
+            && consolidadoDre?.data_publicacao
+            && consolidadoDre?.status_sme !== 'EM_ANALISE'
+            && consolidadoDre?.permite_excluir_data_e_pagina_publicacao
     }
 
   return(
@@ -79,7 +97,7 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
                   } = props;
                   return (
                       <form onSubmit={props.handleSubmit}>
-                          <p>Selecione a data e a página da publicação no Diário Oficial da Cidade.</p>
+                          <p>{texto_info}</p>
                           <div className="mt-2">
                               <label htmlFor="data">Data</label>
                               <DatePickerField
@@ -90,18 +108,22 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
                               />
                               {props.errors.data_publicacao && <span className="span_erro text-danger mt-1"> {props.errors.data_publicacao}</span>}
                           </div>
-                          <div className='mt-2'>
-                              <label htmlFor="pagina_publicacao">Informar página da lauda no Diário Oficial</label>
-                              <input
-                                  type="text"
-                                  value={props.values.pagina_publicacao}
-                                  name="pagina_publicacao"
-                                  id="pagina_publicacao"
-                                  className="form-control"
-                                  onChange={props.handleChange}
-                              />
-                              {props.errors.pagina_publicacao && <span className="span_erro text-danger mt-1"> {props.errors.pagina_publicacao} </span>}
-                          </div>
+                          
+                          {
+                            habilita_exibicao_de_lauda &&
+                            <div className='mt-2'>
+                                <label htmlFor="pagina_publicacao">Informar página da lauda no Diário Oficial</label>
+                                <input
+                                    type="text"
+                                    value={props.values.pagina_publicacao}
+                                    name="pagina_publicacao"
+                                    id="pagina_publicacao"
+                                    className="form-control"
+                                    onChange={props.handleChange}
+                                />
+                                {props.errors.pagina_publicacao && <span className="span_erro text-danger mt-1"> {props.errors.pagina_publicacao} </span>}
+                            </div>
+                          }
 
                           <div className="d-flex bd-highlight align-items-center">
                               <div className="py-2 flex-grow-1 bd-highlight">
@@ -129,8 +151,8 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
                   show={showModalConfirmDesmarcarPublicacaoNoDiarioOficial}
                   onHide={()=>setShowModalConfirmDesmarcarPublicacaoNoDiarioOficial(false)}
                   handleClose={()=>setShowModalConfirmDesmarcarPublicacaoNoDiarioOficial(false)}
-                  titulo='Remover publicação'
-                  texto='<p>Deseja remover a data e a página da publicação no Diário Oficial da Cidade?</p>'
+                  titulo={text_normal_remover}
+                  texto={`<p>Deseja remover a data ${texto_publicacao}?</p>`}
                   segundoBotaoOnclick={desmarcarComoPublicado}
               />
           </section>

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/IconeMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/IconeMarcarPublicacaoNoDiarioOficial.js
@@ -3,16 +3,33 @@ import {ModalMarcarPublicacaoNoDiarioOficial} from "../ModalMarcarPublicacaoNoDi
 import moment from "moment";
 import {visoesService} from "../../../../services/visoes.service";
 import { EditIconButton } from "../../../Globais/UI/Button";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 const IconeMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao}) => {
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const habilita_exibicao_lauda = recursoSelecionado?.habilita_exibicao_lauda;
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(habilita_exibicao_lauda);
+
+    const text_possessive = texto_documento_consolidado_pc.possessivo_acao();
+    const texto_publicacao_modal = texto_documento_consolidado_pc.texto_titulo_publicacao_modal();
+    const texto_info_modal = `Informar ${texto_publicacao_modal}.`;
+
     const [showModalMarcarPublicacaoNoDiarioOficial, setShowModalMarcarPublicacaoNoDiarioOficial] = useState(false)
 
     const retornaMsgToolTip = () => {
         let data_de_publicacao = moment(consolidadoDre.data_publicacao).format("DD/MM/YYYY")
         return (
             <div>
-                <p class='mb-1'>Data publicação: {data_de_publicacao}</p>
-                <p class='mb-1'>Página publicação: {consolidadoDre.pagina_publicacao}</p>
+                <p className='mb-1'>Data {text_possessive}: {data_de_publicacao}</p>
+
+                {
+                    habilita_exibicao_lauda && (
+                        <p className='mb-1'>Página publicação: {consolidadoDre.pagina_publicacao}</p>
+                    )
+                }
             </div>
         )
     }
@@ -29,12 +46,12 @@ const IconeMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidad
             }
             <section>
                 <ModalMarcarPublicacaoNoDiarioOficial
-                    titulo='Informar publicação'
+                    titulo={texto_info_modal}
                     show={showModalMarcarPublicacaoNoDiarioOficial}
                     handleClose={() => setShowModalMarcarPublicacaoNoDiarioOficial(false)}
                     consolidadoDre={consolidadoDre}
                     carregaConsolidadosDreJaPublicadosProximaPublicacao={carregaConsolidadosDreJaPublicadosProximaPublicacao}
-                    textoMsg='Informações da publicação alteradas com sucesso.'
+                    textoMsg={`Informações ${text_possessive} alteradas com sucesso.`}
                     textoBotaoSalvar='Salvar'
                 />
             </section>

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/InfoPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/InfoPublicacaoNoDiarioOficial.js
@@ -4,23 +4,31 @@ import { useNavigate } from "react-router-dom";
 import IconeMarcarPublicacaoNoDiarioOficial from "./IconeMarcarPublicacaoNoDiarioOficial";
 import { visoesService } from "../../../../services/visoes.service";
 import { EditIconButton } from "../../../Globais/UI/Button";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 const InfoPublicacaoNoDiarioOficial = ({ consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao }) => {
   const dataTemplate = useDataTemplate();
   const navigate = useNavigate();
+  const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+  const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+
+  const text_possessive = texto_documento_consolidado_pc.texto_acao_objeto();
 
   return (
     <>
-      {consolidadoDre && consolidadoDre.data_publicacao && (
+      {consolidadoDre?.data_publicacao && (
         <div className="mb-0 fonte-12 fonte-normal">
-          <strong>Data da publicação:</strong> {dataTemplate(null, null, consolidadoDre.data_publicacao)}
+          <strong>Data {text_possessive}:</strong> {dataTemplate(null, null, consolidadoDre.data_publicacao)}
           <IconeMarcarPublicacaoNoDiarioOficial
             consolidadoDre={consolidadoDre}
             carregaConsolidadosDreJaPublicadosProximaPublicacao={carregaConsolidadosDreJaPublicadosProximaPublicacao}
           />
         </div>
       )}
-      {consolidadoDre && consolidadoDre?.eh_retificacao && !consolidadoDre.ja_publicado && (
+      
+      {consolidadoDre?.eh_retificacao && !consolidadoDre.ja_publicado && (
         <EditIconButton
           tooltipMessage="Editar Retificação"
           disabled={!visoesService.getPermissoes(["change_relatorio_consolidado_dre"])}

--- a/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/Cabecalho.js
+++ b/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/Cabecalho.js
@@ -1,12 +1,19 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 export const Cabecalho = ({ referenciaPublicacao, onClickVoltar, formataPeriodo }) => {
+  const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+  const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+  const text_possessive = texto_documento_consolidado_pc.possessivo();
+
   return (
     <div className="row pt-2">
       <div className="col-5">
-        <span className="referencia-e-periodo-relatorio">Referência da publicação:</span>
+        <span className="referencia-e-periodo-relatorio">Referência {text_possessive}:</span>
         <br />
         <span className="texto.referencia-e-periodo-relatorio">{referenciaPublicacao}</span>
       </div>

--- a/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
@@ -19,8 +19,17 @@ import { ModalAntDesignConfirmacao } from "../../../Globais/ModalAntDesign";
 import { TituloTabela } from "./TituloTabela";
 import { Tooltip as ReactTooltip } from "react-tooltip";
 import { toastCustom } from "../../../Globais/ToastCustom";
+import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
 
 const RetificacaoRelatorioConsolidado = () => {
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+
+    const text_possessive = texto_documento_consolidado_pc.possessivo();
+    const text_info_lauda_future = texto_documento_consolidado_pc.texto_lauda_a_ser_publicada();
+
     const initialValuesFiltros = {
         filtro_por_nome: '',
         filtro_por_tipo: ''
@@ -632,7 +641,7 @@ const RetificacaoRelatorioConsolidado = () => {
         }
         else{
             await postRetificarPcs(relatorio_consolidado_uuid, payload)
-            toastCustom.ToastCustomSuccess('Retificação criada com sucesso.', 'A retificação da publicação foi criada com sucesso.')
+            toastCustom.ToastCustomSuccess('Retificação criada com sucesso.', `A retificação ${text_possessive} foi criada com sucesso.`)
             onClickVoltar();
         }    
     }
@@ -655,7 +664,7 @@ const RetificacaoRelatorioConsolidado = () => {
         await postDesfazerRetificacaoPcs(relatorio_consolidado_uuid, payload)
 
         if(deve_apagar_retificacao){
-            toastCustom.ToastCustomSuccess('Retificação removida com sucesso.', 'A retificação da publicação foi removida com sucesso.')
+            toastCustom.ToastCustomSuccess('Retificação removida com sucesso.', `A retificação ${text_possessive} foi removida com sucesso.`)
             onClickVoltar();
         }
         else{
@@ -665,7 +674,7 @@ const RetificacaoRelatorioConsolidado = () => {
             setLoadingPcsDoConsolidado(true);
             setLoadingPcsEmRetificacao(true);
 
-            toastCustom.ToastCustomSuccess('Remoção de PCs efetuada com sucesso.', 'PCs removidas da retificação com sucesso.')
+            toastCustom.ToastCustomSuccess('Remoção de PCs efetuada com sucesso.', `PCs removidas da retificação ${text_possessive} com sucesso.`)
             
             await carregaPcsDoConsolidado();
             await carregaPcsEmRetificacao();
@@ -717,8 +726,7 @@ const RetificacaoRelatorioConsolidado = () => {
 
     return (
         <PaginasContainer>
-            <h1 className="titulo-itens-painel mt-5">Retificação da publicação</h1>
-            <>
+            <h1 className="titulo-itens-painel mt-5">Retificação {text_possessive}</h1>
                 <div className="page-content-inner pt-0">
                     {loading ? (
                         <div className="mt-5">
@@ -827,7 +835,7 @@ const RetificacaoRelatorioConsolidado = () => {
                             <ModalAntDesignConfirmacao
                                 handleShow={showModal}
                                 titulo={"Confirmar Retificação"}
-                                bodyText="Lembre-se que apenas as prestações de contas selecionadas serão reabertas para edição e gerarão novos documentos e nova lauda a ser publicada."
+                                bodyText={`Lembre-se que apenas as prestações de contas selecionadas serão reabertas para edição e gerarão novos documentos${text_info_lauda_future}.`}
                                 handleOk={(e) => handleRetificar()}
                                 okText="Continuar"
                                 handleCancel={(e) => setShowModal(false)}
@@ -847,7 +855,7 @@ const RetificacaoRelatorioConsolidado = () => {
                             <ModalAntDesignConfirmacao
                                 handleShow={showModalDeveApagarRetificacao}
                                 titulo={"Cancelar retificação"}
-                                bodyText="Você confirma que deseja cancelar a retificação de todas as PCs retificadas? Esta ação apagará a retificação da publicação."
+                                bodyText={`Você confirma que deseja cancelar a retificação de todas as PCs retificadas? Esta ação apagará a retificação ${text_possessive}.`}
                                 handleOk={(e) => handleDesfazerRetificao(true)}
                                 okText="Confirmar"
                                 handleCancel={(e) => setShowModalDeveApagarRetificacao(false)}
@@ -857,7 +865,6 @@ const RetificacaoRelatorioConsolidado = () => {
                         </>
                     }
                 </div>
-            </>
         </PaginasContainer>
     )
 }

--- a/src/componentes/dres/RelatorioConsolidado/YupSignupSchemaMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/YupSignupSchemaMarcarPublicacaoNoDiarioOficial.js
@@ -1,6 +1,10 @@
 import * as yup from "yup";
 
 export const YupSignupSchemaMarcarPublicacaoNoDiarioOficial = yup.object().shape({
-    data_publicacao: yup.string().required("Campo data da publicação é obrigatório").nullable(),
-    pagina_publicacao: yup.string().required("Campo página da publicação é obrigatório"),
+    data_publicacao: yup.string().required("Campo data é obrigatório").nullable(),
+    pagina_publicacao: yup.string().when('habilita_exibicao_de_lauda', {
+        is: (value) => Boolean(value),
+        then: yup.string().required("Campo página da publicação é obrigatório"),
+        otherwise: yup.string(),
+    }),
 });

--- a/src/componentes/dres/RelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/index.js
@@ -28,9 +28,11 @@ import PreviaDocumentos from "./PreviaDocumento";
 import {PERIODO_RELATORIO_CONSOLIDADO_DRE} from "../../../services/auth.service";
 import BlocoPublicacaoParcial from "./BlocoPublicacaoParcial"
 import useUnidadeSelecionada from "../../../hooks/Globais/useUnidadeSelecionada";
+import { useRecursoSelecionadoContext } from "../../../context/RecursoSelecionado";
 
 const RelatorioConsolidado = () => {
     const { getUUIDUnidadeSelecionadaTipoDRE } = useUnidadeSelecionada(visoesService)
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
     
     const dre_uuid = visoesService.getItemUsuarioLogado('associacao_selecionada.uuid');
     const periodo_relatorio_consolidado_localstorage = localStorage.getItem(PERIODO_RELATORIO_CONSOLIDADO_DRE)
@@ -373,6 +375,8 @@ const RelatorioConsolidado = () => {
         }
     };
 
+    const isShowLaudaPróximaPublicacao = !consolidadoDreProximaPublicacao?.eh_consolidado_de_publicacoes_parciais && recursoSelecionado?.habilita_exibicao_de_lauda;
+
     return (
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Consolidado das PCs</h1>
@@ -416,7 +420,6 @@ const RelatorioConsolidado = () => {
                                     ) :
                                     <>
                                         {podeExibirProximaPublicacao() &&
-                                            <>
                                                 <div className='mt-3'>
                                                     <PublicarDocumentos
                                                         publicarConsolidadoDre={publicarConsolidadoDre}
@@ -448,13 +451,12 @@ const RelatorioConsolidado = () => {
                                                             podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
                                                         />
                                                     }
-                                                    {!consolidadoDreProximaPublicacao.eh_consolidado_de_publicacoes_parciais &&
+                                                    {isShowLaudaPróximaPublicacao &&
                                                         <Lauda
                                                             consolidadoDre={consolidadoDreProximaPublicacao}
                                                         />
                                                     }
                                                 </div>
-                                            </>
                                         }
 
                                         {consolidadosDreJaPublicados && consolidadosDreJaPublicados.map((consolidadoDre) =>
@@ -473,6 +475,7 @@ const RelatorioConsolidado = () => {
                                                 gerarPreviaConsolidadoDre={gerarPreviaConsolidadoDre}
                                                 podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
                                                 podeGerarPreviaRetificacao={podeGerarPreviaRetificacao}
+                                                isShowLauda={recursoSelecionado?.habilita_exibicao_de_lauda}
                                             />
                                         )}
                                     </>

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -13,6 +13,8 @@ import {FormAlterarSenha} from "../componentes/Globais/EdicaoDeSenha/FormAlterar
 import {TextoValidacaoSenha} from "../componentes/Globais/MedidorForcaSenha/textoValidacaoSenha";
 import {FormAlterarEmail} from "../componentes/Globais/FormAlterarEmail";
 import {Button} from "react-bootstrap";
+import { useRecursoSelecionadoContext } from "../context/RecursoSelecionado";
+import { TextoDocumentoConsolidadoPC } from "./TextoDocumentoConsolidadoPC";
 
 
 export const AvisoCapitalModal = (propriedades) => {
@@ -606,12 +608,18 @@ export const ModalConfirmarExportacao = (propriedades) => {
 };
 
 export const ModalAtaNaoPreenchida = (propriedades) => {
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+    
+    const text_fazer = texto_documento_consolidado_pc.texto_acao_concreta();
+
     return (
         <ModalBootstrap
             show={propriedades.show}
             onHide={propriedades.handleClose}
             titulo="Ata não preenchida"
-            bodyText="Para fazer a publicação você precisa preencher as informações da ata."
+            bodyText={`Para ${text_fazer} você precisa preencher as informações da ata.`}
             primeiroBotaoOnclick={propriedades.handleClose}
             primeiroBotaoTexto="Fechar"
             primeiroBotaoCss="success"

--- a/src/utils/TextoDocumentoConsolidadoPC.js
+++ b/src/utils/TextoDocumentoConsolidadoPC.js
@@ -1,0 +1,78 @@
+export class TextoDocumentoConsolidadoPC {
+    constructor(habilita_lauda) {
+        this.habilita_lauda = habilita_lauda;
+    }
+
+    normal() {
+        if (this.habilita_lauda) {
+            return "publicação";
+        }
+
+        return "relatório";
+    }
+
+    possessivo() {
+        const artigo = this.habilita_lauda ? "da" : "do";
+
+        return `${artigo} ${this.normal()}`;
+    }
+
+    possessivo_acao() {
+        const artigo = this.habilita_lauda ? "da" : "do";
+
+        return `${artigo} ${this.texto_acao_simples()}`;
+    }
+
+    texto_artigo_a() {
+        return this.habilita_lauda ? "gerada após a publicação" : "a geração do relatório";
+    }
+
+    texto_emissao() {
+        return this.habilita_lauda ? "gerada após a publicação" : "emitida após a geração do relatório";
+    }
+
+    texto_acao() {
+        return this.habilita_lauda ? "publicação" : "envio externo";
+    }
+
+    texto_acao_simples() {
+        return this.habilita_lauda ? "publicação" : "envio";
+    }
+
+    texto_acao_objeto() {
+        return this.habilita_lauda ? "da publicação" : "do envio da documentação"
+    }
+
+    texto_titulo_publicacao_modal() {
+        return this.habilita_lauda ? "publicação" : "data do envio da documentação"
+    }
+
+    texto_pagina_publicacao() {
+        return this.habilita_lauda ? "e página da publicação" : "";
+    }
+
+    texto_input_label() {
+        return this.habilita_lauda ? "e a página da publicação no Diário Oficial da Cidade" : "do envio externo da documentação";
+    }
+
+    texto_remover_publicacao() {
+        return this.habilita_lauda ? "Remover publicação" : "Remover envio externo da documentação";
+    }
+
+    texto_removido() {
+        return this.habilita_lauda ? "e página da publicação removidas com sucesso." : "com sucesso.";
+    }
+
+    texto_publicacao_aplicada() {
+        return this.habilita_lauda ? "e página da publicação aplicadas" : "aplicada";
+    }
+
+    texto_lauda_a_ser_publicada() {
+        return this.habilita_lauda ? " e nova lauda a ser publicada" : "";
+    }
+
+    texto_acao_concreta() {
+        return this.habilita_lauda ? "fazer a publicação" : "gerar o relatório";
+    }
+
+}


### PR DESCRIPTION
Este PR inclui:

- Passa uuid do recurso para filtragem de processos SEI;
- Passa uuid do recurso para filtrar períodos disponíveis;
- Na criação de processo, envia uuid do recurso (caso flag esteja inativa, o recurso não é enviado e o backend salva o processo com recurso legado);
- Refactor no código para evitar chamadas duplicadas na consulta de processos disponíveis;
- Correção de problema ao clicar no botão de "Voltar" dentro do detalhamento de associação a partir do recurso Prêmio e estava causando a troca de visão para o recurso PTRF e o redirecionamento para a tela de "Acompanhamento de PC". Agora ao clicar no botão "Voltar", o usuário é redirecionado a tela anterior, ou seja, a tela de listagem de associações.
- Correção de problema identificado onde ao recarregar a página dentro do detalhamento de associação na visão de recurso PTRF, a tela é recarregada mas o recurso estava sendo trocado para o Prêmio.

Bug: [AB#151459](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151459)
Tarefa: [AB#151885](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151885)