### PR TITLE
refac(152143): mostra os textos corretos de acordo com campo

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 import { TextoDocumentoConsolidadoPC } from "../../../../../../utils/TextoDocumentoConsolidadoPC";
 
 export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia, ehRetificacao, motivoRetificacao}) => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda);
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
     const texto_publicacao = texto_documento_consolidado_pc.texto_artigo_a();
     const texto_emissao = texto_documento_consolidado_pc.texto_emissao();
 

--- a/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/InfoRefiticacaoRelatorio.js
+++ b/src/componentes/dres/RelatorioConsolidado/BlocoRetificacao/InfoRefiticacaoRelatorio.js
@@ -1,4 +1,4 @@
-import React, {memo} from "react";
+import React, {memo, useMemo} from "react";
 import useDataTemplate from "../../../../hooks/Globais/useDataTemplate";
 import IconeEditarRetificacao from "../BlocoRetificacao/IconeEditarRetificacao";
 import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoConsolidadoPC";
@@ -7,7 +7,7 @@ const dataTemplate = useDataTemplate()
 const InfoRetificacaoRelatorio = ({consolidadoDre}) => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-    const text_possessive = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda).possessivo();
+    const text_possessive = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda).possessivo(), [recursoSelecionado?.habilita_exibicao_de_lauda]);
 
     return(
         <>

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/BotaoMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/BotaoMarcarPublicacaoNoDiarioOficial.js
@@ -1,4 +1,4 @@
-import React, {memo, useState} from "react";
+import React, {memo, useMemo, useState} from "react";
 import {ModalMarcarPublicacaoNoDiarioOficial} from "../ModalMarcarPublicacaoNoDiarioOficial";
 import {visoesService} from "../../../../services/visoes.service";
 import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
@@ -9,14 +9,14 @@ const BotaoMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidad
 
     const [showModalMarcarPublicacaoNoDiarioOficial, setShowModalMarcarPublicacaoNoDiarioOficial] = useState(false)    
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda)
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
 
     const texto_publicacao = texto_documento_consolidado_pc.texto_acao();
     const texto_publicacao_modal = texto_documento_consolidado_pc.texto_titulo_publicacao_modal();
     const texto_aplicada = texto_documento_consolidado_pc.texto_pagina_publicacao();
 
     const texto_info = `Informar ${texto_publicacao}`;
-    const texto_info_modal = `Informar ${texto_publicacao_modal}.`;
+    const texto_info_modal = `Informar ${texto_publicacao_modal}`;
 
     return (
         <>

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/FormMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/FormMarcarPublicacaoNoDiarioOficial.js
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useState} from "react";
+import React, {memo, useCallback, useMemo, useState} from "react";
 import {Formik} from "formik";
 import {YupSignupSchemaMarcarPublicacaoNoDiarioOficial} from "../YupSignupSchemaMarcarPublicacaoNoDiarioOficial";
 import {DatePickerField} from "../../../Globais/DatePickerField";
@@ -17,7 +17,7 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
 
     const habilita_exibicao_de_lauda = recursoSelecionado?.habilita_exibicao_de_lauda;
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(habilita_exibicao_de_lauda)
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(habilita_exibicao_de_lauda), [habilita_exibicao_de_lauda]);
 
     const text_normal_remover = texto_documento_consolidado_pc.texto_remover_publicacao();
     const text_removido = texto_documento_consolidado_pc.texto_removido();
@@ -25,7 +25,7 @@ const FormMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidado
     const text_aplicada = texto_documento_consolidado_pc.texto_publicacao_aplicada();
     const texto_publicacao = texto_documento_consolidado_pc.texto_input_label();
 
