### PR TITLE
hotfix(151057): remove sobreescrita indevida do campo retem_imposto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.42.0",
+  "version": "9.42.1",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroForm.js
@@ -816,7 +816,6 @@ export const CadastroForm = ({verbo_http, veioDeSituacaoPatrimonial}) => {
             }
             else{
                 setShowRetencaoImposto(false);
-                values.retem_imposto = false;
             }
         }
 

--- a/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
+++ b/src/componentes/escolas/Despesas/CadastroDeDespesas/CadastroFormFormik.js
@@ -259,7 +259,20 @@ export const CadastroFormFormik = ({
                                                     props.values.tipo_documento === "object" ? props.values.tipo_documento.id : props.values.tipo_documento.id
                                                 ) : ""
                                             }
-                                            onChange={props.handleChange}
+                                            onChange={(e) => {                                              
+                                                props.handleChange(e);
+
+                                                if(despesasTabelas && despesasTabelas.tipos_documento) {
+                                                    const documento = despesasTabelas.tipos_documento.find(
+                                                        item => item.id === Number(e.target.value)
+                                                    );
+
+                                                    if (!documento?.pode_reter_imposto) {
+                                                        props.setFieldValue("retem_imposto", false);
+                                                    }
+                                                }
+
+                                            }}
                                             onBlur={props.handleBlur}
                                             name='tipo_documento'
                                             id='tipo_documento'


### PR DESCRIPTION
# O que este PR faz

- remove sobreescrita indevida do campo retem_imposto ao executar validações do formik pela função validateFormDespesas ao editar despesa (Gastos da Escola/Análise DRE).

Referência Azure: [AB#151057](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151057)