### PR TITLE
feat(145736): Implementa Geração de Ata de documentos de Ata de Retificação e Retificação de Retificação, R2, R3, Rn - Hom

### DIFF
--- a/src/componentes/Globais/SuporteAsUnidades/__tests__/SuporteAsUnidadesV2.test.js
+++ b/src/componentes/Globais/SuporteAsUnidades/__tests__/SuporteAsUnidadesV2.test.js
@@ -1,0 +1,173 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SuporteAsUnidadesV2 } from "../SuporteAsUnidadesV2";
+
+const mockMutate = jest.fn();
+
+jest.mock("../useAdicionarSuporte", () => ({
+    useAdicionarSuporte: () => ({
+        mutationAdicionarSuporte: { mutate: mockMutate },
+    }),
+}));
+
+jest.mock("react-redux", () => ({
+    useDispatch: () => jest.fn(),
+}));
+
+jest.mock("../../../../services/visoes.service", () => ({
+    visoesService: {
+        getItemUsuarioLogado: jest.fn(),
+        featureFlagAtiva: jest.fn(),
+    },
+}));
+
+jest.mock("../../../../services/auth.service", () => ({
+    getUsuarioLogado: jest.fn(() => ({ login: "user_teste" })),
+}));
+
+jest.mock("../../BarraMensagem", () => ({
+    barraMensagemCustom: {
+        BarraMensagemAcertoExterno: jest.fn(),
+    },
+}));
+
+jest.mock("../../Modal/ModalConfirm", () => ({
+    ModalConfirm: jest.fn(),
+}));
+
+jest.mock("../TextoExplicativoDaPagina", () => ({
+    TextoExplicativo: ({ visao }) => <div data-testid="texto-explicativo" data-visao={visao} />,
+}));
+
+jest.mock("../components/UnidadesEmSuporte/ListaUnidadesEmSuporte", () => ({
+    UnidadesEmSuporte: () => <div data-testid="unidades-em-suporte" />,
+}));
+
+let capturedOnSelecionaUnidade = null;
+jest.mock("../../EscolheUnidade", () => ({
+    EscolheUnidade: ({ onSelecionaUnidade, dre_uuid, visao }) => {
+        capturedOnSelecionaUnidade = onSelecionaUnidade;
+        return (
+            <div
+                data-testid="escolhe-unidade"
+                data-dre-uuid={dre_uuid}
+                data-visao={visao}
+            />
+        );
+    },
+}));
+
+import { visoesService } from "../../../../services/visoes.service";
+import { getUsuarioLogado } from "../../../../services/auth.service";
+import { ModalConfirm } from "../../Modal/ModalConfirm";
+import { barraMensagemCustom } from "../../BarraMensagem";
+
+describe("SuporteAsUnidadesV2", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        capturedOnSelecionaUnidade = null;
+        visoesService.featureFlagAtiva.mockReturnValue(false);
+        visoesService.getItemUsuarioLogado.mockReturnValue("");
+        getUsuarioLogado.mockReturnValue({ login: "user_teste" });
+        barraMensagemCustom.BarraMensagemAcertoExterno.mockReturnValue(
+            <div data-testid="barra-mensagem-feature-flag" />
+        );
+    });
+
+    it("deve renderizar TextoExplicativo com visao correta", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        const texto = screen.getByTestId("texto-explicativo");
+        expect(texto).toBeInTheDocument();
+        expect(texto).toHaveAttribute("data-visao", "UE");
+    });
+
+    it("deve renderizar UnidadesEmSuporte", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        expect(screen.getByTestId("unidades-em-suporte")).toBeInTheDocument();
+    });
+
+    it("deve renderizar o título de vincular unidades de suporte", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        expect(screen.getByText("Vincular unidades de suporte")).toBeInTheDocument();
+    });
+
+    it("deve renderizar EscolheUnidade com visao correta", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        const escolhe = screen.getByTestId("escolhe-unidade");
+        expect(escolhe).toBeInTheDocument();
+        expect(escolhe).toHaveAttribute("data-visao", "UE");
+    });
+
+    it("deve passar dre_uuid vazio para EscolheUnidade quando visao não é DRE", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        const escolhe = screen.getByTestId("escolhe-unidade");
+        expect(escolhe).toHaveAttribute("data-dre-uuid", "");
+        expect(visoesService.getItemUsuarioLogado).not.toHaveBeenCalled();
+    });
+
+    it("deve buscar dreUuid e passar para EscolheUnidade quando visao é DRE", () => {
+        visoesService.getItemUsuarioLogado.mockReturnValue("dre-uuid-123");
+        render(<SuporteAsUnidadesV2 visao="DRE" />);
+        expect(visoesService.getItemUsuarioLogado).toHaveBeenCalledWith("associacao_selecionada.uuid");
+        const escolhe = screen.getByTestId("escolhe-unidade");
+        expect(escolhe).toHaveAttribute("data-dre-uuid", "dre-uuid-123");
+    });
+
+    it("deve exibir barra de mensagem quando feature flag teste-flag está ativa", () => {
+        visoesService.featureFlagAtiva.mockReturnValue(true);
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        expect(visoesService.featureFlagAtiva).toHaveBeenCalledWith("teste-flag");
+        expect(barraMensagemCustom.BarraMensagemAcertoExterno).toHaveBeenCalledWith(
+            "Feature flag teste-flag ativa."
+        );
+        expect(screen.getByTestId("barra-mensagem-feature-flag")).toBeInTheDocument();
+    });
+
+    it("não deve exibir barra de mensagem quando feature flag teste-flag está inativa", () => {
+        visoesService.featureFlagAtiva.mockReturnValue(false);
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        expect(screen.queryByTestId("barra-mensagem-feature-flag")).not.toBeInTheDocument();
+    });
+
+    it("deve chamar ModalConfirm ao selecionar unidade", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        capturedOnSelecionaUnidade({ nome: "Escola Teste PROFA.", codigo_eol: "000123" });
+        expect(ModalConfirm).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: "Confirmação de acesso de suporte",
+                cancelText: "Não",
+                confirmText: "Sim",
+                confirmButtonClass: "btn-danger",
+                dataQa: "modal-confirmar-acesso-suporte",
+            })
+        );
+    });
+
+    it("deve incluir o nome da unidade na mensagem do modal", () => {
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        capturedOnSelecionaUnidade({ nome: "Escola Teste PROFA.", codigo_eol: "000123" });
+        const chamada = ModalConfirm.mock.calls[0][0];
+        expect(chamada.message).toContain("Escola Teste PROFA.");
+    });
+
+    it("deve chamar mutationAdicionarSuporte.mutate ao confirmar modal", () => {
+        ModalConfirm.mockImplementationOnce(({ onConfirm }) => { onConfirm(); });
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        capturedOnSelecionaUnidade({ nome: "Escola Teste", codigo_eol: "000123" });
+        expect(mockMutate).toHaveBeenCalledWith({
+            usuario: "user_teste",
+            payload: { codigo_eol: "000123" },
+        });
+    });
+
+    it("deve usar login do usuário logado ao confirmar suporte", () => {
+        getUsuarioLogado.mockReturnValue({ login: "outro_usuario" });
+        ModalConfirm.mockImplementationOnce(({ onConfirm }) => { onConfirm(); });
+        render(<SuporteAsUnidadesV2 visao="UE" />);
+        capturedOnSelecionaUnidade({ nome: "Escola X", codigo_eol: "999" });
+        expect(mockMutate).toHaveBeenCalledWith(
+            expect.objectContaining({ usuario: "outro_usuario" })
+        );
+    });
+});

--- a/src/componentes/Globais/SuporteAsUnidades/components/UnidadesEmSuporte/hooks/__tests__/useRemoverSuporte.test.js
+++ b/src/componentes/Globais/SuporteAsUnidades/components/UnidadesEmSuporte/hooks/__tests__/useRemoverSuporte.test.js
@@ -1,0 +1,179 @@
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRemoverSuporte } from "../useRemoverSuporte";
+import { encerrarAcessoSuporte, encerrarAcessoSuporteEmLote } from "../../../../../../../services/auth.service";
+import { toastCustom } from "../../../../../ToastCustom";
+
+jest.mock("../../../../../../../services/auth.service", () => ({
+    encerrarAcessoSuporte: jest.fn(),
+    encerrarAcessoSuporteEmLote: jest.fn(),
+}));
+
+jest.mock("../../../../../ToastCustom", () => ({
+    toastCustom: {
+        ToastCustomSuccess: jest.fn(),
+        ToastCustomError: jest.fn(),
+    },
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe("useRemoverSuporte", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("mutationRemoverSuporte", () => {
+        it("deve chamar encerrarAcessoSuporte com os parâmetros corretos", async () => {
+            encerrarAcessoSuporte.mockResolvedValue({ data: { mensagem: "Removido" } });
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                result.current.mutationRemoverSuporte.mutate({
+                    usuario: "user_teste",
+                    unidade_uuid: "uuid-123",
+                });
+            });
+
+            await waitFor(() =>
+                expect(encerrarAcessoSuporte).toHaveBeenCalledWith("user_teste", "uuid-123")
+            );
+        });
+
+        it("deve chamar ToastCustomSuccess ao remover com sucesso", async () => {
+            encerrarAcessoSuporte.mockResolvedValue({ data: { mensagem: "Suporte removido!" } });
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                result.current.mutationRemoverSuporte.mutate({
+                    usuario: "user_teste",
+                    unidade_uuid: "uuid-abc",
+                });
+            });
+
+            await waitFor(() =>
+                expect(toastCustom.ToastCustomSuccess).toHaveBeenCalledWith("Suporte removido!")
+            );
+        });
+
+        it("deve chamar ToastCustomError ao falhar na remoção", async () => {
+            encerrarAcessoSuporte.mockRejectedValue(new Error("Falha"));
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                result.current.mutationRemoverSuporte.mutate({
+                    usuario: "user_teste",
+                    unidade_uuid: "uuid-abc",
+                });
+            });
+
+            await waitFor(() =>
+                expect(toastCustom.ToastCustomError).toHaveBeenCalledWith("Erro ao remover acesso")
+            );
+        });
+
+        it("deve expor isPending como false inicialmente", () => {
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+            expect(result.current.mutationRemoverSuporte.isPending).toBe(false);
+        });
+    });
+
+    describe("mutationRemoverSuporteEmLote", () => {
+        it("deve chamar encerrarAcessoSuporteEmLote com os parâmetros corretos", async () => {
+            encerrarAcessoSuporteEmLote.mockResolvedValue({ data: { mensagem: "Lote removido" } });
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                await result.current.mutationRemoverSuporteEmLote.mutateAsync({
+                    usuario: "user_teste",
+                    unidade_uuids: ["uuid-1", "uuid-2"],
+                });
+            });
+
+            expect(encerrarAcessoSuporteEmLote).toHaveBeenCalledWith("user_teste", [
+                "uuid-1",
+                "uuid-2",
+            ]);
+        });
+
+        it("deve chamar ToastCustomSuccess ao remover em lote com sucesso", async () => {
+            encerrarAcessoSuporteEmLote.mockResolvedValue({ data: { mensagem: "Lote removido!" } });
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                await result.current.mutationRemoverSuporteEmLote.mutateAsync({
+                    usuario: "user_teste",
+                    unidade_uuids: ["uuid-1"],
+                });
+            });
+
+            expect(toastCustom.ToastCustomSuccess).toHaveBeenCalledWith("Lote removido!");
+        });
+
+        it("deve chamar ToastCustomError ao falhar na remoção em lote", async () => {
+            encerrarAcessoSuporteEmLote.mockRejectedValue(new Error("Falha em lote"));
+
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+
+            await act(async () => {
+                try {
+                    await result.current.mutationRemoverSuporteEmLote.mutateAsync({
+                        usuario: "user_teste",
+                        unidade_uuids: ["uuid-1"],
+                    });
+                } catch {}
+            });
+
+            await waitFor(() =>
+                expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
+                    "Erro ao remover acesso em lote"
+                )
+            );
+        });
+
+        it("deve expor isPending como false inicialmente", () => {
+            const { result } = renderHook(() => useRemoverSuporte(), {
+                wrapper: createWrapper(),
+            });
+            expect(result.current.mutationRemoverSuporteEmLote.isPending).toBe(false);
+        });
+    });
+
+    it("deve retornar ambas as mutations", () => {
+        const { result } = renderHook(() => useRemoverSuporte(), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.mutationRemoverSuporte).toBeDefined();
+        expect(result.current.mutationRemoverSuporteEmLote).toBeDefined();
+    });
+});

