### PR TITLE
bugfix(151318): Desabilita campo classificação de crédito na edição de crédito para PC e períodos fechados.

### DIFF
--- a/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
+++ b/src/componentes/escolas/Receitas/Formularios/ReceitaFormFormik.js
@@ -326,6 +326,7 @@ export const ReceitaFormFormik = ({
                                     <select
                                         id="categoria_receita"
                                         name="categoria_receita"
+                                        disabled={readOnlyEstorno || readOnlyCampos || readOnlyClassificacaoReceita || ![['add_receita'], ['change_receita']].some(visoesService.getPermissoes)}
                                         value={props.values.categoria_receita}
                                         onChange={(e) => {
                                             props.handleChange(e);


### PR DESCRIPTION
Este PR inclui:

- Desabilita campo classificação de crédito na edição de crédito para PC e períodos fechados;
- Validação de testes unitários;

Bug: [AB#151318](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151318)
Tarefa: [AB#152161](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152161)