### PR TITLE
hotfix(152426): considera congelamento na obtenção dos saldos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptrf",
-  "version": "9.42.1",
+  "version": "9.42.2",
   "private": true,
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/TabelaReceitasPrevistas.js
+++ b/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/TabelaReceitasPrevistas.js
@@ -3,11 +3,23 @@ import { DataTable } from "primereact/datatable";
 import { useCallback } from "react";
 import { formatMoneyBRL } from "../../../../../utils/money";
 import { EditIconButton } from "../../../../Globais/UI/Button";
+import { usePaaContext } from "../PaaContext";
 
-const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios }) => {
+const TabelaReceitasPrevistas = ({
+  data,
+  handleOpenEditar,
+  totalRecursosProprios,
+}) => {
+  const { paa } = usePaaContext();
+
+  const ehSaldoCongelado = Boolean(paa?.saldo_congelado_em);
+
   const nomeTemplate = useCallback((rowData) => {
     return (
-      <span style={{ color: "var(--color-primary)" }} className="font-weight-bold">
+      <span
+        style={{ color: "var(--color-primary)" }}
+        className="font-weight-bold"
+      >
         {rowData.acao.nome}
       </span>
     );
@@ -15,24 +27,31 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
 
   const getCongeladoOuCapital = (row) => {
     const saldo_congelado_receita_prevista = parseFloat(
-      row?.receitas_previstas_paa?.[0]?.saldo_congelado_capital
-    )
-    return saldo_congelado_receita_prevista || row?.saldos?.saldo_atual_capital
-  }
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_capital,
+    );
+    return ehSaldoCongelado
+      ? saldo_congelado_receita_prevista
+      : row?.saldos?.saldo_atual_capital;
+  };
+
   const getCongeladoOuCusteio = (row) => {
     const saldo_congelado_receita_prevista = parseFloat(
-      row?.receitas_previstas_paa?.[0]?.saldo_congelado_custeio
-    )
-    return saldo_congelado_receita_prevista ||
-            row?.saldos?.saldo_atual_custeio
-  }
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_custeio,
+    );
+    return ehSaldoCongelado
+      ? saldo_congelado_receita_prevista
+      : row?.saldos?.saldo_atual_custeio;
+  };
+
   const getCongeladoOuLivre = (row) => {
     const saldo_congelado_receita_prevista = parseFloat(
-      row?.receitas_previstas_paa?.[0]?.saldo_congelado_livre
-    )
-    const valor_livre = saldo_congelado_receita_prevista || row?.saldos?.saldo_atual_livre
-    return valor_livre < 0 ? 0 : valor_livre
-  }
+      row?.receitas_previstas_paa?.[0]?.saldo_congelado_livre,
+    );
+    const valor_livre = ehSaldoCongelado
+      ? saldo_congelado_receita_prevista
+      : row?.saldos?.saldo_atual_livre;
+    return valor_livre < 0 ? 0 : valor_livre;
+  };
 
   const dataTemplate = useCallback(
     (rowData, column) => {
@@ -41,8 +60,9 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
           return (
             acc +
             (parseFloat(
-              row?.receitas_previstas_paa?.[0]?.previsao_valor_capital
-            ) || 0) + getCongeladoOuCapital(row)
+              row?.receitas_previstas_paa?.[0]?.previsao_valor_capital,
+            ) || 0) +
+            getCongeladoOuCapital(row)
           );
         }, 0);
 
@@ -50,8 +70,9 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
           return (
             acc +
             (parseFloat(
-              row?.receitas_previstas_paa?.[0]?.previsao_valor_custeio
-            ) || 0) + getCongeladoOuCusteio(row)
+              row?.receitas_previstas_paa?.[0]?.previsao_valor_custeio,
+            ) || 0) +
+            getCongeladoOuCusteio(row)
           );
         }, 0);
 
@@ -59,8 +80,9 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
           return (
             acc +
             (parseFloat(
-              row?.receitas_previstas_paa?.[0]?.previsao_valor_livre
-            ) || 0) + getCongeladoOuLivre(row)
+              row?.receitas_previstas_paa?.[0]?.previsao_valor_livre,
+            ) || 0) +
+            getCongeladoOuLivre(row)
           );
         }, 0);
 
@@ -113,9 +135,9 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
           parseFloat(valor_livre),
       };
       const aceitaValorMapping = {
-        valor_capital: 'aceita_capital',
-        valor_custeio: 'aceita_custeio',
-        valor_livre: 'aceita_livre',
+        valor_capital: "aceita_capital",
+        valor_custeio: "aceita_custeio",
+        valor_livre: "aceita_livre",
       };
 
       return (
@@ -124,29 +146,26 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
             formatMoneyBRL(fieldMapping[column.field])
           ) : (
             <>
-              {rowData?.acao?.[aceitaValorMapping?.[column.field]] ?
+              {rowData?.acao?.[aceitaValorMapping?.[column.field]] ? (
                 formatMoneyBRL(fieldMapping[column.field])
-              :
+              ) : (
                 <div className="text-right">-</div>
-              }
+              )}
             </>
           )}
         </div>
       );
     },
