### PR TITLE
tec(151118): Implementa refresh token no login

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { Rotas } from "./rotas";
 import "primereact/resources/themes/saga-blue/theme.css";
@@ -12,6 +12,7 @@ import Modal from "./componentes/Globais/Modal/Modal";
 import { useTheme } from "./context/Tema";
 import { useRecursoSelecionadoContext } from "./context/RecursoSelecionado";
 import { authService } from "./services/auth.service";
+import Loading from "./utils/Loading";
 
 export const App = () => {
   const pathName = useLocation().pathname;
@@ -29,12 +30,20 @@ export const App = () => {
   const PUBLIC_PATHS = ["/login", "/login-suporte", "/esqueci-minha-senha/"];
   const isPublicPath = PUBLIC_PATHS.includes(pathName) || pathName.match(/\/redefinir-senha\//);
 
+  // Enquanto true, a tela fica em loading para evitar renderizar com permissões
+  // desatualizadas do localStorage antes do "/me" responder.
+  const [carregandoPermissoes, setCarregandoPermissoes] = useState(
+    () => !isPublicPath && authService.isLoggedIn()
+  );
+
   // Atualiza permissões e grupos do usuário a cada reload da página.
   // Dependência vazia ([]) garante execução apenas no mount — não a cada navegação,
   // evitando chamadas repetidas ao backend durante a sessão.
   useEffect(() => {
     if (!isPublicPath && authService.isLoggedIn()) {
-      authService.refreshUserData();
+      authService.refreshUserData().finally(() => setCarregandoPermissoes(false));
+    } else {
+      setCarregandoPermissoes(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -43,7 +52,17 @@ export const App = () => {
     <>
       <ToastContainer />
       <section role="main" id="main" className="row">
-        {pathName === "/login" ||
+        {!isPublicPath && carregandoPermissoes ? (
+          <div style={{ justifySelf: "center", alignItems: "center", width: "100%" }}>
+            <Loading
+              style={{ paddingTop: "200px" }}
+              corGrafico="black"
+              corFonte="dark"
+              marginTop="0"
+              marginBottom="0"
+            />
+          </div>
+        ) : pathName === "/login" ||
         pathName === "/login-suporte" ||
         pathName === "/esqueci-minha-senha/" ||
         pathName.match(/\/redefinir-senha\/[a-zA-Z0-9]/) ? (

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { ToastContainer } from "react-toastify";
 import Modal from "./componentes/Globais/Modal/Modal";
 import { useTheme } from "./context/Tema";
 import { useRecursoSelecionadoContext } from "./context/RecursoSelecionado";
+import { authService } from "./services/auth.service";
 
 export const App = () => {
   const pathName = useLocation().pathname;
@@ -24,6 +25,19 @@ export const App = () => {
       setTheme(recursoSelecionado.cor);
     }
   }, [recursoSelecionado, theme]);
+
+  const PUBLIC_PATHS = ["/login", "/login-suporte", "/esqueci-minha-senha/"];
+  const isPublicPath = PUBLIC_PATHS.includes(pathName) || pathName.match(/\/redefinir-senha\//);
+
+  // Atualiza permissões e grupos do usuário a cada reload da página.
+  // Dependência vazia ([]) garante execução apenas no mount — não a cada navegação,
+  // evitando chamadas repetidas ao backend durante a sessão.
+  useEffect(() => {
+    if (!isPublicPath && authService.isLoggedIn()) {
+      authService.refreshUserData();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/src/hooks/Globais/__tests__/useDocumentoFinalPaa.test.js
+++ b/src/hooks/Globais/__tests__/useDocumentoFinalPaa.test.js
@@ -4,6 +4,7 @@ import api from '../../../services/api';
 
 jest.mock('../../../services/api', () => ({
     get: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 jest.mock('../../../services/auth.service', () => ({

--- a/src/services/__tests__/CentralDeDownload.test.js
+++ b/src/services/__tests__/CentralDeDownload.test.js
@@ -16,6 +16,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/__tests__/Core.test.js
+++ b/src/services/__tests__/Core.test.js
@@ -12,6 +12,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/__tests__/Dashboard.test.js
+++ b/src/services/__tests__/Dashboard.test.js
@@ -13,6 +13,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/__tests__/GestaoDePerfis.test.js
+++ b/src/services/__tests__/GestaoDePerfis.test.js
@@ -26,6 +26,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/__tests__/GestaoDeUsuarios.test.js
+++ b/src/services/__tests__/GestaoDeUsuarios.test.js
@@ -24,6 +24,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const URL_GRUPOS = '/api/grupos/';

--- a/src/services/__tests__/Mandatos.test.js
+++ b/src/services/__tests__/Mandatos.test.js
@@ -26,6 +26,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/MotivosRejeicaoEncerramentoConta.test.js
+++ b/src/services/__tests__/MotivosRejeicaoEncerramentoConta.test.js
@@ -13,6 +13,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/Notificacoes.test.js
+++ b/src/services/__tests__/Notificacoes.test.js
@@ -21,6 +21,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/Paa.test.js
+++ b/src/services/__tests__/Paa.test.js
@@ -4,6 +4,7 @@ import { TOKEN_ALIAS } from '../auth.service.js';
 
 jest.mock('../api', () => ({
     get: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/SuporteAsUnidades.test.js
+++ b/src/services/__tests__/SuporteAsUnidades.test.js
@@ -10,6 +10,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/ValoresReprogramados.test.js
+++ b/src/services/__tests__/ValoresReprogramados.test.js
@@ -15,6 +15,7 @@ jest.mock('../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/__tests__/auth.service.test.js
+++ b/src/services/__tests__/auth.service.test.js
@@ -54,6 +54,7 @@ jest.mock('../api', () => ({
     get: jest.fn(),
     put: jest.fn(),
     patch: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 jest.mock('../mantemEstadoAcompanhamentoDePc.service', () => ({

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -11,6 +11,15 @@ const Api = axios.create({
   baseURL: API_URL
 });
 
+// auth.service importa api, então api não pode importar auth.service diretamente.
+// O handler é registrado em runtime (auth.service chama registerUnauthorizedHandler(logout)
+// no nível do módulo) resolvendo a dependência circular sem acoplamento em tempo de importação.
+let unauthorizedHandler = null;
+
+export const registerUnauthorizedHandler = (handler) => {
+  unauthorizedHandler = handler;
+};
+
 // Interceptor para adicionar uuid do recurso selecionado como header
 Api.interceptors.request.use(
   (config) => {
@@ -18,9 +27,9 @@ Api.interceptors.request.use(
     if (config.url && (config.url.includes('/login') || config.url.includes('/logout'))) {
       return config;
     }
-    
+
     const recursoSelecionado = recursoSelecionadoStorageService.getRecursoSelecionado();
-    
+
     if (recursoSelecionado) {
       try {
         const recurso = recursoSelecionado;
@@ -31,11 +40,89 @@ Api.interceptors.request.use(
         console.warn('Erro ao processar recurso selecionado:', error);
       }
     }
-    
+
     return config;
   },
   (error) => {
     return Promise.reject(error);
+  }
+);
+
+// isRefreshing evita que múltiplas requisições simultâneas com token expirado
+// disparem múltiplos POSTs em /api/token/refresh. A fila acumula as demais
+// enquanto o refresh está em andamento e as resolve/rejeita em bloco ao final.
+let isRefreshing = false;
+let failedQueue = [];
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) reject(error);
+    else resolve(token);
+  });
+  failedQueue = [];
+};
+
+const callUnauthorizedHandler = () => {
+  if (unauthorizedHandler) unauthorizedHandler();
+  else window.location.assign('/login');
+};
+
+const enqueueRequest = (originalRequest) =>
+  new Promise((resolve, reject) => {
+    failedQueue.push({ resolve, reject });
+  }).then((token) => {
+    originalRequest.headers['Authorization'] = `JWT ${token}`;
+    return Api(originalRequest);
+  });
+
+Api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // POST /login com credenciais erradas retorna 401 — não deve acionar refresh.
+    // GET /me e demais rotas autenticadas devem tentar refresh normalmente.
+    // token/refresh falhando com 401 significa refresh expirado — não deve recursar.
+    // _retry impede loop infinito caso o novo token também retorne 401.
+    const isAuthEndpoint =
+      (originalRequest?.url?.includes('/login') && originalRequest?.method?.toLowerCase() === 'post') ||
+      originalRequest?.url?.includes('token/refresh');
+
+    if (error.response?.status !== 401 || isAuthEndpoint || originalRequest?._retry) {
+      return Promise.reject(error);
+    }
+
+    if (isRefreshing) {
+      return enqueueRequest(originalRequest);
+    }
+
+    originalRequest._retry = true;
+    isRefreshing = true;
+
+    const refresh = localStorage.getItem('REFRESH_TOKEN');
+
+    if (!refresh) {
+      // Sem refresh token armazenado: sessão inválida, força novo login.
+      isRefreshing = false;
+      callUnauthorizedHandler();
+      return Promise.reject(error);
+    }
+
+    try {
+      const { data } = await Api.post('api/token/refresh', { refresh });
+      const newToken = data.access;
+      localStorage.setItem('TOKEN', newToken);
+      Api.defaults.headers.common['Authorization'] = `JWT ${newToken}`;
+      originalRequest.headers['Authorization'] = `JWT ${newToken}`;
+      processQueue(null, newToken);
+      return Api(originalRequest);
+    } catch (refreshError) {
+      processQueue(refreshError, null);
+      callUnauthorizedHandler();
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
   }
 );
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,4 +1,4 @@
-import api from './api';
+import api, { registerUnauthorizedHandler } from './api';
 import HTTP_STATUS from "http-status-codes";
 import {DATA_HORA_USUARIO_LOGADO, visoesService} from "./visoes.service";
 import {mantemEstadoAcompanhamentoDePc as meapcservice} from "./mantemEstadoAcompanhamentoDePc.service";
@@ -26,6 +26,8 @@ export const PERIODO_RELATORIO_CONSOLIDADO_DRE = "PERIODO_RELATORIO_CONSOLIDADO_
 export const PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO = "PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO"
 export const ACESSO_MODO_SUPORTE = "ACESSO_MODO_SUPORTE";
 export const RECURSO_SELECIONADO = "RECURSO_SELECIONADO";
+// Token de longa duração (X(h), definido em backend) usado para renovar o access token sem novo login.
+export const REFRESH_TOKEN_ALIAS = "REFRESH_TOKEN";
 
 const authHeader = {
     'Content-Type': 'application/json'
@@ -47,6 +49,9 @@ const setDataLogin = async ()=>{
         const duration = moment.duration(now.diff(past)); // Calcula diferença entre datas
         const days = duration.asDays(); // Mostra a diferença em dias
         if (days >= 1){
+            // Limpa caches de estado que podem carregar dados de um dia anterior.
+            // Não chama logout() aqui: o usuário acaba de autenticar com sucesso,
+            // redirecionar seria descartar o token recém-obtido do servidor.
             localStorage.removeItem('DADOS_USUARIO_LOGADO');
             localStorage.removeItem(ACOMPANHAMENTO_DE_PC);
             localStorage.removeItem(ACOMPANHAMENTO_PC_UNIDADE);
@@ -55,7 +60,6 @@ const setDataLogin = async ()=>{
             localStorage.removeItem(PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO);
             localStorage.setItem(DATA_LOGIN, moment(new Date(), "YYYY-MM-DD").format("YYYY-MM-DD"));
             localStorage.setItem(DATA_HORA_USUARIO_LOGADO, data_hora_atual);
-            await logout();
         }
     }else {
         localStorage.setItem(DATA_LOGIN, moment(new Date(), "YYYY-MM-DD").format("YYYY-MM-DD"))
@@ -83,6 +87,9 @@ const login = async (login, senha, suporte=false) => {
             localStorage.setItem(ACESSO_MODO_SUPORTE, suporte ? true : false);
 
             localStorage.setItem(TOKEN_ALIAS, resp.token);
+            if (resp.refresh) {
+                localStorage.setItem(REFRESH_TOKEN_ALIAS, resp.refresh);
+            }
             localStorage.setItem(
                 USUARIO_NOME,
                 resp.nome
@@ -130,7 +137,21 @@ const login = async (login, senha, suporte=false) => {
 const isLoggedIn = () => {
     const token = localStorage.getItem(TOKEN_ALIAS);
     return !!token;
-  };
+};
+
+// Busca permissões, visões e feature flags atualizados do backend e sobrescreve
+// o cache do localStorage. Chamado no mount do App para evitar que um reload
+// sirva dados desatualizados (ex.: permissões revogadas desde o último login).
+// Falhas são silenciosas para não bloquear a navegação do usuário.
+const refreshUserData = async () => {
+    const suporte = localStorage.getItem(ACESSO_MODO_SUPORTE) === 'true';
+    try {
+        const response = await api.get(`api/me?suporte=${suporte}`, authHeaderAuthorization());
+        await visoesService.setDadosUsuariosLogados(response.data, suporte);
+    } catch (error) {
+        console.warn('Erro ao atualizar dados do usuário', error?.response?.data);
+    }
+};
 
 const getToken = () => {
     let token = localStorage.getItem(TOKEN_ALIAS);
@@ -154,55 +175,48 @@ const limparStorageAoTrocarRecurso = () => {
     localStorage.removeItem(PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO);
 };
 
-const logout = () => {
-    localStorage.removeItem(TOKEN_ALIAS);
-    localStorage.removeItem(USUARIO_NOME);
-    localStorage.removeItem(ASSOCIACAO_UUID);
-    localStorage.removeItem(ASSOCIACAO_NOME);
-    localStorage.removeItem(ASSOCIACAO_NOME_ESCOLA);
-    localStorage.removeItem(ASSOCIACAO_TIPO_ESCOLA);
-    localStorage.removeItem('periodoConta');
-    localStorage.removeItem('uuidPrestacaoConta');
-    localStorage.removeItem('periodoPrestacaoDeConta');
-    localStorage.removeItem('statusPrestacaoDeConta');
-    localStorage.removeItem('contaPrestacaoDeConta');
-    localStorage.removeItem('acaoLancamento');
-    localStorage.removeItem('uuidAta');
-    localStorage.removeItem('prestacao_de_contas_nao_apresentada');
-    localStorage.removeItem(STORAGE_KEY_PERIODO_CONTA_GERACAO_DOCUMENTOS);
-    localStorage.removeItem(USUARIO_EMAIL);
-    localStorage.removeItem(USUARIO_LOGIN);
-    localStorage.removeItem(USUARIO_CPF);
-    localStorage.removeItem(DADOS_DA_ASSOCIACAO);
-    localStorage.removeItem(PERIODO_RELATORIO_CONSOLIDADO_DRE);
-    localStorage.removeItem(PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO);
-    window.location.assign("/login")
+const STORAGE_KEYS_SESSAO = [
+    TOKEN_ALIAS,
+    REFRESH_TOKEN_ALIAS,
+    USUARIO_NOME,
+    USUARIO_EMAIL,
+    USUARIO_LOGIN,
+    USUARIO_CPF,
+    ASSOCIACAO_UUID,
+    ASSOCIACAO_NOME,
+    ASSOCIACAO_NOME_ESCOLA,
+    ASSOCIACAO_TIPO_ESCOLA,
+    DADOS_DA_ASSOCIACAO,
+    PERIODO_RELATORIO_CONSOLIDADO_DRE,
+    PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO,
+    STORAGE_KEY_PERIODO_CONTA_GERACAO_DOCUMENTOS,
+    'periodoConta',
+    'uuidPrestacaoConta',
+    'periodoPrestacaoDeConta',
+    'statusPrestacaoDeConta',
+    'contaPrestacaoDeConta',
+    'acaoLancamento',
+    'uuidAta',
+    'prestacao_de_contas_nao_apresentada',
+];
+
+const limparStorageSessao = () => {
+    STORAGE_KEYS_SESSAO.forEach(key => localStorage.removeItem(key));
 };
 
+const logout = () => {
+    limparStorageSessao();
+    window.location.assign("/login");
+};
+
+registerUnauthorizedHandler(logout);
+
 const logoutToSuporte = () => {
+    // Remove também DADOS_USUARIO_LOGADO, mantido pelo logout normal
+    // para permitir restaurar a sessão do usuário original ao retornar do suporte.
     localStorage.removeItem('DADOS_USUARIO_LOGADO');
-    localStorage.removeItem(TOKEN_ALIAS);
-    localStorage.removeItem(USUARIO_NOME);
-    localStorage.removeItem(ASSOCIACAO_UUID);
-    localStorage.removeItem(ASSOCIACAO_NOME);
-    localStorage.removeItem(ASSOCIACAO_NOME_ESCOLA);
-    localStorage.removeItem(ASSOCIACAO_TIPO_ESCOLA);
-    localStorage.removeItem('periodoConta');
-    localStorage.removeItem('uuidPrestacaoConta');
-    localStorage.removeItem('periodoPrestacaoDeConta');
-    localStorage.removeItem('statusPrestacaoDeConta');
-    localStorage.removeItem('contaPrestacaoDeConta');
-    localStorage.removeItem('acaoLancamento');
-    localStorage.removeItem('uuidAta');
-    localStorage.removeItem('prestacao_de_contas_nao_apresentada');
-    localStorage.removeItem(STORAGE_KEY_PERIODO_CONTA_GERACAO_DOCUMENTOS);
-    localStorage.removeItem(USUARIO_EMAIL);
-    localStorage.removeItem(USUARIO_LOGIN);
-    localStorage.removeItem(USUARIO_CPF);
-    localStorage.removeItem(DADOS_DA_ASSOCIACAO);
-    localStorage.removeItem(PERIODO_RELATORIO_CONSOLIDADO_DRE);
-    localStorage.removeItem(PERIODO_SELECIONADO_DRE_ACOMPANHAMENTO);
-    window.location.assign("/login-suporte")
+    limparStorageSessao();
+    window.location.assign("/login-suporte");
 };
 
 
@@ -229,6 +243,7 @@ export const authService = {
     logoutToSuporte,
     getToken,
     isLoggedIn,
+    refreshUserData,
     esqueciMinhaSenha,
     limparStorageAoTrocarRecurso
 };

--- a/src/services/dres/__tests__/ApoioDiretoria.test.js
+++ b/src/services/dres/__tests__/ApoioDiretoria.test.js
@@ -11,6 +11,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Associacoes.test.js
+++ b/src/services/dres/__tests__/Associacoes.test.js
@@ -32,6 +32,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/AtasParecerTecnico.test.js
+++ b/src/services/dres/__tests__/AtasParecerTecnico.test.js
@@ -14,6 +14,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Atribuicoes.test.js
+++ b/src/services/dres/__tests__/Atribuicoes.test.js
@@ -15,6 +15,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Comissoes.test.js
+++ b/src/services/dres/__tests__/Comissoes.test.js
@@ -15,6 +15,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Dashboard.test.js
+++ b/src/services/dres/__tests__/Dashboard.test.js
@@ -11,6 +11,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Laudas.test.js
+++ b/src/services/dres/__tests__/Laudas.test.js
@@ -10,6 +10,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/PrestacaoDeContas.test.js
+++ b/src/services/dres/__tests__/PrestacaoDeContas.test.js
@@ -96,6 +96,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/PrestacaoDeContasReprovadaNaoApresentacao.test.js
+++ b/src/services/dres/__tests__/PrestacaoDeContasReprovadaNaoApresentacao.test.js
@@ -12,6 +12,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/ProcessosAssociacao.test.js
+++ b/src/services/dres/__tests__/ProcessosAssociacao.test.js
@@ -13,6 +13,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/RegularidadeUnidadeEducacionao.test.js
+++ b/src/services/dres/__tests__/RegularidadeUnidadeEducacionao.test.js
@@ -11,6 +11,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/RelatorioConsolidado.test.js
+++ b/src/services/dres/__tests__/RelatorioConsolidado.test.js
@@ -51,6 +51,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/TecnicosDre.test.js
+++ b/src/services/dres/__tests__/TecnicosDre.test.js
@@ -15,6 +15,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/Unidades.test.js
+++ b/src/services/dres/__tests__/Unidades.test.js
@@ -19,6 +19,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/dres/__tests__/ValoresReprogramadosDre.test.js
+++ b/src/services/dres/__tests__/ValoresReprogramadosDre.test.js
@@ -12,6 +12,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/AnaliseDaDre.test.js
+++ b/src/services/escolas/__tests__/AnaliseDaDre.test.js
@@ -3,7 +3,8 @@ import { getListaDeAnalises, getListaDeAnalisesFiltros } from '../AnaliseDaDre.s
 import { TOKEN_ALIAS } from '../../auth.service.js';
 
 jest.mock('../../api', () => ({
-    get: jest.fn()
+    get: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/Associacao.test.js
+++ b/src/services/escolas/__tests__/Associacao.test.js
@@ -41,6 +41,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 jest.mock('../../../utils/AssociacaoUtils.js', () => ({

--- a/src/services/escolas/__tests__/AtasAssocicao.test.js
+++ b/src/services/escolas/__tests__/AtasAssocicao.test.js
@@ -18,6 +18,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/AtasPaa.test.js
+++ b/src/services/escolas/__tests__/AtasPaa.test.js
@@ -8,6 +8,7 @@ import { TOKEN_ALIAS } from '../../auth.service.js';
 
 jest.mock('../../api', () => ({
   get: jest.fn(),
+  registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/escolas/__tests__/BensProduzidos.service.test.js
+++ b/src/services/escolas/__tests__/BensProduzidos.service.test.js
@@ -8,6 +8,7 @@ import {
 jest.mock('../../api', () => ({
     get: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/escolas/__tests__/DemonstrativoFinanceiro.test.js
+++ b/src/services/escolas/__tests__/DemonstrativoFinanceiro.test.js
@@ -15,6 +15,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/Despesas.test.js
+++ b/src/services/escolas/__tests__/Despesas.test.js
@@ -31,6 +31,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 jest.mock('../../../utils/AssociacaoUtils.js', () => ({

--- a/src/services/escolas/__tests__/Paa.test.js
+++ b/src/services/escolas/__tests__/Paa.test.js
@@ -70,6 +70,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/PaaAtividades.test.js
+++ b/src/services/escolas/__tests__/PaaAtividades.test.js
@@ -12,6 +12,7 @@ import { TOKEN_ALIAS } from '../../auth.service';
 jest.mock('../../api', () => ({
   get: jest.fn(),
   patch: jest.fn(),
+  registerUnauthorizedHandler: jest.fn(),
 }));
 
 const mockToken = 'fake-token';

--- a/src/services/escolas/__tests__/PresentesAta.test.js
+++ b/src/services/escolas/__tests__/PresentesAta.test.js
@@ -16,6 +16,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/PrestacaoDeContas.test.js
+++ b/src/services/escolas/__tests__/PrestacaoDeContas.test.js
@@ -53,6 +53,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/RateiosDespesas.test.js
+++ b/src/services/escolas/__tests__/RateiosDespesas.test.js
@@ -15,6 +15,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/Receitas.test.js
+++ b/src/services/escolas/__tests__/Receitas.test.js
@@ -28,6 +28,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/RelacaoDeBens.test.js
+++ b/src/services/escolas/__tests__/RelacaoDeBens.test.js
@@ -13,6 +13,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/TabelaValoresPendentesPorAcao.test.js
+++ b/src/services/escolas/__tests__/TabelaValoresPendentesPorAcao.test.js
@@ -8,6 +8,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/escolas/__tests__/ValoresReprogramados.test.js
+++ b/src/services/escolas/__tests__/ValoresReprogramados.test.js
@@ -12,6 +12,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/sme/__tests__/AcompanhamentoSME.test.js
+++ b/src/services/sme/__tests__/AcompanhamentoSME.test.js
@@ -25,6 +25,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/sme/__tests__/ConsultaDeSaldosBancarios.test.js
+++ b/src/services/sme/__tests__/ConsultaDeSaldosBancarios.test.js
@@ -17,6 +17,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/sme/__tests__/DashboardSme.test.js
+++ b/src/services/sme/__tests__/DashboardSme.test.js
@@ -20,6 +20,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/sme/__tests__/ExtracaoDados.test.js
+++ b/src/services/sme/__tests__/ExtracaoDados.test.js
@@ -8,6 +8,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 

--- a/src/services/sme/__tests__/Parametrizacoes.test.js
+++ b/src/services/sme/__tests__/Parametrizacoes.test.js
@@ -161,6 +161,7 @@ jest.mock('../../api', () => ({
     patch: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    registerUnauthorizedHandler: jest.fn(),
 }));
 
 


### PR DESCRIPTION

Esse PR:

- loading ao carregar dados do usuário logado (f5 na página), permitindo atualização de flags e permissões em localstorage
  - Somente para rotas privadas
- lista STORAGE_KEYS_SESSAO criada para reutilização em logout() e logoutToSuporte(), antes com código duplicado
- Adiciona interceptor pare refresh token quando expirado o refresh/token
- Ajusta testes unitários impactados

História [AB#151118](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151118)
