### PR TITLE
hotfix(151060): melhora mensagem de erro ao editar despesa caso rateios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.41.1",
+  "version": "9.41.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -757,13 +757,8 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
         let mensagemErro = 'Verifique se os dados foram preenchidos corretamente.'
 
         if (response && response.data){
-            if (response.data.hasOwnProperty("rateios")) {
-                const rateios = response.data.rateios[0];
-                mensagemErro += " Rateios: " + rateios.mensagem.map((msg) => msg).join(", ")
-            } else {
-                const error = {response};
-                mensagemErro = getErrorMessage(error, "Ocorreu um erro criar/editar despesa.");
-            }
+            const error = {response};
+            mensagemErro = getErrorMessage(error, "Ocorreu um erro criar/editar despesa.");
         }
         
         toastCustom.ToastCustomError('Erro ao tentar salvar despesa.', mensagemErro)


### PR DESCRIPTION
# O que este PR faz

- Corrige a não disposição do Toast para mensagem de erros em edição da despesa quando se travata de retornos de erros do backend com a chave "rateios" por conta de uma regra legada especifica. A remoção da regra garante o toast de erro de forma centralizada pelo método getErrorMessage.

Referência Azure: [AB#151060](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151060)