-    [data, totalRecursosProprios]
+    [data, totalRecursosProprios],
   );
 
   const acoesTemplate = (rowData) => {
     return !rowData["fixed"] ? (
-      <EditIconButton
-        onClick={() => handleOpenEditar(rowData)}
-      />
+      <EditIconButton onClick={() => handleOpenEditar(rowData)} />
     ) : null;
   };
   const ehColunaDesabilitada = useCallback((rowData, rowIndex, colunaNome) => {
     if (rowData.fixed) return false;
-
 
     return !rowData?.acao[colunaNome];
   }, []);
@@ -156,31 +175,57 @@ const TabelaReceitasPrevistas = ({ data, handleOpenEditar, totalRecursosProprios
       className="tabela-receitas-previstas no-hover"
       value={[...data, { acao: { nome: "Total do PTRF" }, fixed: true }]}
     >
-      <Column field="nome" header="Recursos" body={nomeTemplate} style={{width: '15%'}} />
-      <Column field="valor_custeio" header="Custeio (R$)" body={dataTemplate} style={{width: '15%'}}
-        bodyClassName={(rowData, { rowIndex }) => {
-            return ehColunaDesabilitada(rowData, rowIndex, "aceita_custeio")
-              ? "cell-desativada": "";
-          }}
+      <Column
+        field="nome"
+        header="Recursos"
+        body={nomeTemplate}
+        style={{ width: "15%" }}
       />
-      <Column field="valor_capital" header="Capital (R$)" body={dataTemplate} style={{width: '15%'}}
+      <Column
+        field="valor_custeio"
+        header="Custeio (R$)"
+        body={dataTemplate}
+        style={{ width: "15%" }}
         bodyClassName={(rowData, { rowIndex }) => {
-            return ehColunaDesabilitada(rowData, rowIndex, "aceita_capital")
-              ? "cell-desativada": "";
-          }}
+          return ehColunaDesabilitada(rowData, rowIndex, "aceita_custeio")
+            ? "cell-desativada"
+            : "";
+        }}
+      />
+      <Column
+        field="valor_capital"
+        header="Capital (R$)"
+        body={dataTemplate}
+        style={{ width: "15%" }}
+        bodyClassName={(rowData, { rowIndex }) => {
+          return ehColunaDesabilitada(rowData, rowIndex, "aceita_capital")
+            ? "cell-desativada"
+            : "";
+        }}
       />
       <Column
         field="valor_livre"
         header="Livre Aplicação (R$)"
         body={dataTemplate}
-        style={{width: '20%'}}
+        style={{ width: "20%" }}
         bodyClassName={(rowData, { rowIndex }) => {
           return ehColunaDesabilitada(rowData, rowIndex, "aceita_livre")
-            ? "cell-desativada": "";
+            ? "cell-desativada"
+            : "";
         }}
       />
-      <Column field="total" header="Total (R$)" body={dataTemplate} style={{width: '15%', fontWeight: 'bold'}} />
-      <Column field="acoes" header="Ações" body={acoesTemplate} style={{width: '10%'}} />
+      <Column
+        field="total"
+        header="Total (R$)"
+        body={dataTemplate}
+        style={{ width: "15%", fontWeight: "bold" }}
+      />
+      <Column
+        field="acoes"
+        header="Ações"
+        body={acoesTemplate}
+        style={{ width: "10%" }}
+      />
     </DataTable>
   );
 };

--- a/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/__tests__/TabelaReceitasPrevistas.test.js
+++ b/src/componentes/escolas/Paa/componentes/ReceitasPrevistas/__tests__/TabelaReceitasPrevistas.test.js
@@ -3,6 +3,7 @@ import { render, screen, renderHook, fireEvent } from "@testing-library/react";
 import { useGetAcoesAssociacao } from "../hooks/useGetAcoesAssociacao";
 import TabelaReceitasPrevistas from "../TabelaReceitasPrevistas";
 import { useGetProgramasPddeTotais } from "../hooks/useGetProgramasPddeTotais";