-    const texto_info = `Selecione a data ${texto_publicacao}.`;
+    const texto_info = `Selecione a data ${texto_publicacao}`;
 
     const initialState = {
         habilita_exibicao_de_lauda,

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/IconeMarcarPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/IconeMarcarPublicacaoNoDiarioOficial.js
@@ -1,4 +1,4 @@
-import React, {memo, useState} from "react";
+import React, {memo, useMemo, useState} from "react";
 import {ModalMarcarPublicacaoNoDiarioOficial} from "../ModalMarcarPublicacaoNoDiarioOficial";
 import moment from "moment";
 import {visoesService} from "../../../../services/visoes.service";
@@ -9,13 +9,13 @@ import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoCon
 const IconeMarcarPublicacaoNoDiarioOficial = ({consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao}) => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-    const habilita_exibicao_lauda = recursoSelecionado?.habilita_exibicao_lauda;
+    const habilita_exibicao_lauda = recursoSelecionado?.habilita_exibicao_de_lauda;
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(habilita_exibicao_lauda);
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(habilita_exibicao_lauda), [habilita_exibicao_lauda]);
 
     const text_possessive = texto_documento_consolidado_pc.possessivo_acao();
     const texto_publicacao_modal = texto_documento_consolidado_pc.texto_titulo_publicacao_modal();
-    const texto_info_modal = `Informar ${texto_publicacao_modal}.`;
+    const texto_info_modal = `Informar ${texto_publicacao_modal}`;
 
     const [showModalMarcarPublicacaoNoDiarioOficial, setShowModalMarcarPublicacaoNoDiarioOficial] = useState(false)
 

--- a/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/InfoPublicacaoNoDiarioOficial.js
+++ b/src/componentes/dres/RelatorioConsolidado/MarcarPublicacaoNoDiarioOficial/InfoPublicacaoNoDiarioOficial.js
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import useDataTemplate from "../../../../hooks/Globais/useDataTemplate";
 import { useNavigate } from "react-router-dom";
 import IconeMarcarPublicacaoNoDiarioOficial from "./IconeMarcarPublicacaoNoDiarioOficial";
@@ -12,7 +12,7 @@ const InfoPublicacaoNoDiarioOficial = ({ consolidadoDre, carregaConsolidadosDreJ
   const navigate = useNavigate();
   const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-  const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+  const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
 
   const text_possessive = texto_documento_consolidado_pc.texto_acao_objeto();
 

--- a/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/Cabecalho.js
+++ b/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/Cabecalho.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { useRecursoSelecionadoContext } from "../../../../context/RecursoSelecionado";
@@ -7,7 +7,7 @@ import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoCon
 export const Cabecalho = ({ referenciaPublicacao, onClickVoltar, formataPeriodo }) => {
   const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-  const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+  const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
   const text_possessive = texto_documento_consolidado_pc.possessivo();
 
   return (

--- a/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/RetificacaoRelatorioConsolidado/index.js
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useEffect, useState, useRef} from "react";
+import React, {memo, useCallback, useEffect, useState, useRef, useMemo} from "react";
 import { PaginasContainer } from "../../../../paginas/PaginasContainer";
 import '../relatorio-consolidado.scss'
 import { Cabecalho } from "./Cabecalho";
@@ -25,7 +25,7 @@ import { TextoDocumentoConsolidadoPC } from "../../../../utils/TextoDocumentoCon
 const RetificacaoRelatorioConsolidado = () => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
 
     const text_possessive = texto_documento_consolidado_pc.possessivo();
     const text_info_lauda_future = texto_documento_consolidado_pc.texto_lauda_a_ser_publicada();

--- a/src/utils/Modais.js
+++ b/src/utils/Modais.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useMemo } from "react";
 import {
     ModalBootstrap,
     ModalBootstrapReverConciliacao,
@@ -610,7 +610,7 @@ export const ModalConfirmarExportacao = (propriedades) => {
 export const ModalAtaNaoPreenchida = (propriedades) => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
 
-    const texto_documento_consolidado_pc = new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_lauda)
+    const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
     
     const text_fazer = texto_documento_consolidado_pc.texto_acao_concreta();
 


### PR DESCRIPTION
Este PR inclui:

- Mostra os textos corretamente de acordo com o campo "habilita_exibicao_de_lauda" dos dados de recurso;
- Adiciona o useMemo na captura da criação da instância "TextoDocumentoConsolidadoPC" para sempre que atualizar o campo, atualizar a instância também;

História: [AB#150754](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150754)
Tarefa: [AB#152143](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152143)