### PR TITLE
feat(145736): Ajusta lógica de exibição de botão retificar/Continuar retificação

### DIFF
--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/__tests__/exibirBotaoRetificarPaa.test.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/__tests__/exibirBotaoRetificarPaa.test.js
@@ -50,7 +50,7 @@ describe('podeExibirBotaoRetificar', () => {
     ).toBe(false);
   });
 
-  it('em retificação: true quando documento não está em versão FINAL', () => {
+  it('em retificação: false quando documento não está em versão FINAL', () => {
     expect(
       podeExibirBotaoRetificar({
         ...vigenteBase,
@@ -60,7 +60,7 @@ describe('podeExibirBotaoRetificar', () => {
           documento: { status: { versao: 'PRELIMINAR' } },
         },
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('em retificação: false quando documento está em versão FINAL', () => {

--- a/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/exibirBotaoRetificarPaa.js
+++ b/src/componentes/escolas/Paa/PaaVigenteEAnteriores/utils/exibirBotaoRetificarPaa.js
@@ -20,7 +20,10 @@ export function podeExibirBotaoRetificar(vigente) {
   const regras_podem_continuar_retificacao = [
     visoesService.featureFlagAtiva('paa-retificacao'),
     vigente.esta_em_retificacao,
-    vigente?.retificacao?.documento?.status?.versao !== 'FINAL',
+    // ciclo_retificacao_sem_documento=True indica que o ciclo corrente ainda não gerou
+    // seu próprio documento — o doc exibido pode ser fallback do ciclo anterior (FINAL),
+    // por isso não inferimos o estado via versao do documento.
+    vigente.ciclo_retificacao_sem_documento === true,
   ]
 
   return regras_podem_retificar.every((regra) => regra === true) ||


### PR DESCRIPTION

Esse PR:

- Utiliza prop de serializer do backend para exibir botão de retificação ou continuar retificação na tela de edição de ata do PAA
- Ajusta testes unitários

História [AB#145736](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/145736)