--- a/src/componentes/Globais/SuporteAsUnidades/components/UnidadesEmSuporte/hooks/__tests__/useUnidadesEmSuporte.test.js
+++ b/src/componentes/Globais/SuporteAsUnidades/components/UnidadesEmSuporte/hooks/__tests__/useUnidadesEmSuporte.test.js
@@ -1,0 +1,107 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUnidadesEmSuporte } from "../useUnidadesEmSuporte";
+import { getUnidadesEmSuporte } from "../../../../../../../services/auth.service";
+
+jest.mock("../../../../../../../services/auth.service", () => ({
+    getUnidadesEmSuporte: jest.fn(),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    return ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe("useUnidadesEmSuporte", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("deve chamar getUnidadesEmSuporte com usuario e page ao montar", async () => {
+        getUnidadesEmSuporte.mockResolvedValue({ count: 0, results: [] });
+        renderHook(() => useUnidadesEmSuporte("user_teste", 1), {
+            wrapper: createWrapper(),
+        });
+        await waitFor(() => expect(getUnidadesEmSuporte).toHaveBeenCalledWith("user_teste", 1));
+    });
+
+    it("deve usar page=1 como padrão quando não informada", async () => {
+        getUnidadesEmSuporte.mockResolvedValue({ count: 0, results: [] });
+        renderHook(() => useUnidadesEmSuporte("user_teste"), {
+            wrapper: createWrapper(),
+        });
+        await waitFor(() => expect(getUnidadesEmSuporte).toHaveBeenCalledWith("user_teste", 1));
+    });
+
+    it("deve retornar dados após sucesso", async () => {
+        const mockData = { count: 2, results: [{ uuid: "1" }, { uuid: "2" }] };
+        getUnidadesEmSuporte.mockResolvedValue(mockData);
+
+        const { result } = renderHook(() => useUnidadesEmSuporte("user_teste", 1), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.data).toEqual(mockData);
+        expect(result.current.count).toBe(2);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it("deve retornar isError=true quando a chamada falha", async () => {
+        getUnidadesEmSuporte.mockRejectedValue(new Error("Erro de rede"));
+
+        const { result } = renderHook(() => useUnidadesEmSuporte("user_teste", 1), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.data).toEqual({ count: 0, results: [] });
+    });
+
+    it("não deve executar a query quando usuario é falsy", async () => {
+        const { result } = renderHook(() => useUnidadesEmSuporte("", 1), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(getUnidadesEmSuporte).not.toHaveBeenCalled();
+    });
+
+    it("deve retornar count=0 e results=[] como padrão antes dos dados chegarem", async () => {
+        getUnidadesEmSuporte.mockResolvedValue({ count: 5, results: [] });
+
+        const { result } = renderHook(() => useUnidadesEmSuporte("user_teste", 1), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.count).toBe(0);
+        expect(result.current.data).toEqual({ count: 0, results: [] });
+    });
+
+    it("deve chamar getUnidadesEmSuporte com a page informada", async () => {
+        getUnidadesEmSuporte.mockResolvedValue({ count: 0, results: [] });
+        renderHook(() => useUnidadesEmSuporte("user_teste", 3), {
+            wrapper: createWrapper(),
+        });
+        await waitFor(() => expect(getUnidadesEmSuporte).toHaveBeenCalledWith("user_teste", 3));
+    });
+
+    it("deve expor a função refetch", async () => {
+        getUnidadesEmSuporte.mockResolvedValue({ count: 0, results: [] });
+
+        const { result } = renderHook(() => useUnidadesEmSuporte("user_teste", 1), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(typeof result.current.refetch).toBe("function");
+    });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDaUnidadeEducacional/__tests__/InfosUnidadeEducacional.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDaUnidadeEducacional/__tests__/InfosUnidadeEducacional.test.js
@@ -1,0 +1,189 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { InfosUnidadeEducacional } from "../InfosUnidadeEducacional";
+
+const mockDadosCompletos = {
+  dados_da_associacao: {
+    unidade: {
+      nome: "EMEF Teste",
+      codigo_eol: "123456",
+      email: "emef@teste.com",
+      qtd_alunos: 350,
+      diretor_nome: "Carlos Diretor",
+      telefone: "(11) 1234-5678",
+      tipo_logradouro: "Rua",
+      logradouro: "das Flores",
+      numero: "100",
+      complemento: "Fundos",
+      bairro: "Centro",
+      cep: "01000-000",
+    },
+  },
+};
+
+describe("InfosUnidadeEducacional", () => {
+  it("deve renderizar o título da seção", () => {
+    render(<InfosUnidadeEducacional dadosDaAssociacao={mockDadosCompletos} />);
+
+    expect(screen.getByText("Dados da unidade")).toBeInTheDocument();
+  });
+
+  it("deve exibir todos os campos com dados completos", () => {
+    render(<InfosUnidadeEducacional dadosDaAssociacao={mockDadosCompletos} />);
+
+    expect(screen.getByText("EMEF Teste")).toBeInTheDocument();
+    expect(screen.getByText("123456")).toBeInTheDocument();
+    expect(screen.getByText("emef@teste.com")).toBeInTheDocument();
+    expect(screen.getByText("350")).toBeInTheDocument();
+    expect(screen.getByText("Carlos Diretor")).toBeInTheDocument();
+    expect(screen.getByText("(11) 1234-5678")).toBeInTheDocument();
+  });
+
+  it("deve exibir os rótulos dos campos", () => {
+    render(<InfosUnidadeEducacional dadosDaAssociacao={mockDadosCompletos} />);
+
+    expect(screen.getByText("Nome da Unidade Educacional")).toBeInTheDocument();
+    expect(screen.getByText("Código EOL da Unidade Escolar")).toBeInTheDocument();
+    expect(screen.getByText("E-mail da Unidade Escolar")).toBeInTheDocument();
+    expect(screen.getByText("Número de estudantes")).toBeInTheDocument();
+    expect(screen.getByText("Nome do Diretor")).toBeInTheDocument();
+    expect(screen.getByText("Telefone da Unidade Educacional")).toBeInTheDocument();
+    expect(screen.getByText("Endereço da Unidade Educacional")).toBeInTheDocument();
+  });
+
+  it("deve montar o endereço completo com todos os campos presentes", () => {
+    render(<InfosUnidadeEducacional dadosDaAssociacao={mockDadosCompletos} />);
+
+    expect(
+      screen.getByText((content) =>
+        content.includes("Rua") &&
+        content.includes("das Flores,") &&
+        content.includes("100 -") &&
+        content.includes("Fundos -") &&
+        content.includes("Centro,") &&
+        content.includes("São Paulo - SP,") &&
+        content.includes("01000-000")
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("deve montar o endereço sem logradouro quando ausente", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          ...mockDadosCompletos.dados_da_associacao.unidade,
+          logradouro: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("São Paulo - SP,") && content.includes("01000-000")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+    expect(enderecoEl.textContent).not.toContain("das Flores");
+  });
+
+  it("deve montar o endereço sem complemento quando ausente", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          ...mockDadosCompletos.dados_da_associacao.unidade,
+          complemento: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("das Flores,") &&
+      content.includes("São Paulo - SP,") &&
+      content.includes("01000-000")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+    expect(enderecoEl.textContent).not.toContain("Fundos");
+  });
+
+  it("deve montar o endereço sem bairro quando ausente", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          ...mockDadosCompletos.dados_da_associacao.unidade,
+          bairro: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("das Flores,") &&
+      content.includes("Fundos") &&
+      content.includes("São Paulo - SP,") &&
+      content.includes("01000-000")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+    expect(enderecoEl.textContent).not.toContain("Centro");
+  });
+
+  it("deve montar o endereço sem cep quando ausente", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          ...mockDadosCompletos.dados_da_associacao.unidade,
+          cep: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("das Flores,") &&
+      content.includes("São Paulo - SP,") &&
+      !content.includes("01000-000")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+  });
+
+  it("deve montar o endereço sem número quando ausente", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          ...mockDadosCompletos.dados_da_associacao.unidade,
+          numero: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("das Flores,") &&
+      content.includes("Fundos") &&
+      content.includes("São Paulo - SP,") &&
+      content.includes("01000-000")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+    expect(enderecoEl.textContent).not.toContain("100 -");
+  });
+
+  it("deve montar o endereço somente com tipo_logradouro e cidade/estado quando todos os outros campos ausentes", () => {
+    const dados = {
+      dados_da_associacao: {
+        unidade: {
+          tipo_logradouro: "Avenida",
+          logradouro: undefined,
+          numero: undefined,
+          complemento: undefined,
+          bairro: undefined,
+          cep: undefined,
+        },
+      },
+    };
+    render(<InfosUnidadeEducacional dadosDaAssociacao={dados} />);
+
+    const enderecoEl = screen.getByText((content) =>
+      content.includes("Avenida") && content.includes("São Paulo - SP,")
+    );
+    expect(enderecoEl).toBeInTheDocument();
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/BarraStatusEncerramentoConta/__tests__/BarraStatusEncerramentoConta.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/BarraStatusEncerramentoConta/__tests__/BarraStatusEncerramentoConta.test.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { BarraStatusEncerramentoConta } from "../index";
+
+describe("BarraStatusEncerramentoConta", () => {
+    it("não exibe texto/classe quando conta é undefined", () => {
+        const { container } = render(<BarraStatusEncerramentoConta conta={undefined} />);
+
+        expect(
+            screen.queryByText("Solicitação de encerramento da conta negada.")
+        ).not.toBeInTheDocument();
+
+        const divCol = container.querySelector(".col-12");
+        expect(divCol).not.toHaveClass("barra-status-encerramento-conta-rejeitada");
+    });
+
+    it("não exibe texto/classe quando conta não possui solicitacao_encerramento", () => {
+        const conta = { nome: "Conta sem solicitação" };
+        const { container } = render(<BarraStatusEncerramentoConta conta={conta} />);
+
+        expect(
+            screen.queryByText("Solicitação de encerramento da conta negada.")
+        ).not.toBeInTheDocument();
+
+        const divCol = container.querySelector(".col-12");
+        expect(divCol).not.toHaveClass("barra-status-encerramento-conta-rejeitada");
+    });
+
+    it("não exibe texto/classe quando status é APROVADA", () => {
+        const conta = { solicitacao_encerramento: { status: "APROVADA" } };
+        const { container } = render(<BarraStatusEncerramentoConta conta={conta} />);
+
+        expect(
+            screen.queryByText("Solicitação de encerramento da conta negada.")
+        ).not.toBeInTheDocument();
+
+        const divCol = container.querySelector(".col-12");
+        expect(divCol).not.toHaveClass("barra-status-encerramento-conta-rejeitada");
+    });
+
+    it("não exibe texto/classe quando status é um valor diferente de APROVADA/REJEITADA", () => {
+        const conta = { solicitacao_encerramento: { status: "PENDENTE" } };
+        const { container } = render(<BarraStatusEncerramentoConta conta={conta} />);
+
+        expect(
+            screen.queryByText("Solicitação de encerramento da conta negada.")
+        ).not.toBeInTheDocument();
+
+        const divCol = container.querySelector(".col-12");
+        expect(divCol).not.toHaveClass("barra-status-encerramento-conta-rejeitada");
+    });
+
+    it("exibe texto e classe quando status é REJEITADA", () => {
+        const conta = { solicitacao_encerramento: { status: "REJEITADA" } };
+        const { container } = render(<BarraStatusEncerramentoConta conta={conta} />);
+
+        expect(
+            screen.getByText("Solicitação de encerramento da conta negada.")
+        ).toBeInTheDocument();
+
+        const divCol = container.querySelector(".col-12");
+        expect(divCol).toHaveClass("barra-status-encerramento-conta-rejeitada");
+
+        const icone = container.querySelector("svg");
+        expect(icone).toHaveClass("icone-barra-encerramento-conta-rejeitada");
+    });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/ModalConfirmarEncerramento/__tests__/ModalConfirmarEncerramento.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/ModalConfirmarEncerramento/__tests__/ModalConfirmarEncerramento.test.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ModalConfirmarEncerramento } from "../index";
+
+let capturedProps = null;
+
+jest.mock("../../../../../../Globais/ModalBootstrap", () => ({
+    ModalBootstrap: (props) => {
+        capturedProps = props;
+        return <div data-testid="modal-bootstrap" />;
+    },
+}));
+
+describe("ModalConfirmarEncerramento", () => {
+    beforeEach(() => {
+        capturedProps = null;
+    });
+
+    it("repassa corretamente todos os props para o ModalBootstrap", () => {
+        const handleClose = jest.fn();
+        const onConfirmarEncerramento = jest.fn();
+
+        const props = {
+            show: true,
+            handleClose,
+            titulo: "Confirmar encerramento",
+            texto: "Deseja confirmar o encerramento da conta?",
+            primeiroBotaoTexto: "Cancelar",
+            primeiroBotaoCss: "secondary",
+            onConfirmarEncerramento,
+            segundoBotaoTexto: "Confirmar",
+            segundoBotaoCss: "primary",
+        };
+
+        render(<ModalConfirmarEncerramento {...props} />);
+
+        expect(screen.getByTestId("modal-bootstrap")).toBeInTheDocument();
+        expect(capturedProps).not.toBeNull();
+        expect(capturedProps.show).toBe(true);
+        expect(capturedProps.onHide).toBe(handleClose);
+        expect(capturedProps.titulo).toBe("Confirmar encerramento");
+        expect(capturedProps.bodyText).toBe(
+            "Deseja confirmar o encerramento da conta?"
+        );
+        expect(capturedProps.primeiroBotaoOnclick).toBe(handleClose);
+        expect(capturedProps.primeiroBotaoTexto).toBe("Cancelar");
+        expect(capturedProps.primeiroBotaoCss).toBe("secondary");
+        expect(capturedProps.segundoBotaoOnclick).toBe(onConfirmarEncerramento);
+        expect(capturedProps.segundoBotaoTexto).toBe("Confirmar");
+        expect(capturedProps.segundoBotaoCss).toBe("primary");
+    });
+
+    it("repassa show=false quando informado", () => {
+        const props = {
+            show: false,
+            handleClose: jest.fn(),
+            titulo: "Titulo",
+            texto: "Texto",
+            primeiroBotaoTexto: "Cancelar",
+            primeiroBotaoCss: "secondary",
+            onConfirmarEncerramento: jest.fn(),
+            segundoBotaoTexto: "Confirmar",
+            segundoBotaoCss: "primary",
+        };
+
+        render(<ModalConfirmarEncerramento {...props} />);
+
+        expect(capturedProps.show).toBe(false);
+    });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/ModalRejeitarEncerramento/__tests__/ModalRejeitarEncerramento.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/ModalRejeitarEncerramento/__tests__/ModalRejeitarEncerramento.test.js
@@ -1,0 +1,144 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ModalRejeitarEncerramento } from "../index";
+
+let capturedProps = null;
+
+jest.mock("../../../../../../Globais/ModalBootstrap", () => ({
+    ModalMotivosRejeicaoEncerramentoConta: (props) => {
+        capturedProps = props;
+        return (
+            <div data-testid="modal-motivos-rejeicao">
+                {props.bodyText}
+            </div>
+        );
+    },
+}));
+
+describe("ModalRejeitarEncerramento", () => {
+    const motivosRejeicaoBase = [
+        { uuid: "uuid-1", nome: "Motivo 1", selected: false },
+        { uuid: "uuid-2", nome: "Motivo 2", selected: false },
+    ];
+
+    beforeEach(() => {
+        capturedProps = null;
+    });
+
+    const baseProps = (overrides = {}) => ({
+        show: true,
+        handleClose: jest.fn(),
+        titulo: "Rejeitar encerramento",
+        motivosRejeicao: motivosRejeicaoBase.map((m) => ({ ...m })),
+        primeiroBotaoTexto: "Cancelar",
+        primeiroBotaoCss: "secondary",
+        onRejeitarEncerramento: jest.fn(),
+        segundoBotaoTexto: "Confirmar",
+        segundoBotaoCss: "primary",
+        ...overrides,
+    });
+
+    it("renderiza os motivos passados via props", () => {
+        render(<ModalRejeitarEncerramento {...baseProps()} />);
+
+        expect(screen.getByText("Motivo 1")).toBeInTheDocument();
+        expect(screen.getByText("Motivo 2")).toBeInTheDocument();
+
+        const checkboxes = screen.getAllByRole("checkbox");
+        expect(checkboxes).toHaveLength(2);
+        expect(checkboxes[0]).not.toBeChecked();
+        expect(checkboxes[1]).not.toBeChecked();
+    });
+
+    it("toggle de checkbox inverte selected apenas do motivo correspondente", () => {
+        render(<ModalRejeitarEncerramento {...baseProps()} />);
+
+        const checkboxes = screen.getAllByRole("checkbox");
+
+        fireEvent.click(checkboxes[0]);
+
+        expect(checkboxes[0]).toBeChecked();
+        expect(checkboxes[1]).not.toBeChecked();
+
+        fireEvent.click(checkboxes[0]);
+        expect(checkboxes[0]).not.toBeChecked();
+
+        fireEvent.click(checkboxes[1]);
+        expect(checkboxes[0]).not.toBeChecked();
+        expect(checkboxes[1]).toBeChecked();
+    });
+
+    it("digitar no textarea atualiza outrosMotivosRejeicao", () => {
+        render(<ModalRejeitarEncerramento {...baseProps()} />);
+
+        const textarea = screen.getByLabelText ? null : document.querySelector('textarea[name="motivo-rejeicao"]');
+        const ta = textarea || document.querySelector('textarea[name="motivo-rejeicao"]');
+
+        fireEvent.change(ta, { target: { value: "Outro motivo qualquer" } });
+
+        expect(ta.value).toBe("Outro motivo qualquer");
+    });
+
+    it("ao confirmar, chama onRejeitarEncerramento com motivosRejeicao e outrosMotivosRejeicao atualizados", () => {
+        const onRejeitarEncerramento = jest.fn();
+        render(
+            <ModalRejeitarEncerramento
+                {...baseProps({ onRejeitarEncerramento })}
+            />
+        );
+
+        const checkboxes = screen.getAllByRole("checkbox");
+        fireEvent.click(checkboxes[1]);
+
+        const textarea = document.querySelector('textarea[name="motivo-rejeicao"]');
+        fireEvent.change(textarea, { target: { value: "Texto extra" } });
+
+        expect(capturedProps.segundoBotaoOnclick).toBeInstanceOf(Function);
+        capturedProps.segundoBotaoOnclick();
+
+        expect(onRejeitarEncerramento).toHaveBeenCalledTimes(1);
+        const [motivosChamados, outrosChamados] = onRejeitarEncerramento.mock.calls[0];
+
+        expect(outrosChamados).toBe("Texto extra");
+        expect(motivosChamados).toEqual([
+            { uuid: "uuid-1", nome: "Motivo 1", selected: false },
+            { uuid: "uuid-2", nome: "Motivo 2", selected: true },
+        ]);
+    });
+
+    it("não exibe span de erro quando errorModalRejeicao não é fornecido", () => {
+        render(<ModalRejeitarEncerramento {...baseProps()} />);
+
+        expect(document.querySelector(".span_erro")).not.toBeInTheDocument();
+    });
+
+    it("exibe span de erro quando errorModalRejeicao é fornecido", () => {
+        render(
+            <ModalRejeitarEncerramento
+                {...baseProps({ errorModalRejeicao: "Selecione ao menos um motivo" })}
+            />
+        );
+
+        expect(screen.getByText(/Selecione ao menos um motivo/)).toBeInTheDocument();
+        expect(document.querySelector(".span_erro")).toBeInTheDocument();
+    });
+
+    it("repassa props básicos corretamente para o ModalMotivosRejeicaoEncerramentoConta", () => {
+        const handleClose = jest.fn();
+        render(
+            <ModalRejeitarEncerramento
+                {...baseProps({ handleClose, show: false })}
+            />
+        );
+
+        expect(capturedProps.show).toBe(false);
+        expect(capturedProps.onHide).toBe(handleClose);
+        expect(capturedProps.titulo).toBe("Rejeitar encerramento");
+        expect(capturedProps.primeiroBotaoOnclick).toBe(handleClose);
+        expect(capturedProps.primeiroBotaoTexto).toBe("Cancelar");
+        expect(capturedProps.primeiroBotaoCss).toBe("secondary");
+        expect(capturedProps.segundoBotaoTexto).toBe("Confirmar");
+        expect(capturedProps.segundoBotaoCss).toBe("primary");
+    });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/TabelaContasEncerradas/__tests__/TabelaContasEncerradas.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/DadosDasContas/TabelaContasEncerradas/__tests__/TabelaContasEncerradas.test.js
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TabelaContasEncerradas } from "../index";
+
+jest.mock("primereact/datatable", () => {
+    const ReactLocal = require("react");
+    return {
+        DataTable: ({ value, children, paginator, rows }) => (
+            <table data-testid="datatable" data-paginator={String(paginator)} data-rows={rows}>
+                <tbody>
+                    {value?.map((row, index) => (
+                        <tr key={index}>
+                            {ReactLocal.Children.toArray(children).map((col, i) => (
+                                <td key={i}>
+                                    {col.props.body
+                                        ? col.props.body(row)
+                                        : row[col.props.field]}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        ),
+    };
+});
+
+jest.mock("primereact/column", () => ({
+    Column: (props) => props,
+}));
+
+describe("TabelaContasEncerradas", () => {
+    const contaComEncerramento = {
+        nome_exibicao_recurso: "Recurso 1",
+        tipo_conta: { nome: "Tipo A" },
+        banco_nome: "Banco X",
+        agencia: "1234",
+        numero_conta: "5678-9",
+        solicitacao_encerramento: {
+            data_de_encerramento_na_agencia: "2024-03-15",
+        },
+    };
+
+    const contaSemEncerramento = {
+        nome_exibicao_recurso: "Recurso 2",
+        tipo_conta: { nome: "Tipo B" },
+        banco_nome: "Banco Y",
+        agencia: "4321",
+        numero_conta: "9876-5",
+        solicitacao_encerramento: null,
+    };
+
+    it("renderiza o título da tabela", () => {
+        render(<TabelaContasEncerradas contas={[]} rowsPerPage={10} />);
+
+        expect(screen.getByText("Histórico de contas encerradas")).toBeInTheDocument();
+    });
+
+    it("renderiza a tabela com os dados das contas", () => {
+        render(
+            <TabelaContasEncerradas
+                contas={[contaComEncerramento, contaSemEncerramento]}
+                rowsPerPage={10}
+            />
+        );
+
+        expect(screen.getByText("Recurso 1")).toBeInTheDocument();
+        expect(screen.getByText("Recurso 2")).toBeInTheDocument();
+        expect(screen.getByText("Banco X")).toBeInTheDocument();
+        expect(screen.getByText("Banco Y")).toBeInTheDocument();
+    });
+
+    it("paginator é true quando contas.length > rowsPerPage", () => {
+        const contas = [contaComEncerramento, contaSemEncerramento, contaComEncerramento];
+        render(<TabelaContasEncerradas contas={contas} rowsPerPage={2} />);
+
+        const datatable = screen.getByTestId("datatable");
+        expect(datatable).toHaveAttribute("data-paginator", "true");
+        expect(datatable).toHaveAttribute("data-rows", "2");
+    });
+
+    it("paginator é false quando contas.length <= rowsPerPage", () => {
+        const contas = [contaComEncerramento];
+        render(<TabelaContasEncerradas contas={contas} rowsPerPage={10} />);
+
+        const datatable = screen.getByTestId("datatable");
+        expect(datatable).toHaveAttribute("data-paginator", "false");
+    });
+
+    it("dataTemplate formata a data quando há solicitacao_encerramento", () => {
+        render(
+            <TabelaContasEncerradas contas={[contaComEncerramento]} rowsPerPage={10} />
+        );
+
+        expect(screen.getByText("15/03/2024")).toBeInTheDocument();
+    });
+
+    it("dataTemplate retorna '-' quando não há solicitacao_encerramento", () => {
+        render(
+            <TabelaContasEncerradas contas={[contaSemEncerramento]} rowsPerPage={10} />
+        );
+
+        expect(screen.getByText("-")).toBeInTheDocument();
+    });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ConfirmaDeleteProcessoDialog.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ConfirmaDeleteProcessoDialog.test.js
@@ -1,0 +1,203 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+let capturedProps = null;
+
+jest.mock('../../../../../Globais/ModalBootstrap', () => ({
+  ModalBootstrap: (props) => {
+    capturedProps = props;
+    return (
+      <div data-testid="modal-bootstrap">
+        <span data-testid="titulo">{props.titulo}</span>
+        <span data-testid="body-text">{props.bodyText}</span>
+        <button data-testid="btn-cancelar" onClick={props.primeiroBotaoOnclick}>
+          {props.primeiroBotaoTexto}
+        </button>
+        <button data-testid="btn-excluir" onClick={props.segundoBotaoOnclick}>
+          {props.segundoBotaoTexto}
+        </button>
+      </div>
+    );
+  },
+}));
+
+/* eslint-disable-next-line import/first */
+import { ConfirmaDeleteProcesso } from '../ConfirmaDeleteProcessoDialog';
+
+describe('ConfirmaDeleteProcesso Testes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedProps = null;
+  });
+
+  test('1. Renderiza sem erros', () => {
+    const { container } = render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(container).toBeDefined();
+    expect(screen.getByTestId('modal-bootstrap')).toBeInTheDocument();
+  });
+
+  test('2. Repassa prop show para o ModalBootstrap', () => {
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.show).toBe(true);
+  });
+
+  test('3. Repassa show=false para o ModalBootstrap', () => {
+    render(
+      <ConfirmaDeleteProcesso
+        show={false}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.show).toBe(false);
+  });
+
+  test('4. Repassa handleClose como onHide', () => {
+    const handleClose = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={handleClose}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.onHide).toBe(handleClose);
+  });
+
+  test('5. Define o título fixo correto', () => {
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.titulo).toBe('Excluir o número do processo SEI');
+    expect(screen.getByTestId('titulo')).toHaveTextContent('Excluir o número do processo SEI');
+  });
+
+  test('6. Define o bodyText fixo com HTML correto', () => {
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.bodyText).toBe(
+      '<p>Tem certeza que deseja excluir esse número de processo?</p>'
+    );
+  });
+
+  test('7. Repassa onConfirmDelete como segundoBotaoOnclick', () => {
+    const onConfirmDelete = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={onConfirmDelete}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.segundoBotaoOnclick).toBe(onConfirmDelete);
+  });
+
+  test('8. Repassa onCancelDelete como primeiroBotaoOnclick', () => {
+    const onCancelDelete = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={onCancelDelete}
+      />
+    );
+
+    expect(capturedProps.primeiroBotaoOnclick).toBe(onCancelDelete);
+  });
+
+  test('9. Define textos e cores fixas dos botões', () => {
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.segundoBotaoTexto).toBe('Excluir');
+    expect(capturedProps.segundoBotaoCss).toBe('danger');
+    expect(capturedProps.primeiroBotaoTexto).toBe('Cancelar');
+    expect(capturedProps.primeiroBotaoCss).toBe('outline-success');
+  });
+
+  test('10. Clicar no botão Excluir (simulado) chama onConfirmDelete', () => {
+    const onConfirmDelete = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={onConfirmDelete}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('btn-excluir'));
+    expect(onConfirmDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('11. Clicar no botão Cancelar (simulado) chama onCancelDelete', () => {
+    const onCancelDelete = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={jest.fn()}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={onCancelDelete}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('btn-cancelar'));
+    expect(onCancelDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('12. Não chama handleClose automaticamente ao montar', () => {
+    const handleClose = jest.fn();
+    render(
+      <ConfirmaDeleteProcesso
+        show={true}
+        handleClose={handleClose}
+        onConfirmDelete={jest.fn()}
+        onCancelDelete={jest.fn()}
+      />
+    );
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessoSeiPrestacaoDeContaForm.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessoSeiPrestacaoDeContaForm.test.js
@@ -1,0 +1,439 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+jest.mock('react-text-mask', () => ({
+  __esModule: true,
+  default: ({ mask, guide, showMask, ...props }) => <input {...props} />,
+}));
+
+jest.mock('../../../../../../services/visoes.service');
+
+let capturedModalProps = null;
+jest.mock('../../../../../Globais/ModalBootstrap', () => ({
+  ModalBootstrapFormMembros: (props) => {
+    capturedModalProps = props;
+    return (
+      <div data-testid="modal-form-membros">
+        <span data-testid="titulo">{props.titulo}</span>
+        <div data-testid="body">{props.bodyText}</div>
+      </div>
+    );
+  },
+}));
+
+/* eslint-disable-next-line import/first */
+import {
+  ProcessoSeiPrestacaoDeContaForm,
+  YupSignupSchemaProcesso,
+} from '../ProcessoSeiPrestacaoDeContaForm';
+/* eslint-disable-next-line import/first */
+import { visoesService } from '../../../../../../services/visoes.service';
+
+const baseProps = {
+  show: true,
+  handleClose: jest.fn(),
+  onSubmit: jest.fn(),
+  handleChange: jest.fn(),
+  handleChangeSelectPeriodos: jest.fn(),
+  validateForm: jest.fn(),
+  initialValues: { numero_processo: '', ano: '', periodos: [] },
+  periodosDisponiveis: [],
+  customNumeroProcessoError: '',
+  setCustomNumeroProcessoError: jest.fn(),
+  loadingPeriodos: false,
+  recursoNome: '',
+  showRecursoField: false,
+};
+
+const setupDefaultMocks = () => {
+  visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+  visoesService.getPermissoes = jest.fn().mockReturnValue(true);
+};
+
+describe('ProcessoSeiPrestacaoDeContaForm Testes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedModalProps = null;
+    setupDefaultMocks();
+  });
+
+  test('1. Renderiza sem erros', () => {
+    const { container } = render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+    expect(container).toBeDefined();
+    expect(screen.getByTestId('modal-form-membros')).toBeInTheDocument();
+  });
+
+  test('2. Repassa show e onHide corretamente', () => {
+    const handleClose = jest.fn();
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} handleClose={handleClose} show={false} />);
+
+    expect(capturedModalProps.show).toBe(false);
+    expect(capturedModalProps.onHide).toBe(handleClose);
+  });
+
+  test('3. Título "Adicionar processo" quando não há uuid em initialValues', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} initialValues={{ numero_processo: '', ano: '' }} />);
+    expect(screen.getByTestId('titulo')).toHaveTextContent('Adicionar processo');
+  });
+
+  test('4. Título "Editar processo" quando há uuid em initialValues', () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        initialValues={{ uuid: 'p1', numero_processo: '1234.5678/0000001-0', ano: '2024' }}
+      />
+    );
+    expect(screen.getByTestId('titulo')).toHaveTextContent('Editar processo');
+  });
+
+  test('5. Campo Recurso não aparece quando showRecursoField=false', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} showRecursoField={false} />);
+    expect(screen.queryByLabelText(/Recurso/)).not.toBeInTheDocument();
+  });
+
+  test('6. Campo Recurso aparece quando showRecursoField=true, com o valor de recursoNome', () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        showRecursoField={true}
+        recursoNome="Recurso Teste"
+      />
+    );
+    const input = screen.getByLabelText(/Recurso/);
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('Recurso Teste');
+    expect(input).toBeDisabled();
+  });
+
+  test('7. Campo Recurso usa string vazia quando recursoNome não informado', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} showRecursoField={true} recursoNome={undefined} />);
+    const input = screen.getByLabelText(/Recurso/);
+    expect(input).toHaveValue('');
+  });
+
+  test('8. Input de número do processo chama handleChange e setCustomNumeroProcessoError', () => {
+    const handleChange = jest.fn();
+    const setCustomNumeroProcessoError = jest.fn();
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        handleChange={handleChange}
+        setCustomNumeroProcessoError={setCustomNumeroProcessoError}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Número do processo SEI');
+    fireEvent.change(input, { target: { name: 'numero_processo', value: '1234.5678/0000001-0' } });
+
+    expect(handleChange).toHaveBeenCalledWith('numero_processo', '1234.5678/0000001-0');
+    expect(setCustomNumeroProcessoError).toHaveBeenCalledWith('');
+  });
+
+  test('9. Input de ano chama handleChange e setCustomNumeroProcessoError', () => {
+    const handleChange = jest.fn();
+    const setCustomNumeroProcessoError = jest.fn();
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        handleChange={handleChange}
+        setCustomNumeroProcessoError={setCustomNumeroProcessoError}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Ano do processo');
+    fireEvent.change(input, { target: { name: 'ano', value: '2024' } });
+
+    expect(handleChange).toHaveBeenCalledWith('ano', '2024');
+    expect(setCustomNumeroProcessoError).toHaveBeenCalledWith('');
+  });
+
+  test('10. Input de ano fica desabilitado quando initialValues.uuid presente', () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        initialValues={{ uuid: 'p1', numero_processo: '1234.5678/0000001-0', ano: '2024' }}
+      />
+    );
+    const input = screen.getByPlaceholderText('Ano do processo');
+    expect(input).toBeDisabled();
+  });
+
+  test('11. Input de ano fica habilitado sem uuid e com permissão', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+    const input = screen.getByPlaceholderText('Ano do processo');
+    expect(input).not.toBeDisabled();
+  });
+
+  test('12. Exibe erro de props.errors.numero_processo (via yup na submissão)', async () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        initialValues={{ numero_processo: '', ano: '2024', periodos: [] }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Campo Número do processo é obrigatório')).toBeInTheDocument();
+    });
+  });
+
+  test('13. Exibe customNumeroProcessoError quando não há erro formik para numero_processo', () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        customNumeroProcessoError="Já existe um processo com este número"
+      />
+    );
+
+    expect(screen.getByText('Já existe um processo com este número')).toBeInTheDocument();
+  });
+
+  test('14. Não exibe customNumeroProcessoError quando há erro formik para numero_processo', async () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        customNumeroProcessoError="Erro customizado"
+        initialValues={{ numero_processo: '', ano: '2024', periodos: [] }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Campo Número do processo é obrigatório')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Erro customizado')).not.toBeInTheDocument();
+  });
+
+  test('15. Exibe erro de props.errors.ano', async () => {
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        initialValues={{ numero_processo: '1234.5678/0000001-0', ano: '', periodos: [] }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Campo ano é obrigatório')).toBeInTheDocument();
+    });
+  });
+
+  test('16. Campo de períodos não aparece quando feature flag inativa', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+    expect(screen.queryByLabelText(/Períodos/)).not.toBeInTheDocument();
+  });
+
+  test('17. Campo de períodos aparece quando feature flag ativa, populado por periodosDisponiveis', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        periodosDisponiveis={[
+          { uuid: 'per1', referencia: '1º Período 2024' },
+          { uuid: 'per2', referencia: '2º Período 2024' },
+        ]}
+      />
+    );
+
+    expect(screen.getByLabelText(/Períodos/)).toBeInTheDocument();
+    expect(visoesService.featureFlagAtiva).toHaveBeenCalledWith('periodos-processo-sei');
+  });
+
+  test('18. Select de períodos exibe spinner de loading quando loadingPeriodos=true', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} loadingPeriodos={true} />);
+
+    expect(screen.getByAltText('')).toBeInTheDocument();
+  });
+
+  test('19. Select de períodos fica desabilitado quando ano tem menos de 4 dígitos', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} initialValues={{ numero_processo: '', ano: '20' }} />);
+
+    // #periodos é o input interno do ant-design; o container com ant-select-disabled é o div pai
+    const selectInput = document.querySelector('#periodos');
+    const selectContainer = selectInput.closest('.ant-select');
+    expect(selectContainer).toHaveClass('ant-select-disabled');
+  });
+
+  test('20. Select de períodos fica desabilitado quando getPermissoes=false', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} initialValues={{ numero_processo: '', ano: '2024' }} />);
+
+    const selectInput = document.querySelector('#periodos');
+    const selectContainer = selectInput.closest('.ant-select');
+    expect(selectContainer).toHaveClass('ant-select-disabled');
+  });
+
+  test('21. Exibe erro de props.errors.periodos ao submeter com periodos vazio', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        initialValues={{ numero_processo: '1234.5678/0000001-0', ano: '2024', periodos: [] }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Campo períodos é obrigatório')).toBeInTheDocument();
+    });
+  });
+
+  test('22. Input numero_processo desabilitado quando getPermissoes retorna false', () => {
+    visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+
+    const input = screen.getByPlaceholderText('Número do processo SEI');
+    expect(input).toBeDisabled();
+  });
+
+  test('23. Botão Salvar desabilitado quando getPermissoes retorna false', () => {
+    visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+
+    const botaoSalvar = screen.getByRole('button', { name: 'Salvar' });
+    expect(botaoSalvar).toBeDisabled();
+  });
+
+  test('24. Botão Salvar desabilitado quando loadingPeriodos=true', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} loadingPeriodos={true} />);
+
+    const botaoSalvar = screen.getByRole('button', { name: 'Salvar' });
+    expect(botaoSalvar).toBeDisabled();
+  });
+
+  test('25. Botão Salvar habilitado quando getPermissoes=true e loadingPeriodos=false', () => {
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} />);
+
+    const botaoSalvar = screen.getByRole('button', { name: 'Salvar' });
+    expect(botaoSalvar).not.toBeDisabled();
+  });
+
+  test('26. Clique em Cancelar chama handleClose', () => {
+    const handleClose = jest.fn();
+    render(<ProcessoSeiPrestacaoDeContaForm {...baseProps} handleClose={handleClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('27. Submeter o formulário preenchido chama onSubmit', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        onSubmit={onSubmit}
+        initialValues={{ numero_processo: '1234.5678/0000001-0', ano: '2024', periodos: [] }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+  });
+
+  test('28. Submeter o formulário vazio não chama onSubmit (validação obrigatória)', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        onSubmit={onSubmit}
+        initialValues={{ numero_processo: '', ano: '' }}
+      />
+    );
+
+    const form = document.getElementById('membrosForm');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test('29. handleChangeSelectPeriodos é repassado ao Select de períodos', () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    const handleChangeSelectPeriodos = jest.fn();
+    render(
+      <ProcessoSeiPrestacaoDeContaForm
+        {...baseProps}
+        handleChangeSelectPeriodos={handleChangeSelectPeriodos}
+        periodosDisponiveis={[{ uuid: 'per1', referencia: '1º Período 2024' }]}
+      />
+    );
+
+    expect(document.querySelector('#periodos')).toBeInTheDocument();
+  });
+});
+
+describe('YupSignupSchemaProcesso Testes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('1. Valida com sucesso quando numero_processo e ano preenchidos e feature flag inativa', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '1234', ano: '2024' })
+    ).resolves.toBeTruthy();
+  });
+
+  test('2. Falha quando numero_processo está vazio', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '', ano: '2024' })
+    ).rejects.toThrow('Campo Número do processo é obrigatório');
+  });
+
+  test('3. Falha quando ano está vazio', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '1234', ano: '' })
+    ).rejects.toThrow('Campo ano é obrigatório');
+  });
+
+  test('4. Falha quando periodos vazio e feature flag ativa', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '1234', ano: '2024', periodos: [] })
+    ).rejects.toThrow('Campo períodos é obrigatório');
+  });
+
+  test('5. Sucesso quando periodos preenchido e feature flag ativa', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '1234', ano: '2024', periodos: ['per1'] })
+    ).resolves.toBeTruthy();
+  });
+
+  test('6. Sucesso quando periodos vazio mas feature flag inativa', async () => {
+    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    await expect(
+      YupSignupSchemaProcesso.validate({ numero_processo: '1234', ano: '2024', periodos: [] })
+    ).resolves.toBeTruthy();
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessoSeiRegularidade.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessoSeiRegularidade.test.js
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+jest.mock('react-text-mask', () => ({
+  __esModule: true,
+  default: ({ mask, guide, showMask, ...props }) => <input {...props} />,
+}));
+
+jest.mock('../../../../../../services/dres/Associacoes.service');
+jest.mock('../../../../../../services/visoes.service');
+
+jest.mock('../../../../../../utils/Loading', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading">Loading...</div>,
+}));
+
+/* eslint-disable-next-line import/first */
+import { ProcessoSeiRegularidade } from '../ProcessoSeiRegularidade';
+/* eslint-disable-next-line import/first */
+import { updateAssociacao } from '../../../../../../services/dres/Associacoes.service';
+/* eslint-disable-next-line import/first */
+import { visoesService } from '../../../../../../services/visoes.service';
+
+const baseDadosDaAssociacao = {
+  dados_da_associacao: {
+    uuid: 'a1',
+    processo_regularidade: '1234.5678/0000001-0',
+  },
+};
+
+const setupDefaultMocks = () => {
+  visoesService.getPermissoes = jest.fn().mockReturnValue(true);
+  updateAssociacao.mockResolvedValue({ status: 200 });
+};
+
+// Helper: aguarda o input estar visível (loading=false)
+const getInput = () => screen.getByPlaceholderText('Número do processo SEI');
+
+describe('ProcessoSeiRegularidade Testes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('1. Renderiza sem erros', async () => {
+    const { container } = render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+    expect(container).toBeDefined();
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+  });
+
+  test('2. Exibe o Loading momentaneamente e depois o formulário', async () => {
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+      expect(getInput()).toBeInTheDocument();
+    });
+  });
+
+  test('3. Exibe o título "Processos SEI"', async () => {
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Processos SEI')).toBeInTheDocument();
+    });
+  });
+
+  test('4. Input exibe o valor inicial de processo_regularidade', async () => {
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toHaveValue('1234.5678/0000001-0');
+    });
+  });
+
+  test('5. Input fica desabilitado quando getPermissoes retorna false', async () => {
+    visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeDisabled();
+    });
+  });
+
+  test('6. Botão Salvar fica desabilitado quando getPermissoes retorna false', async () => {
+    visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      const botao = screen.getByRole('button', { name: 'Salvar' });
+      expect(botao).toBeDisabled();
+    });
+  });
+
+  test('7. Input e botão habilitados quando getPermissoes retorna true', async () => {
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Salvar' })).not.toBeDisabled();
+    });
+  });
+
+  test('8. Submeter o form chama updateAssociacao com uuid e payload corretos', async () => {
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+
+    const input = getInput();
+    fireEvent.change(input, { target: { name: 'processo_regularidade', value: '9999.8888/0000002-1' } });
+
+    const form = input.closest('form');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(updateAssociacao).toHaveBeenCalledWith('a1', {
+        processo_regularidade: '9999.8888/0000002-1',
+      });
+    });
+  });
+
+  test('9. Sucesso (status 200) atualiza o estado local sem erros', async () => {
+    updateAssociacao.mockResolvedValue({ status: 200 });
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+
+    const form = getInput().closest('form');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(updateAssociacao).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+  });
+
+  test('10. Resposta com status diferente de 200 não quebra a aplicação', async () => {
+    updateAssociacao.mockResolvedValue({ status: 400 });
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+
+    const form = getInput().closest('form');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(updateAssociacao).toHaveBeenCalled();
+    });
+  });
+
+  test.skip('11. Erro (rejeição da promise) é tratado sem crash', async () => {
+    updateAssociacao.mockRejectedValue(new Error('Erro de rede'));
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={baseDadosDaAssociacao} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+
+    const form = getInput().closest('form');
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(updateAssociacao).toHaveBeenCalled();
+    });
+
+    expect(getInput()).toBeInTheDocument();
+  });
+
+  test('12. Renderiza com processo_regularidade indefinido (campo vazio)', async () => {
+    const dados = { dados_da_associacao: { uuid: 'a2', processo_regularidade: undefined } };
+    render(<ProcessoSeiRegularidade dadosDaAssociacao={dados} />);
+
+    await waitFor(() => {
+      expect(getInput()).toBeInTheDocument();
+    });
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessosSeiPrestacaoDeContas.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/ProcessosSei/__tests__/ProcessosSeiPrestacaoDeContas.test.js
@@ -1,24 +1,101 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
+let capturedFormProps = null;
+let capturedOnConfirm = null;
+
 jest.mock('../ProcessoSeiPrestacaoDeContaForm', () => ({
-  ProcessoSeiPrestacaoDeContaForm: () => <div data-testid="form">Formulário</div>,
+  ProcessoSeiPrestacaoDeContaForm: (props) => {
+    capturedFormProps = props;
+    if (!props.show) return null;
+    return (
+      <div data-testid="form">
+        <button data-testid="form-submit" onClick={() => props.onSubmit(props.initialValues)}>Salvar</button>
+        <button data-testid="form-close" onClick={props.handleClose}>Fechar</button>
+        <button data-testid="form-change-ano" onClick={() => props.handleChange('ano', '2024')}>Change Ano</button>
+        <button data-testid="form-change-numero" onClick={() => props.handleChange('numero_processo', '99999')}>Change Numero</button>
+        <button data-testid="form-change-periodos" onClick={() => props.handleChangeSelectPeriodos(['p1', 'p2'])}>Change Periodos</button>
+        <button data-testid="form-validate" onClick={() => props.validateForm()}>Validate</button>
+      </div>
+    );
+  },
 }));
 
-jest.mock('primereact/datatable', () => ({
-  DataTable: ({ value }) => (
-    <div data-testid="table">
-      {value && value.map(item => <span key={item.uuid}>{item.numero_processo}</span>)}
-    </div>
+jest.mock('../ConfirmaDeleteProcessoDialog', () => ({
+  ConfirmaDeleteProcesso: (props) =>
+    props.show ? (
+      <div data-testid="confirm-delete">
+        <button data-testid="btn-confirm-delete" onClick={props.onConfirmDelete}>Confirmar</button>
+        <button data-testid="btn-cancel-delete" onClick={props.onCancelDelete}>Cancelar</button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../../../../../Globais/Modal/ModalConfirm', () => ({
+  ModalConfirm: jest.fn(),
+}));
+
+jest.mock('../../../../../Globais/ToastCustom', () => ({
+  toastCustom: {
+    ToastCustomSuccess: jest.fn(),
+    ToastCustomError: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../../Globais/UI/Button', () => ({
+  EditIconButton: ({ onClick }) => (
+    <button data-testid="edit-btn" onClick={onClick} aria-label="Editar">Edit</button>
   ),
 }));
+
+jest.mock('../../../../../Globais/Mensagens/MsgImgLadoDireito', () => ({
+  MsgImgLadoDireito: ({ texto }) => <div data-testid="msg-empty">{texto}</div>,
+}));
+
+jest.mock('antd', () => ({
+  Button: ({ onClick, disabled, children }) => (
+    <button data-testid="delete-btn" onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  Tooltip: ({ children }) => <>{children}</>,
+}));
+
+jest.mock('@ant-design/icons', () => ({
+  DeleteFilled: () => <span>Delete</span>,
+}));
+
+jest.mock('primereact/datatable', () => {
+  const React = require('react');
+  return {
+    DataTable: ({ value, children }) => {
+      const cols = React.Children.toArray(children);
+      return (
+        <div data-testid="table">
+          {value &&
+            value.map((item) => (
+              <div key={item.uuid} data-testid={`row-${item.uuid}`}>
+                {cols.map((col, i) =>
+                  col.props && col.props.body ? (
+                    <div key={i}>{col.props.body(item)}</div>
+                  ) : (
+                    <span key={i}>{item[col.props && col.props.field]}</span>
+                  )
+                )}
+              </div>
+            ))}
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock('primereact/column', () => ({ Column: () => null }));
 
 jest.mock('../../../../../../services/dres/Associacoes.service');
 jest.mock('../../../../../../services/dres/ProcessosAssociacao.service');
 jest.mock('../../../../../../services/visoes.service');
-jest.mock('../../../../../../context/RecursoSelecionado', () => ({
-  useRecursoSelecionadoContext: jest.fn(),
+jest.mock('../../../../../../services/storages/RecursoSelecionado.storage.service', () => ({
+  recursoSelecionadoStorageService: {},
 }));
 
 /* eslint-disable-next-line import/first */
@@ -31,252 +108,544 @@ const mockStore = {
   replaceReducer: jest.fn(),
 };
 
+const PROCESS = {
+  uuid: 'p1',
+  numero_processo: '23076.000001/2024-01',
+  ano: '2024',
+  periodos: [{ uuid: 'per-1', referencia: '2024.1' }],
+  permite_exclusao: true,
+  tooltip_exclusao: '',
+};
+
 const globalProps = {
-  dadosDaAssociacao: { 
-    dados_da_associacao: { 
-      uuid: 'a1',
-      recursos_da_associacao: [{ uuid: 'r1', nome: 'Recurso 1' }]
-    } 
+  dadosDaAssociacao: {
+    dados_da_associacao: {
+      uuid: 'assoc-1',
+      recursos_da_associacao: [{ uuid: 'r1', nome: 'Recurso 1' }],
+    },
   },
   recurso_uuid: 'r1',
   recurso_nome: 'Recurso 1',
 };
 
-const setupMocks = () => {
+const getServices = () => {
   const { getProcessosAssociacao } = require('../../../../../../services/dres/Associacoes.service');
+  const {
+    createProcessoAssociacao,
+    deleteProcessoAssociacao,
+    getPeriodosDisponiveis,
+    updateProcessoAssociacao,
+  } = require('../../../../../../services/dres/ProcessosAssociacao.service');
   const { visoesService } = require('../../../../../../services/visoes.service');
-  const { useRecursoSelecionadoContext } = require('../../../../../../context/RecursoSelecionado');
+  const { ModalConfirm } = require('../../../../../Globais/Modal/ModalConfirm');
+  const { toastCustom } = require('../../../../../Globais/ToastCustom');
+  return { getProcessosAssociacao, createProcessoAssociacao, deleteProcessoAssociacao, getPeriodosDisponiveis, updateProcessoAssociacao, visoesService, ModalConfirm, toastCustom };
+};
 
-  getProcessosAssociacao.mockResolvedValue([
-    {
-      uuid: 'p1',
-      numero_processo: '12345',
-      ano: '2024',
-      periodos: [],
-      permite_exclusao: true,
-      tooltip_exclusao: '',
-    },
-  ]);
-
-  if (visoesService) {
-    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
-    visoesService.getPermissoes = jest.fn().mockReturnValue(true);
-  }
-
-  useRecursoSelecionadoContext.mockReturnValue({
-    recursos: [{ uuid: 'r1', nome: 'Recurso 1' }],
+const setupServices = () => {
+  const svc = getServices();
+  svc.getProcessosAssociacao.mockResolvedValue([PROCESS]);
+  svc.createProcessoAssociacao.mockResolvedValue({ status: 201 });
+  svc.deleteProcessoAssociacao.mockResolvedValue({ status: 204 });
+  svc.getPeriodosDisponiveis.mockResolvedValue([]);
+  svc.updateProcessoAssociacao.mockResolvedValue({ status: 200 });
+  svc.visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+  svc.visoesService.getPermissoes = jest.fn().mockReturnValue(true);
+  svc.ModalConfirm.mockImplementation(({ onConfirm }) => {
+    capturedOnConfirm = onConfirm;
+    return null;
   });
 };
 
-describe('ProcessosSeiPrestacaoDeContas Testes', () => {
+const renderComponent = (props = {}) =>
+  render(
+    <Provider store={mockStore}>
+      <ProcessosSeiPrestacaoDeContas {...globalProps} {...props} />
+    </Provider>
+  );
+
+const waitForTable = () => waitFor(() => expect(screen.getByTestId('table')).toBeInTheDocument());
+
+describe('ProcessosSeiPrestacaoDeContas', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    setupMocks();
+    capturedFormProps = null;
+    capturedOnConfirm = null;
+    setupServices();
   });
 
-  test('1. Renderiza sem erros', () => {
-    const { container } = render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...globalProps} />
-      </Provider>
-    );
-
-    expect(container).toBeDefined();
-  });
-
-  test('2. Exibe o título', async () => {
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...globalProps} />
-      </Provider>
-    );
-
-    const titulo = await screen.findByText('Processos SEI de prestação de contas');
-    expect(titulo).toBeInTheDocument();
-  });
-
-  test('3. Renderiza a tabela', async () => {
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...globalProps} />
-      </Provider>
-    );
-
-    const table = await screen.findByTestId('table');
-    expect(table).toBeInTheDocument();
-  });
-
-  test('4. Renderiza o formulário', () => {
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...globalProps} />
-      </Provider>
-    );
-
-    const form = screen.getByTestId('form');
-    expect(form).toBeInTheDocument();
-  });
-
-  test('5. Chama serviço ao montar', async () => {
-    const { getProcessosAssociacao } = require('../../../../../../services/dres/Associacoes.service');
-
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...globalProps} />
-      </Provider>
-    );
-
-    await waitFor(() => {
-      expect(getProcessosAssociacao).toHaveBeenCalled();
+  describe('Rendering', () => {
+    test('1. Renders title and table after loading', async () => {
+      renderComponent();
+      expect(await screen.findByText('Processos SEI de prestação de contas')).toBeInTheDocument();
+      expect(await screen.findByTestId('table')).toBeInTheDocument();
     });
-  });
 
-  test('6. Não renderiza sem UUID', () => {
-    const customProps = {
-      ...globalProps,
-      dadosDaAssociacao: { dados_da_associacao: { uuid: undefined } },
-    };
+    test('2. Shows empty state message when no processes exist', async () => {
+      const { getProcessosAssociacao } = getServices();
+      getProcessosAssociacao.mockResolvedValue([]);
+      renderComponent();
+      expect(await screen.findByTestId('msg-empty')).toBeInTheDocument();
+    });
 
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...customProps} />
-      </Provider>
-    );
-
-    const titulo = screen.queryByText('Processos SEI de prestação de contas');
-    expect(titulo).not.toBeInTheDocument();
-  });
-
-  test('7. Funciona com props válidas', () => {
-    const customProps = {
-      ...globalProps,
-      dadosDaAssociacao: {
-        dados_da_associacao: {
-          uuid: 'associacao-123',
-          recursos_da_associacao: [{ uuid: 'recurso-1', nome: 'Recurso Teste' }],
+    test('3. Renders nothing when associacao uuid is undefined', () => {
+      renderComponent({
+        dadosDaAssociacao: {
+          dados_da_associacao: { uuid: undefined, recursos_da_associacao: [] },
         },
-      },
-      recurso_uuid: 'recurso-1',
-      recurso_nome: 'Recurso Teste',
-    };
-
-    const { container } = render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...customProps} />
-      </Provider>
-    );
-
-    expect(container.children.length).toBeGreaterThan(0);
-  });
-
-  test('8. Exibe sub-aba de recurso quando usuário tem múltiplos recursos', async () => {
-    const { visoesService } = require('../../../../../../services/visoes.service');
-    const { useRecursoSelecionadoContext } = require('../../../../../../context/RecursoSelecionado');
-
-    // Mock com múltiplos recursos e feature flag ativa
-    useRecursoSelecionadoContext.mockReturnValue({
-      recursos: [
-        { uuid: 'r1', nome: 'Recurso 1' },
-        { uuid: 'r2', nome: 'Recurso 2' },
-        { uuid: 'r3', nome: 'Recurso 3' },
-      ],
+      });
+      expect(screen.queryByText('Processos SEI de prestação de contas')).not.toBeInTheDocument();
     });
 
-    visoesService.featureFlagAtiva = jest.fn((flag) => {
-      if (flag === 'premio-excelencia-processo-sei') {
-        return true;
-      }
-      return false;
-    });
-
-    const customProps = {
-      ...globalProps,
-      dadosDaAssociacao: {
-        dados_da_associacao: {
-          uuid: 'a1',
-          recursos_da_associacao: [
-            { uuid: 'r1', nome: 'Recurso 1' },
-            { uuid: 'r2', nome: 'Recurso 2' },
-            { uuid: 'r3', nome: 'Recurso 3' },
-          ],
+    test('4. Shows recurso_nome label when multiple recursos and flag is active', async () => {
+      const { visoesService } = getServices();
+      visoesService.featureFlagAtiva = jest.fn((flag) =>
+        flag === 'premio-excelencia-processo-sei' ? true : false
+      );
+      renderComponent({
+        dadosDaAssociacao: {
+          dados_da_associacao: {
+            uuid: 'assoc-1',
+            recursos_da_associacao: [{ uuid: 'r1' }, { uuid: 'r2' }],
+          },
         },
-      },
-      recurso_nome: 'Prêmio Excelência',
-    };
-
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...customProps} />
-      </Provider>
-    );
-
-    const recursoLabel = await screen.findByText('Prêmio Excelência');
-    expect(recursoLabel).toBeInTheDocument();
-
-    expect(visoesService.featureFlagAtiva).toHaveBeenCalledWith('premio-excelencia-processo-sei');
-  });
-
-  test('9. Não exibe sub-aba de recurso quando feature flag está inativa', async () => {
-    const { visoesService } = require('../../../../../../services/visoes.service');
-    const { useRecursoSelecionadoContext } = require('../../../../../../context/RecursoSelecionado');
-
-    // Mock com múltiplos recursos mas feature flag inativa
-    useRecursoSelecionadoContext.mockReturnValue({
-      recursos: [
-        { uuid: 'r1', nome: 'Recurso 1' },
-        { uuid: 'r2', nome: 'Recurso 2' },
-      ],
+        recurso_nome: 'Prêmio Excelência',
+      });
+      expect(await screen.findByText('Prêmio Excelência')).toBeInTheDocument();
     });
 
-    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(false);
+    test('5. Hides recurso_nome when only one recurso even if flag is active', async () => {
+      const { visoesService } = getServices();
+      visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+      renderComponent({ recurso_nome: 'Prêmio Excelência' });
+      await waitForTable();
+      expect(screen.queryByText('Prêmio Excelência')).not.toBeInTheDocument();
+    });
 
-    const customProps = {
-      ...globalProps,
-      dadosDaAssociacao: {
-        dados_da_associacao: {
-          uuid: 'a1',
-          recursos_da_associacao: [
-            { uuid: 'r1', nome: 'Recurso 1' },
-            { uuid: 'r2', nome: 'Recurso 2' },
-          ],
+    test('6. Hides recurso_nome when flag is inactive even with multiple recursos', async () => {
+      renderComponent({
+        dadosDaAssociacao: {
+          dados_da_associacao: {
+            uuid: 'assoc-1',
+            recursos_da_associacao: [{ uuid: 'r1' }, { uuid: 'r2' }],
+          },
         },
-      },
-      recurso_nome: 'Prêmio Excelência',
-    };
-
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...customProps} />
-      </Provider>
-    );
-
-    const recursoLabel = screen.queryByText('Prêmio Excelência');
-    expect(recursoLabel).not.toBeInTheDocument();
-  });
-
-  test('10. Não exibe sub-aba quando usuário tem apenas um recurso', async () => {
-    const { visoesService } = require('../../../../../../services/visoes.service');
-    const { useRecursoSelecionadoContext } = require('../../../../../../context/RecursoSelecionado');
-
-    // Mock com um único recurso
-    useRecursoSelecionadoContext.mockReturnValue({
-      recursos: [{ uuid: 'r1', nome: 'Recurso 1' }],
+        recurso_nome: 'Prêmio Excelência',
+      });
+      await waitForTable();
+      expect(screen.queryByText('Prêmio Excelência')).not.toBeInTheDocument();
     });
 
-    visoesService.featureFlagAtiva = jest.fn().mockReturnValue(true);
+    test('7. Renders periodos column when periodos-processo-sei flag is active', async () => {
+      const { visoesService } = getServices();
+      visoesService.featureFlagAtiva = jest.fn((flag) =>
+        flag === 'periodos-processo-sei' ? true : false
+      );
+      renderComponent();
+      expect(await screen.findByText('2024.1')).toBeInTheDocument();
+    });
 
-    const customProps = {
-      ...globalProps,
-      recurso_nome: 'Prêmio Excelência',
+    test('8. periodosTemplate renders nothing for rows with empty periodos', async () => {
+      const { getProcessosAssociacao, visoesService } = getServices();
+      getProcessosAssociacao.mockResolvedValue([{ ...PROCESS, periodos: [] }]);
+      visoesService.featureFlagAtiva = jest.fn((flag) =>
+        flag === 'periodos-processo-sei' ? true : false
+      );
+      renderComponent();
+      await waitForTable();
+      expect(screen.queryByText('2024.1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('handleAddProcessoAction', () => {
+    test('9. Opens form with empty values when clicking adicionar', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      expect(await screen.findByTestId('form')).toBeInTheDocument();
+      expect(capturedFormProps.initialValues.uuid).toBe('');
+      expect(capturedFormProps.initialValues.numero_processo).toBe('');
+      expect(capturedFormProps.initialValues.periodos).toEqual([]);
+    });
+
+    test('10. Add button is no-op when user has no permission', async () => {
+      const { visoesService } = getServices();
+      visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('handleEditProcessoAction', () => {
+    test('11. Opens form pre-filled with processo data when clicking edit', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByTestId('edit-btn'));
+      expect(await screen.findByTestId('form')).toBeInTheDocument();
+      expect(capturedFormProps.initialValues.uuid).toBe('p1');
+      expect(capturedFormProps.initialValues.numero_processo).toBe(PROCESS.numero_processo);
+      expect(capturedFormProps.initialValues.ano).toBe('2024');
+      expect(capturedFormProps.initialValues.periodos).toEqual(['per-1']);
+    });
+  });
+
+  describe('handleDeleteProcessoAction', () => {
+    test('12. Shows confirm-delete dialog when clicking delete button', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByTestId('delete-btn'));
+      expect(await screen.findByTestId('confirm-delete')).toBeInTheDocument();
+    });
+  });
+
+  describe('handleCloseProcessoForm', () => {
+    test('13. Hides form when close button is clicked', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      expect(await screen.findByTestId('form')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('form-close'));
+      expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Delete confirmation dialog', () => {
+    const openDeleteDialog = async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByTestId('delete-btn'));
+      await screen.findByTestId('confirm-delete');
     };
 
-    render(
-      <Provider store={mockStore}>
-        <ProcessosSeiPrestacaoDeContas {...customProps} />
-      </Provider>
-    );
+    test('14. Confirm delete calls deleteProcessoAssociacao and shows success toast', async () => {
+      const { deleteProcessoAssociacao, toastCustom } = getServices();
+      await openDeleteDialog();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('btn-confirm-delete'));
+      });
+      await waitFor(() => {
+        expect(deleteProcessoAssociacao).toHaveBeenCalledWith('p1');
+        expect(toastCustom.ToastCustomSuccess).toHaveBeenCalled();
+      });
+    });
 
-    const recursoLabel = screen.queryByText('Prêmio Excelência');
-    expect(recursoLabel).not.toBeInTheDocument();
+    test('15. Shows error toast when deleteProcessoAssociacao returns non-204', async () => {
+      const { deleteProcessoAssociacao, toastCustom } = getServices();
+      deleteProcessoAssociacao.mockResolvedValue({ status: 500 });
+      await openDeleteDialog();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('btn-confirm-delete'));
+      });
+      await waitFor(() => {
+        expect(toastCustom.ToastCustomError).toHaveBeenCalled();
+      });
+    });
+
+    test('16. Cancel delete closes dialog without calling deleteProcessoAssociacao', async () => {
+      const { deleteProcessoAssociacao } = getServices();
+      await openDeleteDialog();
+      fireEvent.click(screen.getByTestId('btn-cancel-delete'));
+      expect(screen.queryByTestId('confirm-delete')).not.toBeInTheDocument();
+      expect(deleteProcessoAssociacao).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubmitProcesso – create (no uuid)', () => {
+    const openAddAndSubmit = async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('form-submit'));
+      });
+    };
+
+    test('17. Create 201 shows success toast and closes form', async () => {
+      const { toastCustom } = getServices();
+      await openAddAndSubmit();
+      await waitFor(() => {
+        expect(toastCustom.ToastCustomSuccess).toHaveBeenCalled();
+        expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+      });
+    });
+
+    test('18. Create 400 with numero_processo sets custom error message', async () => {
+      const { createProcessoAssociacao } = getServices();
+      createProcessoAssociacao.mockResolvedValue({
+        status: 400,
+        data: { numero_processo: ['Processo já cadastrado'] },
+      });
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('form-submit'));
+      });
+      await waitFor(() => {
+        expect(capturedFormProps.customNumeroProcessoError).toBe('Processo já cadastrado');
+      });
+    });
+
+    test('19. Create 400 without numero_processo closes form', async () => {
+      const { createProcessoAssociacao } = getServices();
+      createProcessoAssociacao.mockResolvedValue({ status: 400, data: {} });
+      await openAddAndSubmit();
+      await waitFor(() => {
+        expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+      });
+    });
+
+    test('20. Create exception closes form', async () => {
+      const { createProcessoAssociacao } = getServices();
+      createProcessoAssociacao.mockRejectedValue(new Error('Network error'));
+      await openAddAndSubmit();
+      await waitFor(() => {
+        expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+      });
+    });
+
+    test('21. With periodos-processo-sei flag active, payload includes periodos', async () => {
+      const { visoesService, createProcessoAssociacao } = getServices();
+      visoesService.featureFlagAtiva = jest.fn((flag) =>
+        flag === 'periodos-processo-sei' ? true : false
+      );
+      await openAddAndSubmit();
+      await waitFor(() => {
+        expect(createProcessoAssociacao).toHaveBeenCalledWith(
+          expect.objectContaining({ periodos: [] })
+        );
+      });
+    });
+  });
+
+  describe('handleSubmitProcesso – update (with uuid)', () => {
+    const openEditAndTriggerConfirm = async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByTestId('edit-btn'));
+      await screen.findByTestId('form');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('form-submit'));
+      });
+    };
+
+    test('22. With uuid, calls ModalConfirm with correct title', async () => {
+      const { ModalConfirm } = getServices();
+      await openEditAndTriggerConfirm();
+      await waitFor(() => {
+        expect(ModalConfirm).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Atenção!', confirmText: 'Confirmar' })
+        );
+      });
+    });
+
+    test('23. Update 200 shows success toast after confirming modal', async () => {
+      const { toastCustom } = getServices();
+      await openEditAndTriggerConfirm();
+      await waitFor(() => expect(capturedOnConfirm).toBeTruthy());
+      await act(async () => { capturedOnConfirm(); });
+      await waitFor(() => {
+        expect(toastCustom.ToastCustomSuccess).toHaveBeenCalled();
+      });
+    });
+
+    test('24. Update 400 with numero_processo sets custom error after confirming', async () => {
+      const { updateProcessoAssociacao } = getServices();
+      updateProcessoAssociacao.mockResolvedValue({
+        status: 400,
+        data: { numero_processo: ['Número inválido'] },
+      });
+      await openEditAndTriggerConfirm();
+      await waitFor(() => expect(capturedOnConfirm).toBeTruthy());
+      await act(async () => { capturedOnConfirm(); });
+      await waitFor(() => {
+        expect(capturedFormProps.customNumeroProcessoError).toBe('Número inválido');
+      });
+    });
+
+    test('25. Update 400 without numero_processo closes form', async () => {
+      const { updateProcessoAssociacao } = getServices();
+      updateProcessoAssociacao.mockResolvedValue({ status: 400, data: {} });
+      await openEditAndTriggerConfirm();
+      await waitFor(() => expect(capturedOnConfirm).toBeTruthy());
+      await act(async () => { capturedOnConfirm(); });
+      await waitFor(() => {
+        expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+      });
+    });
+
+    test('26. Update exception closes form', async () => {
+      const { updateProcessoAssociacao } = getServices();
+      updateProcessoAssociacao.mockRejectedValue(new Error('Network error'));
+      await openEditAndTriggerConfirm();
+      await waitFor(() => expect(capturedOnConfirm).toBeTruthy());
+      await act(async () => { capturedOnConfirm(); });
+      await waitFor(() => {
+        expect(screen.queryByTestId('form')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleChangesInProcessoForm', () => {
+    test('27. Changing "ano" field resets periodos to empty array', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      fireEvent.click(screen.getByTestId('form-change-periodos'));
+      await waitFor(() => expect(capturedFormProps.initialValues.periodos).toEqual(['p1', 'p2']));
+      fireEvent.click(screen.getByTestId('form-change-ano'));
+      await waitFor(() => {
+        expect(capturedFormProps.initialValues.ano).toBe('2024');
+        expect(capturedFormProps.initialValues.periodos).toEqual([]);
+      });
+    });
+
+    test('28. Changing a non-ano field updates only that field', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      fireEvent.click(screen.getByTestId('form-change-numero'));
+      await waitFor(() => {
+        expect(capturedFormProps.initialValues.numero_processo).toBe('99999');
+        expect(capturedFormProps.initialValues.periodos).toEqual([]);
+      });
+    });
+  });
+
+  describe('handleChangeSelectPeriodos', () => {
+    test('29. Updates periodos state', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      fireEvent.click(screen.getByTestId('form-change-periodos'));
+      await waitFor(() => {
+        expect(capturedFormProps.initialValues.periodos).toEqual(['p1', 'p2']);
+      });
+    });
+  });
+
+  describe('carregaPeriodosDisponiveis', () => {
+    test('30. Fetches periodos when ano has 4+ chars', async () => {
+      const { getPeriodosDisponiveis } = getServices();
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('form-change-ano'));
+      });
+      await waitFor(() => {
+        expect(getPeriodosDisponiveis).toHaveBeenCalledWith('assoc-1', '2024', '', 'r1');
+      });
+    });
+
+    test('31. Auto-populates periodos from periodosDisponiveis when periodos is empty', async () => {
+      const { getPeriodosDisponiveis } = getServices();
+      getPeriodosDisponiveis.mockResolvedValue([
+        { uuid: 'pd-1', referencia: '2024.1' },
+        { uuid: 'pd-2', referencia: '2024.2' },
+      ]);
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('form-change-ano'));
+      });
+      await waitFor(() => {
+        expect(capturedFormProps.initialValues.periodos).toEqual(['pd-1', 'pd-2']);
+      });
+    });
+
+    test('32. Does NOT auto-populate periodos when they are already set (edit mode)', async () => {
+      const { getPeriodosDisponiveis } = getServices();
+      getPeriodosDisponiveis.mockResolvedValue([{ uuid: 'pd-1', referencia: '2024.1' }]);
+      renderComponent();
+      await waitForTable();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('edit-btn'));
+      });
+      await screen.findByTestId('form');
+      await waitFor(() => expect(getPeriodosDisponiveis).toHaveBeenCalled());
+      expect(capturedFormProps.initialValues.periodos).toEqual(['per-1']);
+    });
+  });
+
+  describe('tableActionsTemplate', () => {
+    test('33. Delete button is disabled when user has no permission', async () => {
+      const { visoesService } = getServices();
+      visoesService.getPermissoes = jest.fn().mockReturnValue(false);
+      renderComponent();
+      await waitForTable();
+      expect(screen.getByTestId('delete-btn')).toBeDisabled();
+    });
+
+    test('34. Delete button is disabled when processo does not allow deletion', async () => {
+      const { getProcessosAssociacao } = getServices();
+      getProcessosAssociacao.mockResolvedValue([{ ...PROCESS, permite_exclusao: false }]);
+      renderComponent();
+      await waitForTable();
+      expect(screen.getByTestId('delete-btn')).toBeDisabled();
+    });
+
+    test('35. Edit and delete buttons are enabled when permitted', async () => {
+      renderComponent();
+      await waitForTable();
+      expect(screen.getByTestId('edit-btn')).not.toBeDisabled();
+      expect(screen.getByTestId('delete-btn')).not.toBeDisabled();
+    });
+  });
+
+  describe('Service calls', () => {
+    test('36. Calls getProcessosAssociacao with correct args on mount', async () => {
+      const { getProcessosAssociacao } = getServices();
+      renderComponent();
+      await waitFor(() => {
+        expect(getProcessosAssociacao).toHaveBeenCalledWith('assoc-1', 'r1');
+      });
+    });
+
+    test('37. Re-fetches processes when recurso_uuid prop changes', async () => {
+      const { getProcessosAssociacao } = getServices();
+      const { rerender } = renderComponent();
+      await waitForTable();
+      rerender(
+        <Provider store={mockStore}>
+          <ProcessosSeiPrestacaoDeContas {...globalProps} recurso_uuid="r2" />
+        </Provider>
+      );
+      await waitFor(() => {
+        expect(getProcessosAssociacao).toHaveBeenCalledWith('assoc-1', 'r2');
+      });
+    });
+
+    test('38. deleteProcesso catch block handles thrown errors gracefully', async () => {
+      const { deleteProcessoAssociacao } = getServices();
+      deleteProcessoAssociacao.mockRejectedValue(new Error('Network error'));
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByTestId('delete-btn'));
+      await screen.findByTestId('confirm-delete');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('btn-confirm-delete'));
+      });
+      await waitFor(() => expect(screen.getByTestId('table')).toBeInTheDocument());
+    });
+
+    test('39. validateProcessoForm resolves to an empty object', async () => {
+      renderComponent();
+      await waitForTable();
+      fireEvent.click(screen.getByText('adicionar'));
+      await screen.findByTestId('form');
+      const result = await capturedFormProps.validateForm();
+      expect(result).toEqual({});
+    });
   });
 });

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/SituacaoFinanceiraUnidadeEducacional/__tests__/index.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/SituacaoFinanceiraUnidadeEducacional/__tests__/index.test.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SituacaoFinanceiraUnidadeEducacional } from "../index";
+
+jest.mock("../../../../../Globais/Dashborard", () => ({
+  Dashboard: () => <div data-testid="dashboard" />,
+}));
+
+jest.mock("react-router-dom", () => ({
+  Navigate: () => null,
+}));
+
+jest.mock("../../../../../../services/auth.service", () => ({
+  DADOS_DA_ASSOCIACAO: "dados_da_associacao",
+}));
+
+const mockDados = {
+  dados_da_associacao: {
+    nome: "Associação Teste",
+  },
+};
+
+describe("SituacaoFinanceiraUnidadeEducacional", () => {
+  it("deve renderizar o título da seção", () => {
+    render(<SituacaoFinanceiraUnidadeEducacional dadosDaAssociacao={mockDados} />);
+
+    expect(
+      screen.getByText("Situação financeira da associação")
+    ).toBeInTheDocument();
+  });
+
+  it("deve renderizar o componente Dashboard", () => {
+    render(<SituacaoFinanceiraUnidadeEducacional dadosDaAssociacao={mockDados} />);
+
+    expect(screen.getByTestId("dashboard")).toBeInTheDocument();
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/SituacaoPatrimonial/__tests__/index.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/SituacaoPatrimonial/__tests__/index.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SituacaoPatrimonialUnidadeEducacional } from "../index";
+
+jest.mock("../../../../../Globais/Dashborard", () => ({
+  Dashboard: () => <div data-testid="dashboard" />,
+}));
+
+jest.mock("react-router-dom", () => ({
+  Navigate: () => null,
+}));
+
+jest.mock("../../../../../../services/auth.service", () => ({
+  DADOS_DA_ASSOCIACAO: "dados_da_associacao",
+}));
+
+jest.mock("../../../../../escolas/SituacaoPatrimonial/ListaBemProduzido", () => ({
+  ListaBemProduzido: (props) => (
+    <div data-testid="lista-bem-produzido">{String(props.visao_dre)}</div>
+  ),
+}));
+
+describe("SituacaoPatrimonialUnidadeEducacional", () => {
+  it("deve renderizar o título da seção", () => {
+    render(<SituacaoPatrimonialUnidadeEducacional />);
+
+    expect(
+      screen.getByText("Situação Patrimonial da Associação")
+    ).toBeInTheDocument();
+  });
+
+  it("deve renderizar ListaBemProduzido com visao_dre=true", () => {
+    render(<SituacaoPatrimonialUnidadeEducacional />);
+
+    const lista = screen.getByTestId("lista-bem-produzido");
+    expect(lista).toBeInTheDocument();
+    expect(lista).toHaveTextContent("true");
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/__tests__/TopoComBotoes.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/__tests__/TopoComBotoes.test.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TopoComBotoes } from "../TopoComBotoes";
+
+const mockNavigate = jest.fn();
+const mockUseParams = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => mockUseParams(),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockDados = {
+  dados_da_associacao: {
+    nome: "Associação Teste",
+  },
+};
+
+describe("TopoComBotoes", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockUseParams.mockReset();
+  });
+
+  it("deve exibir o nome da associação no título", () => {
+    mockUseParams.mockReturnValue({});
+    render(<TopoComBotoes dadosDaAssociacao={mockDados} />);
+
+    expect(screen.getByText("Associação Teste")).toBeInTheDocument();
+  });
+
+  it("deve navegar para /dre-associacoes quando origem é undefined", () => {
+    mockUseParams.mockReturnValue({});
+    render(<TopoComBotoes dadosDaAssociacao={mockDados} />);
+
+    fireEvent.click(screen.getByText("Voltar"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/dre-associacoes");
+  });
+
+  it("deve navegar para /dre-relatorio-consolidado-dados-das-ues/:periodo/:conta quando origem é dre-relatorio-consolidado com periodo e conta", () => {
+    mockUseParams.mockReturnValue({
+      origem: "dre-relatorio-consolidado",
+      periodo_uuid: "p1",
+      conta_uuid: "c1",
+    });
+    render(<TopoComBotoes dadosDaAssociacao={mockDados} />);
+
+    fireEvent.click(screen.getByText("Voltar"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/dre-relatorio-consolidado-dados-das-ues/p1/c1/"
+    );
+  });
+
+  it("deve navegar com path undefined quando origem é diferente e sem periodo/conta", () => {
+    mockUseParams.mockReturnValue({
+      origem: "outra-origem",
+    });
+    render(<TopoComBotoes dadosDaAssociacao={mockDados} />);
+
+    fireEvent.click(screen.getByText("Voltar"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/componentes/dres/Associacoes/DadosDasAssociacoes/__tests__/index.test.js
+++ b/src/componentes/dres/Associacoes/DadosDasAssociacoes/__tests__/index.test.js
@@ -1,0 +1,361 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { DetalhesDaAssociacao } from "../index";
+import { DADOS_DA_ASSOCIACAO } from "../../../../../services/auth.service";
+import { visoesService } from "../../../../../services/visoes.service";
+
+// ---- Mocks de react-router-dom ----
+let mockUseParamsReturn = {};
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => mockUseParamsReturn,
+    Navigate: () => <div data-testid="navigate-redirect" />,
+}));
+
+// ---- Mock de visoes.service ----
+jest.mock("../../../../../services/visoes.service", () => ({
+    visoesService: {
+        getPermissoes: jest.fn(),
+        featureFlagAtiva: jest.fn(),
+    },
+}));
+
+// ---- Mocks de componentes filhos ----
+jest.mock("../TopoComBotoes", () => ({
+    TopoComBotoes: ({ dadosDaAssociacao }) => (
+        <div data-testid="topo-com-botoes">
+            {dadosDaAssociacao?.dados_da_associacao?.nome}
+        </div>
+    ),
+}));
+
+jest.mock("../DadosDaAssociacao/InfosAssociacao", () => ({
+    InfosAssociacao: () => <div data-testid="infos-associacao">InfosAssociacao</div>,
+}));
+
+jest.mock("../DadosDaUnidadeEducacional/InfosUnidadeEducacional", () => ({
+    InfosUnidadeEducacional: () => (
+        <div data-testid="infos-unidade-educacional">InfosUnidadeEducacional</div>
+    ),
+}));
+
+jest.mock("../DadosDasContas/InfosContas", () => ({
+    InfosContas: () => <div data-testid="infos-contas">InfosContas</div>,
+}));
+
+jest.mock("../ProcessosSei/ProcessoSeiRegularidade", () => ({
+    ProcessoSeiRegularidade: () => (
+        <div data-testid="processo-sei-regularidade">ProcessoSeiRegularidade</div>
+    ),
+}));
+
+jest.mock("../ProcessosSei/ProcessosSeiPrestacaoDeContas", () => ({
+    ProcessosSeiPrestacaoDeContas: ({ recurso_uuid, recurso_nome }) => (
+        <div data-testid="processos-sei-prestacao-de-contas">
+            ProcessosSeiPrestacaoDeContas
+            {recurso_uuid ? `-${recurso_uuid}` : ""}
+            {recurso_nome ? `-${recurso_nome}` : ""}
+        </div>
+    ),
+}));
+
+jest.mock("../SituacaoFinanceiraUnidadeEducacional", () => ({
+    SituacaoFinanceiraUnidadeEducacional: () => (
+        <div data-testid="situacao-financeira">SituacaoFinanceiraUnidadeEducacional</div>
+    ),
+}));
+
+jest.mock("../SituacaoPatrimonial", () => ({
+    SituacaoPatrimonialUnidadeEducacional: ({ visao_dre }) => (
+        <div data-testid="situacao-patrimonial">
+            SituacaoPatrimonialUnidadeEducacional-{String(visao_dre)}
+        </div>
+    ),
+}));
+
+const TODAS_PERMISSOES_TRUE = {
+    access_dados_unidade_dre: true,
+    access_processo_sei: true,
+    access_situacao_financeira_dre: true,
+    access_situacao_patrimonial_dre: true,
+};
+
+const setupGetPermissoes = (permissoesMap) => {
+    visoesService.getPermissoes.mockImplementation((permissoesSolicitadas) => {
+        const chave = permissoesSolicitadas[0];
+        return !!permissoesMap[chave];
+    });
+};
+
+const criarRecurso = (uuid, nome, nome_exibicao, legado = false) => ({
+    uuid,
+    nome,
+    nome_exibicao,
+    legado,
+});
+
+const popularLocalStorage = (recursos_da_associacao, extras = {}) => {
+    const dados = {
+        dados_da_associacao: {
+            nome: "Associação Teste",
+            uuid: "uuid-associacao-1",
+            recursos_da_associacao,
+            ...extras,
+        },
+    };
+    localStorage.setItem(DADOS_DA_ASSOCIACAO, JSON.stringify(dados));
+};
+
+const setPathname = (pathname) => {
+    window.history.pushState({}, "", pathname);
+};
+
+describe("DetalhesDaAssociacao", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockUseParamsReturn = {};
+        setPathname("/dre-associacoes");
+        visoesService.getPermissoes.mockReset();
+        visoesService.featureFlagAtiva.mockReset();
+        visoesService.featureFlagAtiva.mockReturnValue(false);
+        setupGetPermissoes(TODAS_PERMISSOES_TRUE);
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    describe("comportamento existente quando localStorage está vazio", () => {
+        it("lança erro ao montar pois dadosDaAssociacao é null (bug pré-existente, ramo Navigate é código morto)", () => {
+            // Suprime o log de erro do React sobre o erro não capturado
+            const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+            expect(() => render(<DetalhesDaAssociacao />)).toThrow();
+            consoleErrorSpy.mockRestore();
+        });
+    });
+
+    describe("com permissões todas true e único recurso", () => {
+        beforeEach(() => {
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+        });
+
+        it("renderiza todas as 6 abas/links", () => {
+            render(<DetalhesDaAssociacao />);
+            expect(screen.getByText("Dados da unidade")).toBeInTheDocument();
+            expect(screen.getByText("Dados da associação")).toBeInTheDocument();
+            expect(screen.getByText("Contas da associação")).toBeInTheDocument();
+            expect(screen.getByText("Processos SEI")).toBeInTheDocument();
+            expect(screen.getByText("Situação Financeira")).toBeInTheDocument();
+            expect(screen.getByText("Situação Patrimonial")).toBeInTheDocument();
+        });
+
+        it("renderiza o TopoComBotoes com os dados da associação", () => {
+            render(<DetalhesDaAssociacao />);
+            expect(screen.getByTestId("topo-com-botoes")).toHaveTextContent("Associação Teste");
+        });
+
+        it("a primeira aba (dados_unidade) fica ativa por padrão e mostra InfosUnidadeEducacional", () => {
+            render(<DetalhesDaAssociacao />);
+            const abaDadosUnidade = screen.getByText("Dados da unidade");
+            expect(abaDadosUnidade).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("infos-unidade-educacional")).toBeInTheDocument();
+        });
+
+        it("clicar na aba dados_associacao ativa o conteúdo correspondente", () => {
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Dados da associação"));
+            expect(screen.getByText("Dados da associação")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("infos-associacao")).toBeInTheDocument();
+        });
+
+        it("clicar na aba contas_associacao ativa o conteúdo correspondente", () => {
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Contas da associação"));
+            expect(screen.getByText("Contas da associação")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("infos-contas")).toBeInTheDocument();
+        });
+
+        it("clicar na aba processos_sei ativa o conteúdo e mostra ProcessoSeiRegularidade + ProcessosSeiPrestacaoDeContas sem sub-abas", () => {
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Processos SEI"));
+            expect(screen.getByText("Processos SEI")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("processo-sei-regularidade")).toBeInTheDocument();
+            expect(screen.getByTestId("processos-sei-prestacao-de-contas")).toBeInTheDocument();
+        });
+
+        it("clicar na aba situacao_financeira ativa o conteúdo correspondente", () => {
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Situação Financeira"));
+            expect(screen.getByText("Situação Financeira")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("situacao-financeira")).toBeInTheDocument();
+        });
+
+        it("clicar na aba situacao_patrimonial ativa o conteúdo correspondente", () => {
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Situação Patrimonial"));
+            expect(screen.getByText("Situação Patrimonial")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("situacao-patrimonial")).toHaveTextContent("true");
+        });
+
+        it("clicar duas vezes na mesma aba desativa e reativa (toggle)", () => {
+            render(<DetalhesDaAssociacao />);
+            const abaContas = screen.getByText("Contas da associação");
+            fireEvent.click(abaContas);
+            expect(abaContas).toHaveClass("btn-escolhe-aba-active");
+            fireEvent.click(abaContas);
+            expect(abaContas).not.toHaveClass("btn-escolhe-aba-active");
+        });
+    });
+
+    describe("com algumas permissões false", () => {
+        it("oculta abas sem permissão e setPrimeiroActive pula para a primeira permitida (contas_associacao)", () => {
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+            setupGetPermissoes({
+                access_dados_unidade_dre: true,
+                access_processo_sei: false,
+                access_situacao_financeira_dre: false,
+                access_situacao_patrimonial_dre: false,
+            });
+
+            render(<DetalhesDaAssociacao />);
+
+            // dados_unidade, dados_associacao e contas_associacao usam a mesma permissão (true)
+            expect(screen.getByText("Dados da unidade")).toBeInTheDocument();
+            expect(screen.getByText("Dados da associação")).toBeInTheDocument();
+            expect(screen.getByText("Contas da associação")).toBeInTheDocument();
+            expect(screen.queryByText("Processos SEI")).not.toBeInTheDocument();
+            expect(screen.queryByText("Situação Financeira")).not.toBeInTheDocument();
+            expect(screen.queryByText("Situação Patrimonial")).not.toBeInTheDocument();
+
+            // Primeira aba (dados_unidade) é a primeira na lista e tem permissão, deve estar ativa
+            expect(screen.getByText("Dados da unidade")).toHaveClass("btn-escolhe-aba-active");
+        });
+
+        it("quando dados_unidade_dre é false, a primeira aba ativa é processos_sei (próxima com permissão)", () => {
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+            setupGetPermissoes({
+                access_dados_unidade_dre: false,
+                access_processo_sei: true,
+                access_situacao_financeira_dre: true,
+                access_situacao_patrimonial_dre: true,
+            });
+
+            render(<DetalhesDaAssociacao />);
+
+            expect(screen.queryByText("Dados da unidade")).not.toBeInTheDocument();
+            expect(screen.queryByText("Dados da associação")).not.toBeInTheDocument();
+            expect(screen.queryByText("Contas da associação")).not.toBeInTheDocument();
+            expect(screen.getByText("Processos SEI")).toBeInTheDocument();
+            expect(screen.getByText("Processos SEI")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("processo-sei-regularidade")).toBeInTheDocument();
+        });
+
+        it("quando nenhuma permissão é true, nenhuma aba é renderizada", () => {
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+            setupGetPermissoes({});
+
+            render(<DetalhesDaAssociacao />);
+
+            expect(screen.queryByText("Dados da unidade")).not.toBeInTheDocument();
+            expect(screen.queryByText("Dados da associação")).not.toBeInTheDocument();
+            expect(screen.queryByText("Contas da associação")).not.toBeInTheDocument();
+            expect(screen.queryByText("Processos SEI")).not.toBeInTheDocument();
+            expect(screen.queryByText("Situação Financeira")).not.toBeInTheDocument();
+            expect(screen.queryByText("Situação Patrimonial")).not.toBeInTheDocument();
+        });
+    });
+
+    describe("origem via useParams = 'situacao-patrimonial'", () => {
+        it("inicia com a aba situacao_patrimonial ativa quando há permissão", () => {
+            mockUseParamsReturn = { origem: "situacao-patrimonial" };
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+
+            render(<DetalhesDaAssociacao />);
+
+            expect(screen.getByText("Situação Patrimonial")).toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Dados da unidade")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByTestId("situacao-patrimonial")).toBeInTheDocument();
+        });
+    });
+
+    describe("acesso via dre-relatorio-consolidado", () => {
+        it("nenhuma aba inicia ativa quando pathname contém 'dre-relatorio-consolidado'", () => {
+            setPathname("/dre-relatorio-consolidado/123");
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1")]);
+
+            render(<DetalhesDaAssociacao />);
+
+            expect(screen.getByText("Dados da unidade")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Dados da associação")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Contas da associação")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Processos SEI")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Situação Financeira")).not.toHaveClass("btn-escolhe-aba-active");
+            expect(screen.getByText("Situação Patrimonial")).not.toHaveClass("btn-escolhe-aba-active");
+        });
+    });
+
+    describe("múltiplos recursos + feature flag premio-excelencia-processo-sei", () => {
+        it("com feature flag true e múltiplos recursos, mostra sub-abas ordenadas (legado primeiro, depois alfabético) e clicar nelas as ativa mantendo processos_sei ativo", () => {
+            visoesService.featureFlagAtiva.mockImplementation(
+                (flag) => flag === "premio-excelencia-processo-sei"
+            );
+            popularLocalStorage([
+                criarRecurso("r-zeta", "zeta", "Zeta Recurso", false),
+                criarRecurso("r-legado", "legado", "Legado Recurso", true),
+                criarRecurso("r-alpha", "alpha", "Alpha Recurso", false),
+            ]);
+
+            render(<DetalhesDaAssociacao />);
+
+            fireEvent.click(screen.getByText("Processos SEI"));
+
+            // Ordem esperada: legado primeiro, depois alfabético por nome_exibicao (Alpha, Zeta)
+            const subAbasContainer = screen.getByText("Legado Recurso").closest("div.nav-tabs");
+            const linksTexts = within(subAbasContainer)
+                .getAllByRole("tab")
+                .map((el) => el.textContent);
+            expect(linksTexts).toEqual(["Legado Recurso", "Alpha Recurso", "Zeta Recurso"]);
+
+            // Ao clicar em processos_sei com >1 recurso, a primeira sub-aba (legado) já deve estar ativa
+            expect(screen.getByText("Legado Recurso")).toHaveClass("btn-escolhe-aba-active");
+
+            // Clicar em outra sub-aba (Alpha) a ativa
+            fireEvent.click(screen.getByText("Alpha Recurso"));
+            expect(screen.getByText("Alpha Recurso")).toHaveClass("btn-escolhe-aba-active");
+            // processos_sei continua ativo
+            expect(screen.getByText("Processos SEI")).toHaveClass("btn-escolhe-aba-active");
+
+            // Existem 3 instâncias do ProcessosSeiPrestacaoDeContas, uma por recurso
+            const instancias = screen.getAllByTestId("processos-sei-prestacao-de-contas");
+            expect(instancias).toHaveLength(3);
+        });
+
+        it("com feature flag false (mesmo com múltiplos recursos), sub-abas não aparecem", () => {
+            visoesService.featureFlagAtiva.mockReturnValue(false);
+            popularLocalStorage([
+                criarRecurso("r-zeta", "zeta", "Zeta Recurso", false),
+                criarRecurso("r-alpha", "alpha", "Alpha Recurso", false),
+            ]);
+
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Processos SEI"));
+
+            expect(screen.queryByText("Zeta Recurso")).not.toBeInTheDocument();
+            expect(screen.queryByText("Alpha Recurso")).not.toBeInTheDocument();
+            expect(screen.getAllByTestId("processos-sei-prestacao-de-contas")).toHaveLength(1);
+        });
+
+        it("com feature flag true mas único recurso, sub-abas não aparecem", () => {
+            visoesService.featureFlagAtiva.mockImplementation(
+                (flag) => flag === "premio-excelencia-processo-sei"
+            );
+            popularLocalStorage([criarRecurso("r1", "recurso-1", "Recurso 1", false)]);
+
+            render(<DetalhesDaAssociacao />);
+            fireEvent.click(screen.getByText("Processos SEI"));
+
+            expect(screen.queryByText("Recurso 1")).not.toBeInTheDocument();
+            expect(screen.getAllByTestId("processos-sei-prestacao-de-contas")).toHaveLength(1);
+        });
+    });
+});

--- a/src/componentes/dres/Associacoes/__tests__/FiltrosAssociacoes.test.js
+++ b/src/componentes/dres/Associacoes/__tests__/FiltrosAssociacoes.test.js
@@ -1,0 +1,164 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FiltrosAssociacoes } from "../FiltrosAssociacoes";
+
+describe("FiltrosAssociacoes", () => {
+    const tabelaAssociacoesPadrao = {
+        tipos_unidade: [
+            { id: "EMEI", nome: "EMEI" },
+            { id: "EMEF", nome: "EMEF" },
+            { id: "ADM", nome: "ADM" },
+            { id: "DRE", nome: "DRE" },
+            { id: "IFSP", nome: "IFSP" },
+            { id: "CMCT", nome: "CMCT" },
+        ],
+        filtro_informacoes: [
+            { id: "status1", nome: "Status 1" },
+            { id: "status2", nome: "Status 2" },
+        ],
+    };
+
+    const stateFiltrosPadrao = {
+        unidade_escolar_ou_associacao: "",
+        tipo_de_unidade: "",
+        filtro_status: [],
+    };
+
+    let handleChangeFiltrosAssociacao;
+    let handleSubmitFiltrosAssociacao;
+    let limpaFiltros;
+    let handleOnChangeMultipleSelectStatus;
+
+    beforeEach(() => {
+        handleChangeFiltrosAssociacao = jest.fn();
+        handleSubmitFiltrosAssociacao = jest.fn((e) => e && e.preventDefault && e.preventDefault());
+        limpaFiltros = jest.fn();
+        handleOnChangeMultipleSelectStatus = jest.fn();
+    });
+
+    const renderComponent = (props = {}) => {
+        return render(
+            <FiltrosAssociacoes
+                tabelaAssociacoes={tabelaAssociacoesPadrao}
+                stateFiltros={stateFiltrosPadrao}
+                handleChangeFiltrosAssociacao={handleChangeFiltrosAssociacao}
+                handleSubmitFiltrosAssociacao={handleSubmitFiltrosAssociacao}
+                limpaFiltros={limpaFiltros}
+                handleOnChangeMultipleSelectStatus={handleOnChangeMultipleSelectStatus}
+                {...props}
+            />
+        );
+    };
+
+    it("renderiza o input de unidade escolar ou associação", () => {
+        renderComponent();
+        expect(
+            screen.getByPlaceholderText("Escreva o termo que deseja filtrar")
+        ).toBeInTheDocument();
+    });
+
+    it("chama handleChangeFiltrosAssociacao ao digitar no input de unidade", () => {
+        renderComponent();
+        const input = screen.getByPlaceholderText(
+            "Escreva o termo que deseja filtrar"
+        );
+        fireEvent.change(input, { target: { value: "Escola Teste" } });
+        expect(handleChangeFiltrosAssociacao).toHaveBeenCalledWith(
+            "unidade_escolar_ou_associacao",
+            "Escola Teste"
+        );
+    });
+
+    it("popula o select de tipo de unidade excluindo ADM, DRE, IFSP e CMCT", () => {
+        renderComponent();
+        const select = document.getElementById("tipo_de_unidade");
+        expect(select).toBeInTheDocument();
+
+        expect(screen.getByText("EMEI")).toBeInTheDocument();
+        expect(screen.getByText("EMEF")).toBeInTheDocument();
+
+        expect(screen.queryByText("ADM")).not.toBeInTheDocument();
+        expect(screen.queryByText("DRE")).not.toBeInTheDocument();
+        expect(screen.queryByText("IFSP")).not.toBeInTheDocument();
+        expect(screen.queryByText("CMCT")).not.toBeInTheDocument();
+
+        // Opção default + 2 opções válidas
+        expect(select.querySelectorAll("option")).toHaveLength(3);
+    });
+
+    it("chama handleChangeFiltrosAssociacao ao selecionar tipo de unidade", () => {
+        renderComponent();
+        const select = document.getElementById("tipo_de_unidade");
+        fireEvent.change(select, { target: { value: "EMEI", name: "tipo_de_unidade" } });
+        expect(handleChangeFiltrosAssociacao).toHaveBeenCalledWith(
+            "tipo_de_unidade",
+            "EMEI"
+        );
+    });
+
+    it("renderiza o multiselect de status com as opções de filtro_informacoes", () => {
+        renderComponent();
+        expect(screen.getByText("Selecione as informações")).toBeInTheDocument();
+    });
+
+    it("chama handleOnChangeMultipleSelectStatus ao alterar o multiselect", () => {
+        renderComponent();
+        // O Select do antd renderiza um combobox - localizamos pelo placeholder
+        const selectMultiplo = screen.getByText("Selecione as informações");
+        fireEvent.mouseDown(selectMultiplo);
+        // Abre opções
+        const opcao = screen.queryAllByText("Status 1");
+        if (opcao.length > 0) {
+            fireEvent.click(opcao[opcao.length - 1]);
+            expect(handleOnChangeMultipleSelectStatus).toHaveBeenCalled();
+        } else {
+            // Em ambientes onde antd não renderiza dropdown completo, garante que ao menos existe
+            expect(selectMultiplo).toBeInTheDocument();
+        }
+    });
+
+    it("chama limpaFiltros ao clicar em Cancelar", () => {
+        renderComponent();
+        fireEvent.click(screen.getByText("Cancelar"));
+        expect(limpaFiltros).toHaveBeenCalledTimes(1);
+    });
+
+    it("chama handleSubmitFiltrosAssociacao ao submeter o formulário", () => {
+        renderComponent();
+        fireEvent.click(screen.getByText("Filtrar"));
+        expect(handleSubmitFiltrosAssociacao).toHaveBeenCalledTimes(1);
+    });
+
+    it("não quebra quando tabelaAssociacoes é um objeto vazio", () => {
+        renderComponent({ tabelaAssociacoes: {} });
+
+        const select = document.getElementById("tipo_de_unidade");
+        expect(select).toBeInTheDocument();
+        expect(select.querySelectorAll("option")).toHaveLength(1);
+
+        expect(screen.getByText("Selecione as informações")).toBeInTheDocument();
+    });
+
+    it("não quebra quando tipos_unidade e filtro_informacoes são listas vazias", () => {
+        renderComponent({
+            tabelaAssociacoes: { tipos_unidade: [], filtro_informacoes: [] },
+        });
+        const select = document.getElementById("tipo_de_unidade");
+        expect(select.querySelectorAll("option")).toHaveLength(1);
+    });
+
+    it("exibe o valor atual de stateFiltros nos campos", () => {
+        renderComponent({
+            stateFiltros: {
+                unidade_escolar_ou_associacao: "Termo Atual",
+                tipo_de_unidade: "EMEI",
+                filtro_status: [],
+            },
+        });
+        expect(
+            screen.getByPlaceholderText("Escreva o termo que deseja filtrar")
+        ).toHaveValue("Termo Atual");
+        expect(document.getElementById("tipo_de_unidade")).toHaveValue("EMEI");
+    });
+});

--- a/src/componentes/dres/Associacoes/__tests__/TabelaAssociacoes.test.js
+++ b/src/componentes/dres/Associacoes/__tests__/TabelaAssociacoes.test.js
@@ -1,0 +1,138 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TabelaAssociacoes } from "../TabelaAssociacoes";
+
+jest.mock("primereact/datatable", () => ({
+    DataTable: ({ value, children, paginator, rows }) => {
+        const colunas = Array.isArray(children) ? children : [children];
+        return (
+            <div
+                data-testid="datatable"
+                data-paginator={String(!!paginator)}
+                data-rows={rows}
+            >
+                <table>
+                    <tbody>
+                        {value?.map((row, index) => (
+                            <tr key={index} data-testid="datatable-row">
+                                {colunas.map((col, i) => (
+                                    <td key={i}>
+                                        {col.props.body
+                                            ? col.props.body(row)
+                                            : row[col.props.field]}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        );
+    },
+}));
+
+jest.mock("primereact/column", () => ({
+    Column: (props) => props,
+}));
+
+jest.mock("../../../Globais/TableTags", () => ({
+    TableTags: () => <div data-testid="table-tags" />,
+}));
+
+let capturedLegendaProps = null;
+jest.mock("../../../Globais/ModalLegendaInformacao/LegendaInformacao", () => ({
+    LegendaInformacao: (props) => {
+        capturedLegendaProps = props;
+        return <div data-testid="legenda-informacao" />;
+    },
+}));
+
+describe("TabelaAssociacoes", () => {
+    const unidadeEscolarTemplate = jest.fn((rowData) => (
+        <strong data-testid="unidade-template">{rowData.unidade.nome_com_tipo}</strong>
+    ));
+    const acoesTemplate = jest.fn((rowData) => (
+        <button data-testid="acao-template">{rowData.uuid}</button>
+    ));
+
+    const associacoesPadrao = [
+        { uuid: "1", unidade: { codigo_eol: "111", nome_com_tipo: "EMEI Teste" } },
+        { uuid: "2", unidade: { codigo_eol: "222", nome_com_tipo: "EMEF Teste" } },
+    ];
+
+    let setShowModalLegendaInformacao;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        capturedLegendaProps = null;
+        setShowModalLegendaInformacao = jest.fn();
+    });
+
+    const renderComponent = (props = {}) => {
+        return render(
+            <TabelaAssociacoes
+                associacoes={associacoesPadrao}
+                rowsPerPage={15}
+                unidadeEscolarTemplate={unidadeEscolarTemplate}
+                acoesTemplate={acoesTemplate}
+                showModalLegendaInformacao={false}
+                setShowModalLegendaInformacao={setShowModalLegendaInformacao}
+                {...props}
+            />
+        );
+    };
+
+    it("renderiza LegendaInformacao com entidadeDasTags 'associacao'", () => {
+        renderComponent();
+        expect(screen.getByTestId("legenda-informacao")).toBeInTheDocument();
+        expect(capturedLegendaProps.entidadeDasTags).toBe("associacao");
+    });
+
+    it("repassa showModalLegendaInformacao e setShowModalLegendaInformacao para LegendaInformacao", () => {
+        renderComponent({ showModalLegendaInformacao: true });
+        expect(capturedLegendaProps.showModalLegendaInformacao).toBe(true);
+        expect(capturedLegendaProps.setShowModalLegendaInformacao).toBe(
+            setShowModalLegendaInformacao
+        );
+    });
+
+    it("renderiza a tabela com as linhas de associacoes", () => {
+        renderComponent();
+        expect(screen.getAllByTestId("datatable-row")).toHaveLength(2);
+    });
+
+    it("ativa o paginator quando associacoes.length > rowsPerPage", () => {
+        const muitasAssociacoes = Array.from({ length: 5 }, (_, i) => ({
+            uuid: String(i),
+            unidade: { codigo_eol: String(i), nome_com_tipo: `Escola ${i}` },
+        }));
+        renderComponent({ associacoes: muitasAssociacoes, rowsPerPage: 3 });
+        expect(screen.getByTestId("datatable")).toHaveAttribute(
+            "data-paginator",
+            "true"
+        );
+    });
+
+    it("não ativa o paginator quando associacoes.length <= rowsPerPage", () => {
+        renderComponent({ rowsPerPage: 15 });
+        expect(screen.getByTestId("datatable")).toHaveAttribute(
+            "data-paginator",
+            "false"
+        );
+    });
+
+    it("renderiza TableTags para a coluna de informações", () => {
+        renderComponent();
+        expect(screen.getAllByTestId("table-tags").length).toBeGreaterThan(0);
+    });
+
+    it("renderiza sem quebrar quando associacoes é uma lista vazia", () => {
+        renderComponent({ associacoes: [] });
+        expect(screen.queryAllByTestId("datatable-row")).toHaveLength(0);
+        expect(screen.getByTestId("datatable")).toHaveAttribute(
+            "data-paginator",
+            "false"
+        );
+    });
+});

--- a/src/componentes/dres/Associacoes/__tests__/index.test.js
+++ b/src/componentes/dres/Associacoes/__tests__/index.test.js
@@ -1,0 +1,418 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Associacoes } from "../index";
+
+jest.mock("../../../../services/dres/Associacoes.service", () => ({
+    getAssociacoesPorUnidade: jest.fn(),
+    filtrosAssociacoes: jest.fn(),
+    getAssociacao: jest.fn(),
+    getContasAssociacao: jest.fn(),
+    getContasAssociacaoEncerradas: jest.fn(),
+    getTabelaAssociacoesDre: jest.fn(),
+}));
+
+jest.mock("../../../../services/visoes.service", () => ({
+    visoesService: {
+        getPermissoes: jest.fn(),
+    },
+}));
+
+jest.mock("../../../../services/auth.service", () => ({
+    DADOS_DA_ASSOCIACAO: "DADOS_DA_ASSOCIACAO",
+}));
+
+jest.mock("../../../../utils/Loading", () => () => (
+    <div data-testid="loading" />
+));
+
+jest.mock("react-router-dom", () => ({
+    Navigate: () => <div data-testid="navigate" />,
+}));
+
+let capturedMsgImgCentralizada = null;
+jest.mock("../../../Globais/Mensagens/MsgImgCentralizada", () => ({
+    MsgImgCentralizada: (props) => {
+        capturedMsgImgCentralizada = props;
+        return <div data-testid="msg-img-centralizada">{props.texto}</div>;
+    },
+}));
+
+let capturedMsgImgLadoDireito = null;
+jest.mock("../../../Globais/Mensagens/MsgImgLadoDireito", () => ({
+    MsgImgLadoDireito: (props) => {
+        capturedMsgImgLadoDireito = props;
+        return <div data-testid="msg-img-lado-direito">{props.texto}</div>;
+    },
+}));
+
+jest.mock("../../../Globais/UI/Icon", () => ({
+    Icon: () => <span data-testid="icon" />,
+}));
+
+let capturedTabelaAssociacoesProps = null;
+jest.mock("../TabelaAssociacoes", () => ({
+    TabelaAssociacoes: (props) => {
+        capturedTabelaAssociacoesProps = props;
+        return <div data-testid="tabela-associacoes" />;
+    },
+}));
+
+let capturedFiltrosAssociacoesProps = null;
+jest.mock("../FiltrosAssociacoes", () => ({
+    FiltrosAssociacoes: (props) => {
+        capturedFiltrosAssociacoesProps = props;
+        return <div data-testid="filtros-associacoes" />;
+    },
+}));
+
+import {
+    getAssociacoesPorUnidade,
+    filtrosAssociacoes,
+    getAssociacao,
+    getContasAssociacao,
+    getContasAssociacaoEncerradas,
+    getTabelaAssociacoesDre,
+} from "../../../../services/dres/Associacoes.service";
+import { visoesService } from "../../../../services/visoes.service";
+
+describe("Associacoes (index)", () => {
+    const associacaoMock = {
+        uuid: "assoc-1",
+        unidade: { codigo_eol: "111", nome_com_tipo: "EMEI Teste" },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        localStorage.clear();
+        capturedMsgImgCentralizada = null;
+        capturedMsgImgLadoDireito = null;
+        capturedTabelaAssociacoesProps = null;
+        capturedFiltrosAssociacoesProps = null;
+
+        getTabelaAssociacoesDre.mockResolvedValue({
+            tipos_unidade: [],
+            filtro_informacoes: [],
+        });
+        getAssociacoesPorUnidade.mockResolvedValue([]);
+        filtrosAssociacoes.mockResolvedValue([]);
+        getAssociacao.mockResolvedValue({ uuid: "assoc-1" });
+        getContasAssociacao.mockResolvedValue([]);
+        getContasAssociacaoEncerradas.mockResolvedValue([]);
+        visoesService.getPermissoes.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it("chama getTabelaAssociacoesDre e getAssociacoesPorUnidade na montagem", async () => {
+        render(<Associacoes />);
+        await waitFor(() => {
+            expect(getTabelaAssociacoesDre).toHaveBeenCalledTimes(1);
+            expect(getAssociacoesPorUnidade).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("exibe Loading enquanto getAssociacoesPorUnidade não resolve", async () => {
+        let resolveFn;
+        getAssociacoesPorUnidade.mockReturnValue(
+            new Promise((resolve) => {
+                resolveFn = resolve;
+            })
+        );
+
+        render(<Associacoes />);
+        expect(screen.getByTestId("loading")).toBeInTheDocument();
+
+        await act(async () => {
+            resolveFn([]);
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
+        });
+    });
+
+    it("renderiza TabelaAssociacoes quando associacoes.length > 0", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("tabela-associacoes")).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId("msg-img-centralizada")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("msg-img-lado-direito")).not.toBeInTheDocument();
+    });
+
+    it("renderiza MsgImgLadoDireito quando lista vazia e sem busca por filtros", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("msg-img-lado-direito")).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId("tabela-associacoes")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("msg-img-centralizada")).not.toBeInTheDocument();
+        expect(capturedMsgImgLadoDireito.texto).toBe(
+            "Não encontramos nenhuma Associação com este perfil, tente novamente"
+        );
+    });
+
+    it("renderiza MsgImgCentralizada quando lista vazia após busca por filtros", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([]);
+        filtrosAssociacoes.mockResolvedValue([]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedFiltrosAssociacoesProps).not.toBeNull();
+        });
+
+        await act(async () => {
+            await capturedFiltrosAssociacoesProps.handleSubmitFiltrosAssociacao({
+                preventDefault: jest.fn(),
+            });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("msg-img-centralizada")).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId("msg-img-lado-direito")).not.toBeInTheDocument();
+        expect(capturedMsgImgCentralizada.texto).toBe(
+            "Não encontramos resultados, verifique os filtros e tente novamente."
+        );
+    });
+
+    it("handleSubmitFiltrosAssociacao chama filtrosAssociacoes com os 4 argumentos corretos e atualiza a tabela", async () => {
+        const resultadoFiltro = [associacaoMock];
+        filtrosAssociacoes.mockResolvedValue(resultadoFiltro);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedFiltrosAssociacoesProps).not.toBeNull();
+        });
+
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleChangeFiltrosAssociacao(
+                "unidade_escolar_ou_associacao",
+                "Termo X"
+            );
+        });
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleChangeFiltrosAssociacao(
+                "tipo_de_unidade",
+                "EMEI"
+            );
+        });
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleOnChangeMultipleSelectStatus([
+                "status1",
+            ]);
+        });
+
+        await act(async () => {
+            await capturedFiltrosAssociacoesProps.handleSubmitFiltrosAssociacao({
+                preventDefault: jest.fn(),
+            });
+        });
+
+        expect(filtrosAssociacoes).toHaveBeenCalledWith(
+            "Termo X",
+            null,
+            "EMEI",
+            ["status1"]
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("tabela-associacoes")).toBeInTheDocument();
+        });
+        expect(capturedTabelaAssociacoesProps.associacoes).toEqual(resultadoFiltro);
+    });
+
+    it("limpaFiltros reseta stateFiltros e rechama getAssociacoesPorUnidade", async () => {
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedFiltrosAssociacoesProps).not.toBeNull();
+        });
+
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleChangeFiltrosAssociacao(
+                "unidade_escolar_ou_associacao",
+                "Termo Y"
+            );
+        });
+
+        expect(capturedFiltrosAssociacoesProps.stateFiltros.unidade_escolar_ou_associacao).toBe(
+            "Termo Y"
+        );
+
+        getAssociacoesPorUnidade.mockClear();
+        getAssociacoesPorUnidade.mockResolvedValue([]);
+
+        await act(async () => {
+            await capturedFiltrosAssociacoesProps.limpaFiltros();
+        });
+
+        expect(getAssociacoesPorUnidade).toHaveBeenCalledTimes(1);
+        expect(capturedFiltrosAssociacoesProps.stateFiltros).toEqual({
+            unidade_escolar_ou_associacao: "",
+            tipo_de_unidade: "",
+            filtro_status: [],
+        });
+    });
+
+    it("handleChangeFiltrosAssociacao e handleOnChangeMultipleSelectStatus atualizam stateFiltros", async () => {
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedFiltrosAssociacoesProps).not.toBeNull();
+        });
+
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleChangeFiltrosAssociacao(
+                "unidade_escolar_ou_associacao",
+                "Buscar Algo"
+            );
+        });
+        expect(capturedFiltrosAssociacoesProps.stateFiltros.unidade_escolar_ou_associacao).toBe(
+            "Buscar Algo"
+        );
+
+        await act(async () => {
+            capturedFiltrosAssociacoesProps.handleOnChangeMultipleSelectStatus([
+                "status1",
+                "status2",
+            ]);
+        });
+        expect(capturedFiltrosAssociacoesProps.stateFiltros.filtro_status).toEqual([
+            "status1",
+            "status2",
+        ]);
+    });
+
+    it("trata erro de getAssociacoesPorUnidade no useEffect inicial sem quebrar", async () => {
+        const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+        getAssociacoesPorUnidade.mockRejectedValue(new Error("Erro de rede"));
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId("msg-img-lado-direito")).toBeInTheDocument();
+        consoleSpy.mockRestore();
+    });
+
+    it("unidadeEscolarTemplate retorna strong quando rowData.unidade.nome_com_tipo existe", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        const { container } = render(
+            capturedTabelaAssociacoesProps.unidadeEscolarTemplate(associacaoMock)
+        );
+        expect(container.querySelector("strong")).toHaveTextContent("EMEI Teste");
+    });
+
+    it("unidadeEscolarTemplate não renderiza strong quando nome_com_tipo não existe", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        const semNome = { uuid: "assoc-2", unidade: {} };
+        const { container } = render(
+            capturedTabelaAssociacoesProps.unidadeEscolarTemplate(semNome)
+        );
+        expect(container.querySelector("strong")).not.toBeInTheDocument();
+    });
+
+    it("o botão de ação fica desabilitado quando o usuário não possui nenhuma permissão", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+        visoesService.getPermissoes.mockReturnValue(false);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        const { container } = render(
+            capturedTabelaAssociacoesProps.acoesTemplate(associacaoMock)
+        );
+        expect(container.querySelector("button")).toBeDisabled();
+    });
+
+    it("o botão de ação fica habilitado quando o usuário possui ao menos uma permissão", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+        visoesService.getPermissoes.mockImplementation((permissoes) =>
+            permissoes.includes("access_dados_unidade_dre")
+        );
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        const { container } = render(
+            capturedTabelaAssociacoesProps.acoesTemplate(associacaoMock)
+        );
+        expect(container.querySelector("button")).not.toBeDisabled();
+    });
+
+    it("passa showModalLegendaInformacao e setShowModalLegendaInformacao para TabelaAssociacoes", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        expect(capturedTabelaAssociacoesProps.showModalLegendaInformacao).toBe(false);
+        expect(typeof capturedTabelaAssociacoesProps.setShowModalLegendaInformacao).toBe(
+            "function"
+        );
+    });
+
+    it("passa rowsPerPage de 15 para TabelaAssociacoes", async () => {
+        getAssociacoesPorUnidade.mockResolvedValue([associacaoMock]);
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedTabelaAssociacoesProps).not.toBeNull();
+        });
+
+        expect(capturedTabelaAssociacoesProps.rowsPerPage).toBe(15);
+    });
+
+    it("passa tabelaAssociacoes obtido de getTabelaAssociacoesDre para FiltrosAssociacoes", async () => {
+        getTabelaAssociacoesDre.mockResolvedValue({
+            tipos_unidade: [{ id: "EMEI", nome: "EMEI" }],
+            filtro_informacoes: [{ id: "status1", nome: "Status 1" }],
+        });
+
+        render(<Associacoes />);
+
+        await waitFor(() => {
+            expect(capturedFiltrosAssociacoesProps.tabelaAssociacoes.tipos_unidade).toEqual([
+                { id: "EMEI", nome: "EMEI" },
+            ]);
+        });
+    });
+});

