### PR TITLE
Feature/151137 busca comissao responsavel analise pc

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/FormularioEditarAta/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/FormularioEditarAta/index.js
@@ -246,6 +246,15 @@ export const FormularioEditaAta = ({
                   <p className="titulo-edicao-ata-presentes mt-4">
                     <strong>Presentes</strong>
                   </p>
+                  
+                  {
+                    values.listaPresentes.length <= 0 && (
+                      <p>
+                        Não há técnicos indicados para a comissão responsável pela análise de prestação de contas.
+                      </p>
+                    )
+                  }
+
                   <FieldArray
                     name="listaPresentes"
                     render={({ remove, push }) => (

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/EdicaoAta/index.js
@@ -6,6 +6,7 @@ import {useParams} from "react-router-dom";
 import { getListaPresentesPadrao, getAtaParecerTecnico, postEdicaoAtaParecerTecnico } from "../../../../../../services/dres/AtasParecerTecnico.service";
 import moment from "moment";
 import {toastCustom} from "../../../../../Globais/ToastCustom"
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 
 moment.updateLocale('pt', {
     months: [
@@ -17,6 +18,7 @@ moment.updateLocale('pt', {
 export const EdicaoAtaParecerTecnico = () => {
     const formRef = useRef();
     let {uuid_ata} = useParams();
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
 
     const [listaPresentesPadrao, setListaPresentesPadrao] = useState([]);
     const [listaPresentes, setListaPresentes] = useState([]);
@@ -61,9 +63,14 @@ export const EdicaoAtaParecerTecnico = () => {
     };
 
     const consultaListaPresentesPadraoAta = async () => {
-        if(dadosAta && dadosAta.dre){
-            let lista_presentes_padrao = await getListaPresentesPadrao(dadosAta.dre.uuid, uuid_ata);
-            setListaPresentesPadrao(lista_presentes_padrao);
+        if(dadosAta && dadosAta.dre && recursoSelecionado?.uuid){
+            try {
+                let lista_presentes_padrao = await getListaPresentesPadrao(dadosAta.dre.uuid, uuid_ata, recursoSelecionado?.uuid);
+                setListaPresentesPadrao(lista_presentes_padrao);
+            } catch (e) {
+                const message = e?.response?.data?.mensagem || "Erro ao consultar lista de presentes padrão da ata";
+                toastCustom.ToastCustomError('Erro ao consultar lista de membros', message)                
+            }
         }
         
     }

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/VisualizacaoAtaParecerTecnico/TextoDinamicoSuperior/index.js
@@ -1,9 +1,14 @@
 import React, { useMemo } from "react";
 import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
 import { TextoDocumentoConsolidadoPC } from "../../../../../../utils/TextoDocumentoConsolidadoPC";
+import { useGetComissaoResponsavelPC } from "../../../hooks/useGetComissaoResponsavelPC";
 
 export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCorpoAta, ehPrevia, ehRetificacao, motivoRetificacao}) => {
     const { recursoSelecionado } = useRecursoSelecionadoContext();
+
+    const { data: comissaoResponsavelPC } = useGetComissaoResponsavelPC({ recurso_uuid: recursoSelecionado?.uuid });
+
+    const comissaoResponsavelPCNome = useMemo(() => comissaoResponsavelPC?.nome || "(Nenhuma comissão responsável pela pc encontrada)", [comissaoResponsavelPC?.nome]);
 
     const texto_documento_consolidado_pc = useMemo(() => new TextoDocumentoConsolidadoPC(recursoSelecionado?.habilita_exibicao_de_lauda), [recursoSelecionado?.habilita_exibicao_de_lauda]);
     const texto_publicacao = texto_documento_consolidado_pc.texto_artigo_a();
@@ -13,7 +18,7 @@ export const TextoDinamicoSuperior = ({retornaDadosAtaFormatado, retornaTituloCo
         const baseLegal = "conforme incisos III e IV do art. 34 da Portaria SME nº 6.634/2021"
 
         const textoBase = `${retornaDadosAtaFormatado("data_reuniao")}, às ${retornaDadosAtaFormatado("hora_reuniao")},
-         reuniu-se a Comissão de Prestação de Contas do PTRF da Diretoria Regional de Educação 
+         reuniu-se a ${comissaoResponsavelPCNome} da Diretoria Regional de Educação 
          ${retornaDadosAtaFormatado("nome_dre")}, instituída pela Portaria DRE-${retornaDadosAtaFormatado("nome_dre")} 
          nº ${retornaDadosAtaFormatado("numero_portaria")} de ${retornaDadosAtaFormatado("data_portaria")},`
 

--- a/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/AtaParecerTecnico/index.js
@@ -7,7 +7,7 @@ import { Tooltip as ReactTooltip } from "react-tooltip";
 import {getDownloadAtaParecerTecnico} from "../../../../services/dres/AtasParecerTecnico.service";
 import {postCriarAtaAtrelarAoConsolidadoDre} from "../../../../services/dres/RelatorioConsolidado.service";
 
-export const AtaParecerTecnico = ({consolidadoDre, podeAcessarInfoConsolidado}) => {
+export const AtaParecerTecnico = ({consolidadoDre, podeAcessarInfoConsolidado, existeComissaoResponsavelPC, }) => {
 
     const onClickVerAta = (uuid_ata) =>{
         window.location.assign(`/visualizacao-da-ata-parecer-tecnico/${uuid_ata}/${consolidadoDre.ja_publicado}`)
@@ -53,8 +53,21 @@ export const AtaParecerTecnico = ({consolidadoDre, podeAcessarInfoConsolidado}) 
         }
     }
 
+    const textoNecessarioComissao = existeComissaoResponsavelPC ? "" : "Não há comissão indicada como responsável pela análise de prestação de contas. Favor entrar em contato com a SME.";
+
+    const getMessageTooltip = () => {
+        if(!existeComissaoResponsavelPC){
+            return textoNecessarioComissao;
+        }
+
+        if (!podeAcessarInfoConsolidado(consolidadoDre)) {
+            return "Não é possível preencher a ata. A análise da(s) prestação(ões) de contas em retificação ainda não foi concluída."
+        }
+
+        return ""
+    }
+
     return (
-        <>
             <div className="rounded-bottom border">
                 <div className='row px-2'>
                     <div className="col-12 col-md-8">
@@ -75,24 +88,30 @@ export const AtaParecerTecnico = ({consolidadoDre, podeAcessarInfoConsolidado}) 
                         </div>
                     </div>
                     <div className="col-12 col-md-4 align-self-center text-right">
-                        {consolidadoDre.ata_de_parecer_tecnico && consolidadoDre.ata_de_parecer_tecnico.uuid ? (
-                            <button
-                                onClick={() => onClickVerAta(consolidadoDre.ata_de_parecer_tecnico.uuid)}
-                                type="button"
-                                className="btn btn-outline-success btn-sm"
-                            >
-                                {consolidadoDre.ja_publicado ? "Consultar" : "Preencher"} ata
-                            </button>
+                        {consolidadoDre.ata_de_parecer_tecnico?.uuid ? (
+                            <>
+                                <button
+                                    onClick={() => onClickVerAta(consolidadoDre.ata_de_parecer_tecnico.uuid)}
+                                    type="button"
+                                    className="btn btn-outline-success btn-sm"
+                                    disabled={!existeComissaoResponsavelPC}
+                                    data-tooltip-id={`tooltip-btn-ata-id-${consolidadoDre.uuid}`}
+                                    data-tooltip-html={textoNecessarioComissao}
+                                >
+                                    {consolidadoDre.ja_publicado ? "Consultar" : "Preencher"} ata
+                                </button>
+                                <ReactTooltip id={`tooltip-btn-ata-id-${consolidadoDre.uuid}`}/>
+                            </>
                             ):
                             <>
                                 <span
                                     data-tooltip-id={`tooltip-id-${consolidadoDre.uuid}`}
-                                    data-tooltip-html={!podeAcessarInfoConsolidado(consolidadoDre) ? "Não é possível preencher a ata. A análise da(s) prestação(ões) de contas em retificação ainda não foi concluída." : ""}>
+                                    data-tooltip-html={getMessageTooltip()}>
                                 <button
                                     onClick={() => criarAtaAtrelarAoConsolidado(consolidadoDre.dre_uuid, consolidadoDre.periodo_uuid, consolidadoDre.uuid ? consolidadoDre.uuid : null)}
                                     type="button"
                                     className="btn btn-outline-success btn-sm"
-                                    disabled={!podeAcessarInfoConsolidado(consolidadoDre)}
+                                    disabled={!podeAcessarInfoConsolidado(consolidadoDre) || !existeComissaoResponsavelPC}
                                 >
                                     Preencher ata
                                 </button>
@@ -103,6 +122,5 @@ export const AtaParecerTecnico = ({consolidadoDre, podeAcessarInfoConsolidado}) 
                     </div>
                 </div>
             </div>
-        </>
     )
 }

--- a/src/componentes/dres/RelatorioConsolidado/BlocoPublicacaoParcial.js
+++ b/src/componentes/dres/RelatorioConsolidado/BlocoPublicacaoParcial.js
@@ -21,7 +21,9 @@ const BlocoPublicacaoParcial = ({
     gerarPreviaRetificacao,
     gerarPreviaConsolidadoDre,
     podeAcessarInfoConsolidado,
-    podeGerarPreviaRetificacao }) => {
+    podeGerarPreviaRetificacao,
+    existeComissaoResponsavelPC,
+}) => {
 
     const [execucaoFinanceiraCarregando, setExecucaoFinanceiraCarregando] = useState(true);
     const [execucaoFinanceira, setExecucaoFinanceira] = useState(false);
@@ -56,6 +58,7 @@ const BlocoPublicacaoParcial = ({
                     gerarPreviaRetificacao={gerarPreviaRetificacao}
                     execucaoFinanceiraCarregando={execucaoFinanceiraCarregando}
                     execucaoFinanceira={execucaoFinanceira}
+                    existeComissaoResponsavelPC={existeComissaoResponsavelPC}
                 >
                     <PreviaDocumentos
                         gerarPreviaConsolidadoDre={gerarPreviaConsolidadoDre}
@@ -72,6 +75,7 @@ const BlocoPublicacaoParcial = ({
                     consolidadoDre={consolidadoDre}
                     podeGerarPreviaRetificacao={podeGerarPreviaRetificacao(consolidadoDre)}
                     podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
+                    existeComissaoResponsavelPC={existeComissaoResponsavelPC}
                 />
                 {
                     isShowLauda &&

--- a/src/componentes/dres/RelatorioConsolidado/PublicarDocumentos.js
+++ b/src/componentes/dres/RelatorioConsolidado/PublicarDocumentos.js
@@ -5,9 +5,26 @@ import BotaoMarcarPublicacaoNoDiarioOficial from "./MarcarPublicacaoNoDiarioOfic
 import {Retificar} from "./Retificar";
 import PreviaDocumentoRetificado from "./PreviaDocumentoRetificado";
 import { Tooltip as ReactTooltip } from "react-tooltip";
+import { Tooltip } from "antd";
 import {visoesService} from "../../../services/visoes.service";
 
-const PublicarDocumentos = ({publicarConsolidadoDre, podeGerarPrevia, children, consolidadoDre, carregaConsolidadosDreJaPublicadosProximaPublicacao, execucaoFinanceira, disableGerar, todasAsPcsDaRetificacaoConcluidas, publicarRetificacao, showPublicarRetificacao, setShowPublicarRetificacao, gerarPreviaRetificacao, removerBtnGerar=false, execucaoFinanceiraCarregando}) => {
+const PublicarDocumentos = ({
+    publicarConsolidadoDre,
+    podeGerarPrevia,
+    children,
+    consolidadoDre,
+    carregaConsolidadosDreJaPublicadosProximaPublicacao,
+    execucaoFinanceira,
+    disableGerar,
+    todasAsPcsDaRetificacaoConcluidas,
+    publicarRetificacao,
+    showPublicarRetificacao,
+    setShowPublicarRetificacao,
+    gerarPreviaRetificacao,
+    removerBtnGerar=false,
+    execucaoFinanceiraCarregando,
+    existeComissaoResponsavelPC,
+}) => {
     const [showPublicarRelatorioConsolidadoPendente, setShowPublicarRelatorioConsolidadoPendente] = useState(false)
     const [alertaJustificativa, setAlertaJustificativa] = useState(true)
     const [showPublicarRelatorioConsolidado, setShowPublicarRelatorioConsolidado] = useState(false)
@@ -37,6 +54,8 @@ const PublicarDocumentos = ({publicarConsolidadoDre, podeGerarPrevia, children, 
         }
     }
 
+    const textoNecessarioComissao = existeComissaoResponsavelPC ? "" : "Não há comissão indicada como responsável pela análise de prestação de contas. Favor entrar em contato com a SME.";
+
     return(
         <>
             <div className="d-flex bd-highlight align-items-center container-publicar-cabecalho text-dark rounded-top border font-weight-bold">
@@ -59,13 +78,15 @@ const PublicarDocumentos = ({publicarConsolidadoDre, podeGerarPrevia, children, 
                         {
                             consolidadoDre.habilita_botao_gerar ? (
                                 <div className="p-2 bd-highlight">
-                                    <button
-                                        onClick={() => handleClick()}
-                                        className="btn btn btn btn-success"
-                                        disabled={disableGerar || !visoesService.getPermissoes(['gerar_relatorio_consolidado_dre'])}
-                                    >
-                                        Gerar
-                                    </button>
+                                    <Tooltip title={textoNecessarioComissao}>
+                                        <button
+                                            onClick={() => handleClick()}
+                                            className="btn btn btn btn-success"
+                                            disabled={!existeComissaoResponsavelPC || disableGerar || !visoesService.getPermissoes(['gerar_relatorio_consolidado_dre'])}
+                                        >
+                                            Gerar
+                                        </button>
+                                    </Tooltip>
                                 </div>
                             ):
 

--- a/src/componentes/dres/RelatorioConsolidado/hooks/useGetComissaoResponsavelPC.js
+++ b/src/componentes/dres/RelatorioConsolidado/hooks/useGetComissaoResponsavelPC.js
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getComissaoResponsavelPC } from "../../../../services/dres/Comissoes.service";
+
+export const useGetComissaoResponsavelPC = ({ recurso_uuid }) => {
+    const { isFetching, isError, data = [], error, refetch } = useQuery({
+        queryKey: ['comissao-responsavel-pc', recurso_uuid],
+        queryFn: ()=> {
+            if (!recurso_uuid) {
+                return Promise.resolve({});
+            }
+
+            return getComissaoResponsavelPC(recurso_uuid)
+        },
+        keepPreviousData: true,
+        staleTime: 5000, // 5 segundos
+        refetchOnWindowFocus: false, // Caso saia da aba e voltar ele refaz a requisição
+        retry: 0,
+    });
+
+    return {isLoading: isFetching, isError, data, error, refetch}
+}

--- a/src/componentes/dres/RelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/index.js
@@ -29,6 +29,8 @@ import {PERIODO_RELATORIO_CONSOLIDADO_DRE} from "../../../services/auth.service"
 import BlocoPublicacaoParcial from "./BlocoPublicacaoParcial"
 import useUnidadeSelecionada from "../../../hooks/Globais/useUnidadeSelecionada";
 import { useRecursoSelecionadoContext } from "../../../context/RecursoSelecionado";
+import { useGetComissaoResponsavelPC } from "./hooks/useGetComissaoResponsavelPC";
+import { toastCustom } from "../../Globais/ToastCustom";
 
 const RelatorioConsolidado = () => {
     const { getUUIDUnidadeSelecionadaTipoDRE } = useUnidadeSelecionada(visoesService)
@@ -57,6 +59,8 @@ const RelatorioConsolidado = () => {
     const [loading, setLoading] = useState(false);
     const [loadingRelatorioConsolidado, setLoadingRelatorioConsolidado] = useState(false);
     const [disableGerar, setDisableGerar] = useState(true);
+
+    const { data: comissaoResponsavelPC } = useGetComissaoResponsavelPC({ recurso_uuid: recursoSelecionado?.uuid });
 
     const carregaPeriodos = useCallback(async () => {
         try {
@@ -306,7 +310,9 @@ const RelatorioConsolidado = () => {
                 await carregaConsolidadosDreJaPublicadosProximaPublicacao()
             }
         } catch (e) {
-            console.log("Erro ao publicar Consolidado Dre ", e)
+            const errorMessage = e?.response?.data?.mensagem || "Erro ao publicar Consolidado Dre.";
+
+            toastCustom.ToastCustomError("Erro ao publicar Consolidado Dre.", errorMessage);
         }
     }
 
@@ -376,6 +382,7 @@ const RelatorioConsolidado = () => {
     };
 
     const isShowLaudaPróximaPublicacao = !consolidadoDreProximaPublicacao?.eh_consolidado_de_publicacoes_parciais && recursoSelecionado?.habilita_exibicao_de_lauda;
+    const existeComissaoResponsavelPC = !!comissaoResponsavelPC?.uuid;
 
     return (
         <PaginasContainer>
@@ -434,6 +441,7 @@ const RelatorioConsolidado = () => {
                                                         setShowPublicarRetificacao={setShowPublicarRetificacao}
                                                         gerarPreviaRetificacao={gerarPreviaRetificacao}
                                                         removerBtnGerar={consolidadoDreProximaPublicacao.eh_consolidado_de_publicacoes_parciais}
+                                                        existeComissaoResponsavelPC={existeComissaoResponsavelPC}
                                                     >
                                                         <PreviaDocumentos
                                                             gerarPreviaConsolidadoDre={gerarPreviaConsolidadoDre}
@@ -449,6 +457,7 @@ const RelatorioConsolidado = () => {
                                                         <AtaParecerTecnico
                                                             consolidadoDre={consolidadoDreProximaPublicacao}
                                                             podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
+                                                            existeComissaoResponsavelPC={existeComissaoResponsavelPC}
                                                         />
                                                     }
                                                     {isShowLaudaPróximaPublicacao &&
@@ -476,6 +485,7 @@ const RelatorioConsolidado = () => {
                                                 podeAcessarInfoConsolidado={podeAcessarInfoConsolidado}
                                                 podeGerarPreviaRetificacao={podeGerarPreviaRetificacao}
                                                 isShowLauda={recursoSelecionado?.habilita_exibicao_de_lauda}
+                                                existeComissaoResponsavelPC={existeComissaoResponsavelPC}
                                             />
                                         )}
                                     </>

--- a/src/services/dres/AtasParecerTecnico.service.js
+++ b/src/services/dres/AtasParecerTecnico.service.js
@@ -16,8 +16,8 @@ export const getInfoContas = async (dre_uuid, periodo_uuid, uuid_ata) => {
     return (await api.get(`api/ata-parecer-tecnico/info-ata/?dre=${dre_uuid}&periodo=${periodo_uuid}&ata=${uuid_ata}`, authHeader())).data
 }
 
-export const getListaPresentesPadrao = async (dre_uuid, ata_uuid) => {
-    return (await api.get(`api/ata-parecer-tecnico/membros-comissao-exame-contas/?dre=${dre_uuid}&ata=${ata_uuid}`, authHeader())).data
+export const getListaPresentesPadrao = async (dre_uuid, ata_uuid, recurso_uuid) => {
+    return (await api.get(`api/ata-parecer-tecnico/membros-comissao-exame-contas/?dre=${dre_uuid}&ata=${ata_uuid}&recurso_uuid=${recurso_uuid}`, authHeader())).data
 }
 
 export const postEdicaoAtaParecerTecnico = async (ata_uuid, payload) => {

--- a/src/services/dres/Comissoes.service.js
+++ b/src/services/dres/Comissoes.service.js
@@ -16,6 +16,13 @@ export const getComissoes = async () => {
     return (await api.get(`api/comissoes/`, authHeader())).data
 };
 
+export const getComissaoResponsavelPC = async (recurso_uuid = null) => {
+    return (await api.get('api/comissoes/comissao-responsavel-analise-pc-por-recurso/', {
+        ...authHeader(),
+        params: { recurso_uuid }
+    })).data
+};
+
 export const getMembrosComissaoFiltro = async (dreUuid, comissaoUuid, nomeOuRf) => {
     if(comissaoUuid){
         return (await api.get(`api/membros-comissoes/?dre__uuid=${dreUuid}&comissao_uuid=${comissaoUuid}&nome_ou_rf=${nomeOuRf}`, authHeader())).data

--- a/src/services/dres/__tests__/AtasParecerTecnico.test.js
+++ b/src/services/dres/__tests__/AtasParecerTecnico.test.js
@@ -60,8 +60,9 @@ describe('Testes para funções de análise', () => {
         api.get.mockResolvedValue({ data: mockData })
         const dre_uuid = '1234'
         const ata_uuid = uuid_ata
-        const result = await getListaPresentesPadrao(dre_uuid, ata_uuid);
-        const url = `api/ata-parecer-tecnico/membros-comissao-exame-contas/?dre=${dre_uuid}&ata=${ata_uuid}`
+        const recurso_uuid = 'recurso-uuid'
+        const result = await getListaPresentesPadrao(dre_uuid, ata_uuid, recurso_uuid);
+        const url = `api/ata-parecer-tecnico/membros-comissao-exame-contas/?dre=${dre_uuid}&ata=${ata_uuid}&recurso_uuid=${recurso_uuid}`
         expect(api.get).toHaveBeenCalledWith( url, authHeader() )
         expect(result).toEqual(mockData);
     });


### PR DESCRIPTION
este PR inclui:

- realiza a busca da comissão responsável via endpoint enviando o recurso como parâmetro;
- desabilita botão de "Gerar" e mostra mensagem de comissão não informada para aquele recurso, caso não tenha comissão para aquele recurso;
- desabilita botão de "Preencher ata" e mostra mensagem de comissão não informada para aquele recurso, caso não tenha comissão para aquele recurso;
- mostra comissão responsável na visualização da ata baseada no novo endpoint;
- mostra mensagem caso não haja técnicos (membros) para aquela comissão;
- ajusta teste unitário;

História: [AB#150333](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150333)
Tarefa: [AB#151137](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151137)