+import { PaaContext } from "../../PaaContext";
 
 jest.mock("../hooks/useGetAcoesAssociacao", () => ({
   useGetAcoesAssociacao: jest.fn(),
@@ -17,6 +18,16 @@ jest.mock("../ReceitasPrevistasModalForm", () => () => (
 ));
 
 const mockHandleOpenEditar = jest.fn();
+
+const renderTabelaReceitasPrevistas = (paaOverride = null, extraProps = {}) => {
+  const paa = paaOverride;
+
+  return render(
+    <PaaContext.Provider value={{ paa, refetch: jest.fn() }}>
+      <TabelaReceitasPrevistas {...extraProps} />
+    </PaaContext.Provider>,
+  );
+};
 
 describe("TabelaReceitasPrevistas Component", () => {
   beforeEach(() => {
@@ -41,11 +52,9 @@ describe("TabelaReceitasPrevistas Component", () => {
 
     const { result } = renderHook(() => useGetAcoesAssociacao());
 
-    render(
-      <TabelaReceitasPrevistas
-        data={result.current.data}
-        handleOpenEditar={mockHandleOpenEditar}
-      />
+    renderTabelaReceitasPrevistas(
+      { saldo_congelado_em: null },
+      { data: result.current.data, handleOpenEditar: mockHandleOpenEditar },
     );
 
     expect(screen.getAllByText("Recurso 1").length).toBeGreaterThan(0);
@@ -66,12 +75,9 @@ describe("TabelaReceitasPrevistas Component", () => {
     });
 
     const { result } = renderHook(() => useGetAcoesAssociacao());
-
-    render(
-      <TabelaReceitasPrevistas
-        data={result.current.data}
-        handleOpenEditar={mockHandleOpenEditar}
-      />
+    renderTabelaReceitasPrevistas(
+      { saldo_congelado_em: null },
+      { data: result.current.data, handleOpenEditar: mockHandleOpenEditar },
     );
 
     expect(screen.queryByLabelText("Editar")).not.toBeInTheDocument();
@@ -91,12 +97,11 @@ describe("TabelaReceitasPrevistas Component", () => {
 
     const { result } = renderHook(() => useGetAcoesAssociacao());
 
-    render(
-      <TabelaReceitasPrevistas
-        data={result.current.data}
-        handleOpenEditar={mockHandleOpenEditar}
-      />
+    renderTabelaReceitasPrevistas(
+      { saldo_congelado_em: null },
+      { data: result.current.data, handleOpenEditar: mockHandleOpenEditar },
     );
+
     expect(screen.getByLabelText("Editar")).toBeInTheDocument();
   });
 
@@ -114,11 +119,9 @@ describe("TabelaReceitasPrevistas Component", () => {
 
     const { result } = renderHook(() => useGetAcoesAssociacao());
 
-    render(
-      <TabelaReceitasPrevistas
-        data={result.current.data}
-        handleOpenEditar={mockHandleOpenEditar}
-      />
+    renderTabelaReceitasPrevistas(
+      { saldo_congelado_em: null },
+      { data: result.current.data, handleOpenEditar: mockHandleOpenEditar },
     );
 
     const editarButton = await screen.findByRole("button", { name: /editar/i });
@@ -126,4 +129,86 @@ describe("TabelaReceitasPrevistas Component", () => {
 
     expect(mockHandleOpenEditar).toHaveBeenCalled();
   });
+
+  it("deve utilizar o saldo congelado quando o PAA estiver congelado", () => {
+    renderTabelaReceitasPrevistas(
+      {
+        saldo_congelado_em: "2026-07-15T10:00:00",
+      },
+      {
+        data: [
+          {
+            uuid: "acao-1",
+            fixed: false,
+            acao: {
+              nome: "Minha ação",
+              aceita_capital: true,
+              aceita_custeio: true,
+              aceita_livre: true,
+            },
+            saldos: {
+              saldo_atual_capital: 100,
+              saldo_atual_custeio: 100,
+              saldo_atual_livre: 100,
+            },
+            receitas_previstas_paa: [
+              {
+                previsao_valor_capital: "0",
+                previsao_valor_custeio: "0",
+                previsao_valor_livre: "0",
+                saldo_congelado_capital: "200",
+                saldo_congelado_custeio: "300",
+                saldo_congelado_livre: "400",
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(screen.getAllByText(/200,00/)).toHaveLength(2);
+    expect(screen.getAllByText(/300,00/)).toHaveLength(2);
+    expect(screen.getAllByText(/400,00/)).toHaveLength(2);
+  });
+});
+
+it("deve utilizar o saldo atual quando o PAA não estiver congelado", () => {
+  renderTabelaReceitasPrevistas(
+    {
+      saldo_congelado_em: null,
+    },
+    {
+      data: [
+        {
+          uuid: "acao-1",
+          fixed: false,
+          acao: {
+            nome: "Minha ação",
+            aceita_capital: true,
+            aceita_custeio: true,
+            aceita_livre: true,
+          },
+          saldos: {
+            saldo_atual_capital: 100,
+            saldo_atual_custeio: 110,
+            saldo_atual_livre: 120,
+          },
+          receitas_previstas_paa: [
+            {
+              previsao_valor_capital: "0",
+              previsao_valor_custeio: "0",
+              previsao_valor_livre: "0",
+              saldo_congelado_capital: "200",
+              saldo_congelado_custeio: "300",
+              saldo_congelado_livre: "400",
+            },
+          ],
+        },
+      ],
+    },
+  );
+
+  expect(screen.getAllByText(/100,00/)).toHaveLength(2);
+  expect(screen.getAllByText(/110,00/)).toHaveLength(2);
+  expect(screen.getAllByText(/120,00/)).toHaveLength(2);
 });


### PR DESCRIPTION
# O que este PR faz
- Na tabela de Receitas Previstas/PAA, foi ajustada a obtenção dos saldos para considerar o estado de congelamento do PAA. Quando o PAA estiver congelado, passam a ser utilizados os valores congelados da ReceitaPrevistaPaa, inclusive quando forem iguais a zero. Caso contrário, são utilizados os saldos correntes.

Referência Azure: [AB#152426](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152426)