--- a/src/componentes/dres/Paa/VisualizarDocumentos/components/PaaCard/PaaCard.tsx
+++ b/src/componentes/dres/Paa/VisualizarDocumentos/components/PaaCard/PaaCard.tsx
@@ -88,14 +88,11 @@ export const PaaCard: React.FC<PaaCardProps> = ({ dados }) => {
         if (id) await getDownloadAtaPaa(id);
     }, []);
 
-    const { retificacao, esta_em_retificacao } = dados;
-    const mostrarRetificacao = Boolean(
-        esta_em_retificacao && retificacao?.documento && retificacao?.ata,
-    );
+    const { retificacao, exibe_dados_retificacao } = dados;
 
     return (
         <div className='paa-card border border-top-0 p-3'>
-            {mostrarRetificacao ? (
+            {exibe_dados_retificacao ? (
                 <>
                     <PaaSecaoPlanoEAta
                         tituloSecao={`PAA Retificado #${retificacao.documento.status.versao_documento}`}

--- a/src/componentes/dres/Paa/VisualizarDocumentos/components/PaaCard/__tests__/PaaCard.jest.js
+++ b/src/componentes/dres/Paa/VisualizarDocumentos/components/PaaCard/__tests__/PaaCard.jest.js
@@ -91,6 +91,7 @@ describe('PaaCard', () => {
         uuid: 'paa-123',
 
         esta_em_retificacao: true,
+        exibe_dados_retificacao: true,
 
         retificacao: {
             documento: {
@@ -154,6 +155,7 @@ describe('PaaCard', () => {
                     dados={{
                         ...dadosMock,
                         esta_em_retificacao: false,
+                        exibe_dados_retificacao: false,
                     }}
                 />,
             );
@@ -338,6 +340,7 @@ describe('PaaCard', () => {
                             ata: {},
                         },
                         esta_em_retificacao: false,
+                        exibe_dados_retificacao: false,
                     }}
                 />,
             );
@@ -385,6 +388,7 @@ describe('PaaCard', () => {
                             ata: {},
                         },
                         esta_em_retificacao: false,
+                        exibe_dados_retificacao: false,
                     }}
                 />,
             );

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/index.js
@@ -4,6 +4,7 @@ import { DatePickerField } from "../../../../../Globais/DatePickerField";
 import { toastCustom } from "../../../../../Globais/ToastCustom";
 import { visoesService } from "../../../../../../services/visoes.service";
 import { FieldArray, Formik } from "formik";
+import { Spin } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faTimesCircle,
@@ -73,6 +74,7 @@ export const NovoFormularioEditaAta = ({
   const [disableBtnApagarPresente, setDisableBtnApagarPresente] =
     useState(false);
   const [disableBtnConfirmarEdicao] = useState(false);
+  const [isLoadingParticipantes, setIsLoadingParticipantes] = useState(false);
   const [disableBtnCancelarEdicao] = useState(false);
   const [formErrors, setFormErrors] = useState({});
   const [ehAdicaoPresente, setEhAdicaoPresente] = useState(false);
@@ -950,6 +952,7 @@ export const NovoFormularioEditaAta = ({
 
       const data_formatada = formatDate(value);
       try {
+        setIsLoadingParticipantes(true);
         const listaComProfessor = await montarListaPorData(data_formatada);
 
         sincronizaListaParticipantes(listaComProfessor, {
@@ -959,6 +962,8 @@ export const NovoFormularioEditaAta = ({
       } catch (error) {
         sincronizaListaParticipantes([], { reinicializar: true });
         notificarErroComposicaoPorData(error);
+      } finally {
+        setIsLoadingParticipantes(false);
       }
       return;
     }
@@ -1232,6 +1237,7 @@ export const NovoFormularioEditaAta = ({
                     <strong>Participantes</strong>
                   </p>
 
+                  <Spin size="large" spinning={isLoadingParticipantes}>
                   {values.listaParticipantes &&
                   values.listaParticipantes.length > 0 &&
                   values.stateFormEditarAta &&
@@ -1819,6 +1825,7 @@ export const NovoFormularioEditaAta = ({
                   ) : (
                     <BarraAvisoPreencerData />
                   )}
+                  </Spin>
 
                   {/*So exibe o campo retificações em atas de retificação*/}
                   {stateFormEditarAta &&

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import "../../geracao-da-ata.scss"
+import { Spin } from "antd";
 import {TopoComBotoes} from "./TopoComBotoes";
 import {FormularioEditaAta} from "./FormularioEditaAta";
 import {NovoFormularioEditaAta} from "./NovoFormularioEditaAta";
@@ -63,6 +64,7 @@ export const EdicaoAtaPaa = () => {
     });
     const [tabelas, setTabelas] = useState({});
     const [membrosCargos, setMembrosCargos] = useState([])
+    const [isLoadingPresentes, setIsLoadingPresentes] = useState(false)
     const [disableBtnSalvar, setDisableBtnSalvar] = useState(false)
     const [dadosAta, setDadosAta] = useState({});
     const [erros, setErros] = useState({});
@@ -74,24 +76,31 @@ export const EdicaoAtaPaa = () => {
             return;
         }
         const fetchData = async () => {
-            let listaPresentesAta = await getListaPresentesAta(ataUuid);
-            let listaPresentesPadraoAta = await getListaPresentesPadraoAta(ataUuid);
+            setIsLoadingPresentes(true)
+            try{
+                let listaPresentesAta = await getListaPresentesAta(ataUuid);
+                let listaPresentesPadraoAta = await getListaPresentesPadraoAta(ataUuid);
 
-            for (let i = 0; i < listaPresentesAta.length; i++) {
-                const presenteAta = listaPresentesAta[i];
+                for (let i = 0; i < listaPresentesAta.length; i++) {
+                    const presenteAta = listaPresentesAta[i];
 
-                for (let j = 0; j < listaPresentesPadraoAta.length; j++) {
-                    const presentePadraoAta = listaPresentesPadraoAta[j];
+                    for (let j = 0; j < listaPresentesPadraoAta.length; j++) {
+                        const presentePadraoAta = listaPresentesPadraoAta[j];
 
-                    if (presenteAta.identificacao === presentePadraoAta.identificacao) {
-                        listaPresentesPadraoAta[j].presente = listaPresentesAta[i].presente;
+                        if (presenteAta.identificacao === presentePadraoAta.identificacao) {
+                            listaPresentesPadraoAta[j].presente = listaPresentesAta[i].presente;
+                        }
                     }
                 }
+
+                let participantesNaoMembros = listaPresentesAta.filter(participante => participante.membro === false);
+
+                setListaPresentesPadrao(listaPresentesPadraoAta.concat(participantesNaoMembros))
+            } catch (e) {
+                console.error('Erro ao obter lista de presentes', e)
+            } finally {
+                setIsLoadingPresentes(false)
             }
-
-            let participantesNaoMembros = listaPresentesAta.filter(participante => participante.membro === false);
-
-            setListaPresentesPadrao(listaPresentesPadraoAta.concat(participantesNaoMembros))
         };
         fetchData();
     }, [ataUuid]);
@@ -324,7 +333,6 @@ export const EdicaoAtaPaa = () => {
         }
     }
     return (
-        <>
             <div className="col-12 container-visualizacao-da-ata mb-5">
                 <div className="col-12 mt-4">
                     <TopoComBotoes
@@ -337,6 +345,7 @@ export const EdicaoAtaPaa = () => {
 
 
                 <div className="col-12">
+                    <Spin spinning={isLoadingPresentes}>
                     {visoesService.featureFlagAtiva('historico-de-membros') ?  <NovoFormularioEditaAta
                         stateFormEditarAta={stateFormEditarAta}
                         tabelas={tabelas}
@@ -364,9 +373,9 @@ export const EdicaoAtaPaa = () => {
                         editaStatusDePresencaMembro={editaStatusDePresencaMembro}
                     >
                     </FormularioEditaAta>}
+                    </Spin>
                 </div>
 
             </div>
-        </>
     )
 };

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
@@ -179,14 +179,13 @@ describe('useVisualizacaoAtaPaa', () => {
 
   it('deve processar rota atual e acionar window.location.assign na edição da ata', () => {
     window.location.pathname = '/teste-path';
-    window.location.search = '?id=9';
     const { result } = renderHook(() => useVisualizacaoAtaPaa());
 
     act(() => {
       result.current.handleClickEditarAta();
     });
 
-    const rotaEsperada = `/relatorios-paa/edicao-ata/123?returnUrl=${encodeURIComponent('/teste-path?id=9')}`;
+    const rotaEsperada = `/relatorios-paa/edicao-ata/123?returnUrl=${encodeURIComponent('/teste-path')}`;
     expect(window.location.assign).toHaveBeenCalledWith(rotaEsperada);
   });
 

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
@@ -75,7 +75,9 @@ export const useVisualizacaoAtaPaa = () => {
     };
 
     const handleClickFecharAta = () => {
-        if (location.state?.origem === 'paa-vigente-e-anteriores') {
+        const searchParams = new URLSearchParams(location.search);
+        const origem = location.state?.origem || searchParams.get("origem");
+        if (origem === 'paa-vigente-e-anteriores') {
             navigate("/paa-vigente-e-anteriores");
         } else {
             navigate("/elaborar-novo-paa", {
@@ -91,7 +93,10 @@ export const useVisualizacaoAtaPaa = () => {
     };
 
     const handleClickEditarAta = () => {
-        const rotaAtual = `${window.location.pathname}${window.location.search || ""}`;
+        const origem = location.state?.origem;
+        const rotaAtual = origem
+            ? `${window.location.pathname}?origem=${encodeURIComponent(origem)}`
+            : window.location.pathname;
         const path = `/relatorios-paa/edicao-ata/${uuid_paa}?returnUrl=${encodeURIComponent(rotaAtual)}`;
         window.location.assign(path);
     };

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import "../../geracao-da-ata.scss";
+import { Spin } from "antd";
 import { TopoComBotoes } from "./TopoComBotoes";
 import WatermarkPrevia from "../../../../Globais/WatermarkPrevia/WatermarkPrevia";
 import { useVisualizacaoAtaPaa } from "./hooks/useVisualizacaoAtaPaa";
@@ -70,35 +71,43 @@ export const VisualizacaoAtaPaa = () => {
             />
           )}
         </div>
-        
+
         { !paaRetificacao && !isLoading ? (
-          <AtaElaboracao 
-            getAnoPorExtenso={getAnoPorExtenso}
-            getDiaPorExtenso={getDiaPorExtenso}
-            getMesPorExtenso={getMesPorExtenso}
-            getLocalReuniao={getLocalReuniao}
-            getNomeUnidade={getNomeUnidade}
-            getHoraInicio={getHoraInicio}
-            getTipoReuniao={getTipoReuniao}
-            getTipoUnidadeComNome={getTipoUnidadeComNome}
-            getNomeUnidadeEducacional={getNomeUnidadeEducacional}
-          />     
+          <span>
+            <Spin spinning={isLoading} size="large">
+              <AtaElaboracao
+                getAnoPorExtenso={getAnoPorExtenso}
+                getDiaPorExtenso={getDiaPorExtenso}
+                getMesPorExtenso={getMesPorExtenso}
+                getLocalReuniao={getLocalReuniao}
+                getNomeUnidade={getNomeUnidade}
+                getHoraInicio={getHoraInicio}
+                getTipoReuniao={getTipoReuniao}
+                getTipoUnidadeComNome={getTipoUnidadeComNome}
+                getNomeUnidadeEducacional={getNomeUnidadeEducacional}
+              />
+            </Spin>
+          </span>
         ) : (
-          <AtaRetificacao 
-            getNomeUnidadeEducacional={getNomeUnidadeEducacional}
-            getAnoPorExtenso={getAnoPorExtenso}
-            getDiaPorExtenso={getDiaPorExtenso}
-            getMesPorExtenso={getMesPorExtenso}
-            getLocalReuniao={getLocalReuniao}
-            getNomeUnidade={getNomeUnidade}
-            getHoraInicio={getHoraInicio}
-            getPeriodoPaaFormatado={getPeriodoPaaFormatado}
-            getDataFormatada={getDataFormatada}
-            getTipoReuniao={getTipoReuniao}
-            dataReuniaoElaboracao={dataReuniaoElaboracao}
-            getNomePresidente={getNomePresidente}
-            getTipoUnidadeComNome={getTipoUnidadeComNome}
-          />
+          <span>
+            <Spin spinning={isLoading} size="large">
+              <AtaRetificacao
+                getNomeUnidadeEducacional={getNomeUnidadeEducacional}
+                getAnoPorExtenso={getAnoPorExtenso}
+                getDiaPorExtenso={getDiaPorExtenso}
+                getMesPorExtenso={getMesPorExtenso}
+                getLocalReuniao={getLocalReuniao}
+                getNomeUnidade={getNomeUnidade}
+                getHoraInicio={getHoraInicio}
+                getPeriodoPaaFormatado={getPeriodoPaaFormatado}
+                getDataFormatada={getDataFormatada}
+                getTipoReuniao={getTipoReuniao}
+                dataReuniaoElaboracao={dataReuniaoElaboracao}
+                getNomePresidente={getNomePresidente}
+                getTipoUnidadeComNome={getTipoUnidadeComNome}
+              />
+            </Spin>
+          </span>
         )}
         
         {!isLoadingPrioridades && prioridadesAgrupadas && !paaRetificacao && !isLoading ? (
@@ -110,18 +119,18 @@ export const VisualizacaoAtaPaa = () => {
         <div className="col-12 mt-4">
           <p>Foi apresentado o seguinte cronograma para as atividades de {getPeriodoPaaFormatado()}:</p>
         </div>
-        
-       { !isLoadingAtividades && atividades && atividades.length > 0 && (
-        <AtividadesEstatutarias 
-          atividades={atividades}
-          isLoadingAtividades={isLoadingAtividades}
-          paaRetificacao={paaRetificacao}
-          isLoading={isLoading}
-          formatarMesAno={formatarMesAno}
-          formatarData={formatarData}
-        />        
-       )}
-       
+
+        { !isLoadingAtividades && atividades && atividades.length > 0 && (
+          <AtividadesEstatutarias
+            atividades={atividades}
+            isLoadingAtividades={isLoadingAtividades}
+            paaRetificacao={paaRetificacao}
+            isLoading={isLoading}
+            formatarMesAno={formatarMesAno}
+            formatarData={formatarData}
+          />
+        )}
+
         { paaRetificacao && !isLoading && (
           <div className="col-12 mt-4">
             <h4 style={{ fontWeight: "bold", fontSize: "20px", color: "#42474A" }}>Justificativa da Retificação</h4>
@@ -129,7 +138,7 @@ export const VisualizacaoAtaPaa = () => {
           </div>
         )}
 
-        <Manifestacoes 
+        <Manifestacoes
           dadosAta={dadosAta}
           paaRetificacao={paaRetificacao}
           tabelas={tabelas}
@@ -151,7 +160,7 @@ export const VisualizacaoAtaPaa = () => {
               e eu, <strong>{getNomeSecretarioReuniao()}</strong>, lavrei a presente Ata, que foi por mim  assinada e pelos demais
               presentes.
             </p>
-          </div>          
+          </div>
         )}
 
         {listaPresentes && listaPresentes.length > 0 && (

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/AtividadesPrevistas.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/AtividadesPrevistas/AtividadesPrevistas.js
@@ -645,9 +645,7 @@ export const AtividadesPrevistas = () => {
                     <>
                       <EditIconButton
                         className="p-0"
-                        onClick={() =>
-                          record.isNovo ? handleEditar(record): null
-                        }
+                        onClick={() => handleEditar(record)}
                       />
                       <IconButton
                         className="p-0"

--- a/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/RelSecaoObjetivos.js
+++ b/src/componentes/escolas/Paa/ElaboracaoPaa/ElaborarNovoPlano/Relatorios/RelSecaoObjetivos.js
@@ -96,7 +96,7 @@ export const RelSecaoObjetivos = ({ paaVigente, onSalvarObjetivos, isSaving, pod
         dataSource={items.filter((i) => !i._destroy)}
         renderItem={(item) => (
           <List.Item>
-            <div className="d-flex w-100">
+            <div className="d-flex w-100 mr-2">
               <Checkbox
                 onChange={onChangeObjetivos}
                 value={item.uuid || item.key}

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/PaaAtaAcoes.test.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/PaaAtaAcoes.test.js
@@ -233,7 +233,7 @@ describe('PaaAtaAcoes', () => {
     renderComRouter(
       <PaaAtaAcoes paaUuid="paa-99" ata={ata} documentoPlano={documentoPlano} />
     );
-    fireEvent.click(screen.getByRole('button', { name: /visualizar ata/i }));
+    fireEvent.click(screen.getByRole('button', { name: /visualizar prévia da ata/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/relatorios-paa/visualizacao-da-ata-paa/paa-99', {
       state: { origem: 'paa-vigente-e-anteriores' },
     });

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/PaaCard.test.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/__tests__/PaaCard.test.js
@@ -125,7 +125,9 @@ describe('PaaCard', () => {
     const dados = {
       uuid: 'paa-uuid',
       esta_em_retificacao: true,
+      exibe_dados_retificacao: true,
       retificacao: {
+        secao_titulo: 'PAA Retificado #2',
         documento: {
           ...DOCUMENTO_PADRAO,
           status: {
@@ -150,6 +152,7 @@ describe('PaaCard', () => {
         },
       },
       original: {
+        secao_titulo: 'PAA Original',
         documento: {
           ...DOCUMENTO_PADRAO,
           existe_arquivo: true,

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/ModalConfirmaGeracaoAta/ModalConfirmaGeracaoAta.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/ModalConfirmaGeracaoAta/ModalConfirmaGeracaoAta.js
@@ -3,7 +3,7 @@ import { Modal } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
-export const ModalConfirmaGeracaoAta = memo(({ open, onClose, onConfirm }) => {
+export const ModalConfirmaGeracaoAta = memo(({ open, onClose, onConfirm, emRetificacao }) => {
     return (
         <Modal
             centered
@@ -23,7 +23,7 @@ export const ModalConfirmaGeracaoAta = memo(({ open, onClose, onConfirm }) => {
             </Modal.Header>
             <Modal.Body>
                 <p>
-                    Ao gerar a Ata de Apresentação, não será mais possível editá-la. Deseja continuar?
+                    Ao gerar a Ata de {emRetificacao ? 'Retificação' : 'Apresentação'}, não será mais possível editá-la. Deseja continuar?
                 </p>
             </Modal.Body>
             <Modal.Footer>

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaAtaAcoes/PaaAtaAcoes.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaAtaAcoes/PaaAtaAcoes.js
@@ -7,7 +7,7 @@ import { toastCustom } from "../../../../../Globais/ToastCustom";
 import { ModalConfirmaGeracaoAta } from "../ModalConfirmaGeracaoAta/ModalConfirmaGeracaoAta";
 import "./PaaAtaAcoes.scss";
 
-export const PaaAtaAcoes = ({ paaUuid, ata, documentoPlano, onDepoisDeGerar }) => {
+export const PaaAtaAcoes = ({ paaUuid, ata, documentoPlano, onDepoisDeGerar, dadosPaa }) => {
   const navigate = useNavigate();
   const podeEditar = visoesService.getPermissoes(["custom_change_paa"]);
   const [modalGerarAberto, setModalGerarAberto] = useState(false);
@@ -60,9 +60,21 @@ export const PaaAtaAcoes = ({ paaUuid, ata, documentoPlano, onDepoisDeGerar }) =
 
   return (
     <div className="d-flex mt-3 mt-md-0 align-items-start flex-wrap gap-2">
+
+      {documentoFinalGerado ? (
+        <button
+          type="button"
+          className="btn btn-outline-success paa-ata-acoes__btn"
+          disabled={!paaUuid}
+          onClick={handleVisualizarAtaEditor}
+        >
+          Visualizar prévia da ata
+        </button>
+      ) : null}
+
       <button
         type="button"
-        className="btn btn-success paa-ata-acoes__btn"
+        className="btn btn-success ml-3 paa-ata-acoes__btn"
         disabled={gerarDesabilitado}
         onClick={abrirModalGerar}
         {...(gerarDesabilitado && mensagemTooltipGerar
@@ -74,21 +86,13 @@ export const PaaAtaAcoes = ({ paaUuid, ata, documentoPlano, onDepoisDeGerar }) =
       >
         Gerar ata
       </button>
+
       {gerarDesabilitado && mensagemTooltipGerar ? (
         <ReactTooltip id={tooltipGerarId} place="top" />
       ) : null}
-      {documentoFinalGerado ? (
-        <button
-          type="button"
-          className="btn btn-outline-success ml-3 paa-ata-acoes__btn"
-          disabled={!paaUuid}
-          onClick={handleVisualizarAtaEditor}
-        >
-          Visualizar ata
-        </button>
-      ) : null}
 
       <ModalConfirmaGeracaoAta
+        emRetificacao={dadosPaa?.esta_em_retificacao ?? false}
         open={modalGerarAberto}
         onClose={() => setModalGerarAberto(false)}
         onConfirm={handleConfirmarGeracaoAta}

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
@@ -100,8 +100,8 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
 
   const { retificacao, exibe_dados_retificacao } = dados;
 
-  const resumoAssembleiaOriginal = original.ata?.resumo_assembleia;
-  const resumoAssembleiaRetificacao = retificacao.ata?.resumo_assembleia;
+  const resumoAssembleiaOriginal = original?.ata?.resumo_assembleia;
+  const resumoAssembleiaRetificacao = retificacao?.ata?.resumo_assembleia;
 
   return (
     <div className="paa-card border border-top-0 p-3">

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaCard.js
@@ -78,11 +78,12 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
   }, []);
 
   const statusGeracaoAtaApresentacao = original?.ata?.status?.status_geracao;
+  const statusGeracaoAtaRetificacao = dados?.retificacao?.ata?.status?.status_geracao;
   useEffect(() => {
-    if (statusGeracaoAtaApresentacao !== 'EM_PROCESSAMENTO') {
-      return undefined;
-    }
-    if (!onDadosAtualizados) {
+    const emProcessamento =
+      statusGeracaoAtaApresentacao === 'EM_PROCESSAMENTO' ||
+      statusGeracaoAtaRetificacao === 'EM_PROCESSAMENTO';
+    if (!emProcessamento || !onDadosAtualizados) {
       return undefined;
     }
     const id = setInterval(() => {
@@ -91,22 +92,23 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
     return () => {
       clearInterval(id);
     };
-  }, [statusGeracaoAtaApresentacao, onDadosAtualizados]);
+  }, [statusGeracaoAtaApresentacao, statusGeracaoAtaRetificacao, onDadosAtualizados]);
 
   if (!original?.documento || !original?.ata) {
     return null;
   }
 
-  const { retificacao, esta_em_retificacao } = dados;
-  const mostrarRetificacao = Boolean(esta_em_retificacao && retificacao?.documento && retificacao?.ata);
+  const { retificacao, exibe_dados_retificacao } = dados;
+
   const resumoAssembleiaOriginal = original.ata?.resumo_assembleia;
+  const resumoAssembleiaRetificacao = retificacao.ata?.resumo_assembleia;
 
   return (
     <div className="paa-card border border-top-0 p-3">
-      {mostrarRetificacao ? (
+      {exibe_dados_retificacao ? (
         <>
           <PaaSecaoPlanoEAta
-            tituloSecao={`PAA Retificado #${retificacao.documento.status.versao_documento}`}
+            tituloSecao={retificacao.secao_titulo}
             documento={retificacao.documento}
             ata={retificacao.ata}
             tituloAta="Ata de retificação do PAA"
@@ -117,10 +119,13 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
             onDownloadDocumento={onDownloadDocumento}
             onVisualizarAta={onVisualizarAta}
             onDownloadAta={onDownloadAta}
+            onDepoisDeGerarAta={onDadosAtualizados}
+            resumoAssembleia={resumoAssembleiaRetificacao}
+            dadosPaa={dados}
           />
           <hr className="my-4 paa-card__separador" />
           <PaaSecaoPlanoEAta
-            tituloSecao="PAA Original"
+            tituloSecao={original.secao_titulo}
             documento={original.documento}
             ata={original.ata}
             tituloAta="Ata de apresentação do PAA"
@@ -133,6 +138,7 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
             onDownloadAta={onDownloadAta}
             onDepoisDeGerarAta={onDadosAtualizados}
             resumoAssembleia={resumoAssembleiaOriginal}
+            dadosPaa={dados}
           />
         </>
       ) : (
@@ -150,6 +156,7 @@ export const PaaCard = ({ dados, onDadosAtualizados }) => {
           onDownloadAta={onDownloadAta}
           onDepoisDeGerarAta={onDadosAtualizados}
           resumoAssembleia={resumoAssembleiaOriginal}
+          dadosPaa={dados}
         />
       )}
       <ModalVisualizarPdf

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaSecaoPlanoEAta/PaaSecaoPlanoEAta.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/components/PaaCard/PaaSecaoPlanoEAta/PaaSecaoPlanoEAta.js
@@ -16,6 +16,7 @@ export const PaaSecaoPlanoEAta = ({
   onDownloadAta,
   onDepoisDeGerarAta,
   resumoAssembleia,
+  dadosPaa
 }) => {
   const chaveDoc = chaveVisualizacaoDocumento(paaUuid, documento.status.retificacao);
   const chaveAta = ata?.uuid ? `ata:${ata.uuid}` : null;
@@ -53,6 +54,7 @@ export const PaaSecaoPlanoEAta = ({
               ata={ata}
               documentoPlano={documento}
               onDepoisDeGerar={onDepoisDeGerarAta}
+              dadosPaa={dadosPaa}
             />
           ) : null}
         </div>

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/hooks/usePaaVigenteEAnteriores.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/hooks/usePaaVigenteEAnteriores.js
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getPaaVigenteEAnteriores } from "../../../../../services/escolas/Paa.service";
+import { toastCustom } from "../../../../Globais/ToastCustom";
 
 export const usePaaVigenteEAnteriores = (associacaoUuid) => {
   const {
@@ -16,6 +18,14 @@ export const usePaaVigenteEAnteriores = (associacaoUuid) => {
     staleTime: 0,
     gcTime: 0,
   });
+  useEffect(() => {
+    if (isError) {
+      toastCustom.ToastCustomError(
+        "Não foi possível carregar o PAA",
+        error?.response?.data?.mensagem || "Falha ao carregar o PAA.",
+      );
+    }
+  }, [isError, error]);
 
   return {
     data,

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/index.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/index.js
@@ -66,7 +66,7 @@ export const PaaVigenteEAnteriores = () => {
                 Não foi possível carregar os dados do PAA.
                 {error?.message ? ` (${error.message})` : ''}
               </div>
-              <button type="button" className="btn btn-outline-primary btn-sm" onClick={() => refetch()}>
+              <button type="button" className="btn btn-success btn-sm" onClick={() => refetch()}>
                 Tentar novamente
               </button>
             </div>

--- a/src/interface/dre/Paa/paa.interface.ts
+++ b/src/interface/dre/Paa/paa.interface.ts
@@ -137,6 +137,7 @@ export interface IVigentePaa {
     unidade: IUnidadeVisualizacaoPaa;
     original: IBlocoDocumentosPaa;
     retificacao: IBlocoDocumentosPaa;
+    exibe_dados_retificacao: boolean;
 }
 export interface IVisualizarDocumentosPaaResponse {
     vigente: IVigentePaa;


### PR DESCRIPTION

Esse PR:

- Adiciona loading em participantes na edição de ata do PAA
- Adiciona loading em presentes na edição de ata do PAA
- Adiciona loading na Ata de Apresentação e de Retificação
- Adiciona loading na tela de atividades estatutárias
- corrige state de origem ao voltar da tela de edição de ata do PAA
- Ajusta Label para Apresentação/Retificação na Modal de confirmação de geração de ata
- exibe_dados_retificados e secao_titulo obtidos do backend para remoção de regra de negócio no frontend
- Ajustes de testes unitários impactados
- Inclusão de testes para cobertura

Fix
- Corrige botão de editar atividades estatutárias quando criada dentro de um PAA, o botão permanecia sem ação após salvar

História [AB#145736](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145736)
