### PR TITLE
feature(152458): Melhorias na visualização da Ata do PAA e ajustes em funcionalidades relacionadas

### DIFF
--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/__tests__/index.test.js
@@ -1,0 +1,199 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { NovoFormularioEditaAta } from "../index";
+
+import {
+    getParticipantesOrdenadosPorCargoPaa,
+    getListaPresentesPadraoPaa,
+} from "../../../../../../../services/escolas/PresentesAtaPaa.service";
+
+import { getCargosComposicaoData } from "../../../../../../../services/Mandatos.service";
+
+import * as utils from "../../utils";
+
+jest.mock(
+    "../../../../../../../services/escolas/PresentesAtaPaa.service",
+    () => ({
+        getParticipantesOrdenadosPorCargoPaa: jest.fn(),
+        getListaPresentesPadraoPaa: jest.fn(),
+        getMembroPorIdentificadorPaa: jest.fn(),
+        getProfessorGremioInfo: jest.fn(),
+    }),
+);
+
+jest.mock("../../../../../../../services/Mandatos.service", () => ({
+    getCargosComposicaoData: jest.fn(),
+}));
+
+jest.mock("../../utils", () => ({
+    ...jest.requireActual("../../utils"),
+    adicionaProfessorGremioNaLista: jest.fn(),
+    extraiProfessorDefaults: jest.fn(),
+    listaPossuiParticipantesAssociacao: jest.fn(),
+    marcaParticipantesComoMembrosDaAssociacao: jest.fn((lista) => lista),
+    formatarListaCargoComposicaoParaFormatoDaListaParticipantes: jest.fn(
+        (lista) => lista,
+    ),
+}));
+
+jest.mock("../../../../../../../services/visoes.service", () => ({
+    visoesService: {
+        getPermissoes: jest.fn(() => true),
+    },
+}));
+
+const propsBase = {
+    stateFormEditarAta: {
+        tipo_ata: "APRESENTACAO",
+        data_reuniao: "2025-01-01",
+        comentarios: "Comentário carregado da API",
+        justificativa_retificacao: "",
+    },
+    tabelas: {
+        pareceres: [],
+        tipos_reuniao: [],
+        convocacoes: [],
+    },
+    formRef: {
+        current: {
+            setFieldValue: jest.fn(),
+            values: {
+                listaParticipantes: [],
+            },
+        },
+    },
+    onSubmitFormEdicaoAta: jest.fn(),
+    uuid_ata: "uuid-123",
+    setDisableBtnSalvar: jest.fn(),
+    repassesPendentes: [],
+    erros: {},
+    showModalAvisoRegeracaoAta: false,
+    setShowModalAvisoRegeracaoAta: jest.fn(),
+};
+
+describe("NovoFormularioEditaAta - alterações do PR", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        localStorage.setItem("ASSOCIACAO_UUID", "assoc-1");
+
+        getParticipantesOrdenadosPorCargoPaa.mockResolvedValue([]);
+        getListaPresentesPadraoPaa.mockResolvedValue([]);
+        getCargosComposicaoData.mockResolvedValue([]);
+
+        utils.listaPossuiParticipantesAssociacao.mockReturnValue(true);
+
+        utils.adicionaProfessorGremioNaLista.mockImplementation(
+            (lista) => lista,
+        );
+
+        utils.extraiProfessorDefaults.mockReturnValue(null);
+    });
+
+    describe("recarregamento quando precisaProfessorGremio mudar", () => {
+        it("deve executar novo carregamento ao alterar precisaProfessorGremio", async () => {
+            const { rerender } = render(
+                <NovoFormularioEditaAta
+                    {...propsBase}
+                    precisaProfessorGremio={false}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(
+                    getParticipantesOrdenadosPorCargoPaa,
+                ).toHaveBeenCalledTimes(1);
+            });
+
+            rerender(
+                <NovoFormularioEditaAta
+                    {...propsBase}
+                    precisaProfessorGremio={true}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(
+                    getParticipantesOrdenadosPorCargoPaa,
+                ).toHaveBeenCalledTimes(2);
+            });
+        });
+    });
+
+    describe("preservação dos dados do professor orientador", () => {
+        it("deve reutilizar professorDefaults quando já existir professor preenchido", async () => {
+            const professorInfo = {
+                nome: "Professor João",
+                cargo: "Professor",
+                identificacao: "1234567",
+                presente: true,
+            };
+
+            utils.extraiProfessorDefaults.mockReturnValue(professorInfo);
+
+            render(
+                <NovoFormularioEditaAta
+                    {...propsBase}
+                    precisaProfessorGremio={true}
+                />,
+        );
+
+            await waitFor(() => {
+                expect(
+                    utils.adicionaProfessorGremioNaLista,
+                ).toHaveBeenCalled();
+            });
+
+            const chamadas =
+                utils.adicionaProfessorGremioNaLista.mock.calls;
+
+            expect(
+                chamadas.some(
+                    (call) =>
+                        call[2]?.nome === "Professor João" &&
+                        call[2]?.identificacao === "1234567",
+                ),
+            ).toBeTruthy();
+        });
+    });
+
+    describe("sincronização dos comentários", () => {
+        it("deve renderizar comentários recebidos do stateFormEditarAta", async () => {
+            const { container } = render(
+                <NovoFormularioEditaAta
+                    {...propsBase}
+                />
+            );
+
+            await waitFor(() => {
+                const textarea = container.querySelector(
+                    'textarea[name="stateFormEditarAta.comentarios"]'
+                );
+
+                expect(textarea).toBeInTheDocument();
+                expect(textarea.value).toBe("Comentário carregado da API");
+            });
+        });
+
+        it("deve aceitar comentários vazios quando vier null", async () => {
+            const { container } = render(
+                <NovoFormularioEditaAta
+                    {...propsBase}
+                    stateFormEditarAta={{
+                        ...propsBase.stateFormEditarAta,
+                        data_reuniao: null,
+                        comentarios: null,
+                    }}
+                />,
+            );
+
+            await waitFor(() => {
+                const textarea = container.querySelector(
+                    'textarea[name="stateFormEditarAta.comentarios"]',
+                );
+
+                expect(textarea.value).toBe("");
+            });
+        });
+    });
+});

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/EdicaoAtaPaa/NovoFormularioEditaAta/index.js
@@ -120,19 +120,23 @@ export const NovoFormularioEditaAta = ({
         lista_cargos_composicao,
       );
 
-    const resetProfessor = {
-      nome: "",
-      cargo: "",
-      identificacao: "",
-      presente: true,
-    };
+    const professorDefaultValues =
+      professorDefaults &&
+      (professorDefaults.nome || professorDefaults.cargo || professorDefaults.identificacao)
+        ? professorDefaults
+        : {
+            nome: "",
+            cargo: "",
+            identificacao: "",
+            presente: true,
+          };
 
-    setProfessorDefaults(resetProfessor);
+    setProfessorDefaults(professorDefaultValues);
 
     const listaComProfessor = adicionaProfessorGremioNaLista(
       composicao_formatada,
       uuid_ata,
-      resetProfessor,
+      professorDefaultValues,
       precisaProfessorGremio,
     );
 
@@ -173,6 +177,7 @@ export const NovoFormularioEditaAta = ({
             ...prev?.stateFormEditarAta,
             justificativa_retificacao:
               stateFormEditarAta.justificativa_retificacao ?? "",
+            comentarios: stateFormEditarAta.comentarios ?? "",
           },
         };
       });
@@ -248,7 +253,7 @@ export const NovoFormularioEditaAta = ({
       precisaCarregarComposicao &&
       stateFormEditarAta &&
       stateFormEditarAta.data_reuniao &&
-      isValidDateString(stateFormEditarAta.data_reuniao)
+      isValidDateOrDateString(stateFormEditarAta.data_reuniao)
     ) {
       carregarComposicao();
     }
@@ -299,7 +304,7 @@ export const NovoFormularioEditaAta = ({
     };
 
     firstFetchData(uuid_ata);
-  }, [uuid_ata]);
+  }, [uuid_ata, precisaProfessorGremio]);
 
   const onClickCancelarAdicao = (remove, lista) => {
     if (lista.length > 0) {
@@ -924,11 +929,11 @@ export const NovoFormularioEditaAta = ({
   };
 
   const isValidDateString = (dateString) => {
-    var parsedDate = new Date(dateString);
-    return (
-      !isNaN(parsedDate.getTime()) &&
-      parsedDate.toISOString().slice(0, 10) === dateString
-    );
+    if (!dateString) {
+      return false;
+    }
+    const parsedDate = new Date(dateString);
+    return !isNaN(parsedDate.getTime());
   };
 
   const isValidDateOrDateString = (value) => {
@@ -1849,7 +1854,7 @@ export const NovoFormularioEditaAta = ({
                               />
                             </div>
                           </div>
-                        </div>                   
+                        </div>
                       </>
 
                     )}

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtividadesEstatutarias/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtividadesEstatutarias/__tests__/index.test.js
@@ -65,33 +65,29 @@ describe("AtividadesEstatutarias Component", () => {
     jest.clearAllMocks();
   });
 
-
   it("deve renderizar o título principal e os cabeçalhos da tabela corretamente", () => {
     render(<AtividadesEstatutarias {...defaultProps} />);
 
     expect(screen.getByRole("heading", { name: /atividades estatutárias/i })).toBeInTheDocument();
-
     expect(screen.getByRole("columnheader", { name: "Tipo de Atividades" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Data" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Atividades Estatutárias Previstas" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Mês/Ano" })).toBeInTheDocument();
   });
 
-
   it("deve exibir a TagRetificacao quando paaRetificacao for verdadeiro e isLoading for falso", () => {
     render(<AtividadesEstatutarias {...defaultProps} paaRetificacao={true} isLoading={false} />);
-    
+
     expect(screen.getByTestId("tag-retificacao")).toBeInTheDocument();
   });
 
   it("não deve exibir a TagRetificacao se isLoading for verdadeiro, mesmo com paaRetificacao ativo", () => {
     render(<AtividadesEstatutarias {...defaultProps} paaRetificacao={true} isLoading={true} />);
-    
+
     expect(screen.queryByTestId("tag-retificacao")).not.toBeInTheDocument();
   });
 
-
-  it("deve renderizar TODAS as atividades quando as condições do primeiro bloco do ternário forem atendidas", () => {
+  it("deve renderizar TODAS as atividades quando as condições padrão forem atendidas", () => {
     render(<AtividadesEstatutarias {...defaultProps} />);
 
     const rows = screen.getAllByRole("row");
@@ -101,30 +97,42 @@ describe("AtividadesEstatutarias Component", () => {
     expect(mockFormatarData).toHaveBeenCalledWith("2026-06-01");
     expect(mockFormatarMesAno).toHaveBeenCalledWith("2026-06-01");
     expect(screen.getByText("Junho/2026")).toBeInTheDocument();
-    expect(mockFormatarMesAno).toHaveBeenCalledWith("2026-06-03");
-
-    const fallbacks = screen.getAllByText("-");
-    expect(fallbacks.length).toBeGreaterThan(0);
   });
 
-  it("deve filtrar e renderizar apenas atividades com alteracao=true quando cair no bloco alternativo (ex: paaRetificacao=true)", () => {
+  it("deve renderizar todas as atividades e exibir a tag de retificação quando paaRetificacao for verdadeiro e houver alterações", () => {
     render(<AtividadesEstatutarias {...defaultProps} paaRetificacao={true} />);
 
-    expect(screen.queryByText("Assembleia")).not.toBeInTheDocument();
+    expect(screen.getByTestId("tag-retificacao")).toBeInTheDocument();
+    expect(screen.getByText("Assembleia")).toBeInTheDocument();
     expect(screen.getByText("Reunião Ordinária")).toBeInTheDocument();
-    
+
     const rows = screen.getAllByRole("row");
-
-    expect(rows).toHaveLength(4);
+    expect(rows).toHaveLength(5);
   });
 
-  it("deve renderizar o bloco alternativo se isLoadingAtividades for verdadeiro", () => {
+  it("deve retornar null (não renderizar nada) se não houver atividades válidas para exibir", () => {
+    const { container } = render(
+      <AtividadesEstatutarias {...defaultProps} atividades={[]} />
+    );
 
-    render(<AtividadesEstatutarias {...defaultProps} isLoadingAtividades={true} />);
-
-    expect(screen.queryByText("Assembleia")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
+  it("deve retornar null se isLoadingAtividades for verdadeiro", () => {
+    const { container } = render(
+      <AtividadesEstatutarias {...defaultProps} isLoadingAtividades={true} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("deve garantir que a TagRetificacao seja exibida se for retificação e ocultada caso contrário", () => {
+    // Caso 1: Com retificação ativa
+    const { rerender } = render(<AtividadesEstatutarias {...defaultProps} paaRetificacao={true} />);
+    expect(screen.getByTestId("tag-retificacao")).toBeInTheDocument();
+    rerender(<AtividadesEstatutarias {...defaultProps} paaRetificacao={false} />);
+    expect(screen.queryByTestId("tag-retificacao")).not.toBeInTheDocument();
+  });
   it("deve usar o índice do map como key alternativa se o uuid da atividade não for fornecido", () => {
     const atividadeSemUuid = [
       {
@@ -140,37 +148,4 @@ describe("AtividadesEstatutarias Component", () => {
     expect(screen.getByText("Sem UUID")).toBeInTheDocument();
   });
 
-  it("deve retornar null (não renderizar a linha) para atividades que NÃO possuem o campo 'alteracao' ativo no modo retificação", () => {
-    const atividadesMistas = [
-      {
-        uuid: "alterada-1",
-        tipoAtividade: "Atividade Alterada",
-        data: "2026-06-01",
-        descricao: "Essa deve aparecer",
-        alteracao: true,
-      },
-      {
-        uuid: "nao-alterada-2",
-        tipoAtividade: "Atividade Intacta",
-        data: "2026-06-02",
-        descricao: "Essa deve bater no 'if' e retornar null",
-        alteracao: false,
-      },
-    ];
-
-    render(
-      <AtividadesEstatutarias
-        {...defaultProps}
-        atividades={atividadesMistas}
-        paaRetificacao={true}
-      />
-    );
-
-    expect(screen.getByText("Atividade Alterada")).toBeInTheDocument();
-    expect(screen.queryByText("Atividade Intacta")).not.toBeInTheDocument();
-
-    const rows = screen.getAllByRole("row");
-
-    expect(rows).toHaveLength(2);
-  });
 });

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtividadesEstatutarias/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/AtividadesEstatutarias/index.jsx
@@ -13,74 +13,49 @@ export const AtividadesEstatutarias = memo(({
     const atividadesComAlteracao = useMemo(() => {
         return atividades ? atividades.filter(act => act.alteracao) : [];
     }, [atividades]);
-    
+
     const naoEstaCarregando = !isLoadingAtividades && !isLoading;
 
-    return (  
-        naoEstaCarregando && atividades && atividades.length > 0 && !paaRetificacao ? (
-         <div className="col-12 mt-4">
-           <h4 className="mb-3" style={{ fontWeight: "bold", color: "#42474A" }}>
-             <span className="mr-3">Atividades Estatutárias </span>{paaRetificacao && !isLoading && <TagRetificacao />}
-           </h4>
-           <table className="table table-bordered" style={{ width: "100%" }}>
-             <thead style={{ backgroundColor: "#dadada" }}>
-               <tr>
-                 <th style={{ width: "20%" }}>Tipo de Atividades</th>
-                 <th style={{ width: "15%" }}>Data</th>
-                 <th style={{ width: "45%" }}>Atividades Estatutárias Previstas</th>
-                 <th style={{ width: "20%" }}>Mês/Ano</th>
-               </tr>
-             </thead>
-              <tbody>
-                {atividades.map((atividade, index) => {
-                  const mesAnoBase =
-                    atividade.isGlobal && !atividade.vinculoUuid
-                      ? atividade.mesLabel || "-"
-                      : formatarMesAno(atividade.data);
-                  return (
-                    <tr key={atividade.uuid || index}>
-                      <td>{atividade.tipoAtividade || "-"}</td>
-                      <td>{formatarData(atividade.data)}</td>
-                      <td>{atividade.descricao || "-"}</td>
-                      <td>{mesAnoBase || "-"}</td>
+    const deveRenderizarPadrao = !paaRetificacao && naoEstaCarregando && atividades && atividades.length > 0;
+    const deveRenderizarComAlteracao = paaRetificacao && naoEstaCarregando && atividadesComAlteracao.length > 0;
+
+    if (!deveRenderizarPadrao && !deveRenderizarComAlteracao) {
+        return null;
+    }
+
+    return (
+        <div className="col-12 mt-4">
+            <h4 className="mb-3" style={{ fontWeight: "bold", color: "#42474A" }}>
+                <span className="mr-3">Atividades Estatutárias </span>{paaRetificacao && !isLoading && <TagRetificacao />}
+            </h4>
+
+            <table className="table table-bordered" style={{ width: "100%" }}>
+                <thead style={{ backgroundColor: "#dadada" }}>
+                    <tr>
+                        <th scope="col" style={{ width: "20%" }}>Tipo de Atividades</th>
+                        <th scope="col" style={{ width: "15%" }}>Data</th>
+                        <th scope="col" style={{ width: "45%" }}>Atividades Estatutárias Previstas</th>
+                        <th scope="col" style={{ width: "20%" }}>Mês/Ano</th>
                     </tr>
-                  );
-                })}
-              </tbody>
-           </table>
-         </div>
-         ) : naoEstaCarregando && atividadesComAlteracao.length > 0 ? (
-         <div className="col-12 mt-4">
-           <h4 className="mb-3" style={{ fontWeight: "bold", color: "#42474A" }}>
-             <span className="mr-3">Atividades Estatutárias </span>{paaRetificacao && !isLoading && <TagRetificacao />}
-           </h4>
-           <table className="table table-bordered" style={{ width: "100%" }}>
-             <thead style={{ backgroundColor: "#dadada" }}>
-               <tr>
-                 <th style={{ width: "20%" }}>Tipo de Atividades</th>
-                 <th style={{ width: "15%" }}>Data</th>
-                 <th style={{ width: "45%" }}>Atividades Estatutárias Previstas</th>
-                 <th style={{ width: "20%" }}>Mês/Ano</th>
-               </tr>
-             </thead>
-              <tbody>
-                {atividadesComAlteracao.map((atividade, index) => {
-                  const mesAnoBase =
-                    atividade.isGlobal && !atividade.vinculoUuid
-                      ? atividade.mesLabel || "-"
-                      : formatarMesAno(atividade.data);
-                  return (
-                    <tr key={atividade.uuid || index}>
-                      <td>{atividade.tipoAtividade || "-"}</td>
-                      <td>{formatarData(atividade.data)}</td>
-                      <td>{atividade.descricao || "-"}</td>
-                      <td>{mesAnoBase || "-"}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-           </table>
-         </div>
-       ) : null
-    )
+                </thead>
+
+                <tbody>
+                    {atividades.map((atividade, index) => {
+                        const mesAnoBase =
+                        atividade.isGlobal && !atividade.vinculoUuid
+                            ? atividade.mesLabel || "-"
+                            : formatarMesAno(atividade.data);
+                        return (
+                            <tr key={atividade.uuid || index}>
+                                <td>{atividade.tipoAtividade || "-"}</td>
+                                <td>{formatarData(atividade.data)}</td>
+                                <td>{atividade.descricao || "-"}</td>
+                                <td>{mesAnoBase || "-"}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
 });

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ListaPresentes/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ListaPresentes/__tests__/index.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { ListaPresentes } from "../index"; 
+import { ListaPresentes } from "../index";
 
 describe("Componente <ListaPresentes />", () => {
   const mockMembros = [
@@ -16,29 +16,26 @@ describe("Componente <ListaPresentes />", () => {
     { uuid: "nm3", nome: "Everton Santos" },
   ];
 
-  it("deve renderizar a estrutura inicial com os títulos das tabelas corretamente", () => {
-    render(<ListaPresentes listaPresentesMembros={[]} listaPresentesNaoMembros={[]} />);
+  it("deve renderizar a estrutura inicial com os títulos e tabelas quando houver dados em ambas as listas", () => {
+    render(<ListaPresentes listaPresentesMembros={mockMembros} listaPresentesNaoMembros={mockNaoMembros} />);
 
     expect(screen.getByRole("heading", { level: 4, name: /lista de presentes/i })).toBeInTheDocument();
     expect(screen.getByText(/membros da diretoria executiva e do conselho fiscal/i)).toBeInTheDocument();
     expect(screen.getByText(/demais presentes/i)).toBeInTheDocument();
 
-    const cabecalhosNomeCargo = screen.getAllByRole("columnheader", { name: /nome e cargo/i });
-    const cabecalhosAssinatura = screen.getAllByRole("columnheader", { name: /assinatura/i });
-
-    expect(cabecalhosNomeCargo).toHaveLength(2);
-    expect(cabecalhosAssinatura).toHaveLength(2);
-  });
-
-  it("deve renderizar as tabelas vazias sem quebrar o componente quando os arrays forem vazios", () => {
-    render(<ListaPresentes listaPresentesMembros={[]} listaPresentesNaoMembros={[]} />);
-
     const tabelas = screen.getAllByRole("table");
     expect(tabelas).toHaveLength(2);
+  });
 
-    const tbodies = document.querySelectorAll("tbody");
-    expect(tbodies[0].children).toHaveLength(0);
-    expect(tbodies[1].children).toHaveLength(0);
+  it("não deve renderizar a seção de 'Demais presentes' quando listaPresentesNaoMembros estiver vazia ou sem nomes válidos", () => {
+    render(<ListaPresentes listaPresentesMembros={mockMembros} listaPresentesNaoMembros={[]} />);
+
+    // Apenas 1 tabela deve existir (a de membros)
+    const tabelas = screen.getAllByRole("table");
+    expect(tabelas).toHaveLength(1);
+
+    // O título de demais presentes não deve aparecer
+    expect(screen.queryByText(/demais presentes/i)).not.toBeInTheDocument();
   });
 
   it("deve renderizar a lista de membros corretamente com todas as variações (nome, cargo ausente, sem nome)", () => {
@@ -56,6 +53,7 @@ describe("Componente <ListaPresentes />", () => {
   it("deve renderizar a lista de não-membros testando as condicionais de cargo e professor do grêmio", () => {
     render(<ListaPresentes listaPresentesMembros={[]} listaPresentesNaoMembros={mockNaoMembros} />);
 
+    expect(screen.getByText(/demais presentes/i)).toBeInTheDocument();
     expect(screen.getByText(/bruno costa/i)).toBeInTheDocument();
     expect(screen.getByText(/secretário/i)).toBeInTheDocument();
     expect(screen.queryByText(/secretário - professor do grêmio/i)).not.toBeInTheDocument();

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ListaPresentes/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ListaPresentes/index.jsx
@@ -36,34 +36,41 @@ export const ListaPresentes = memo(({
               </tbody>
             </table>
 
-            <p className="titulo-tabela-acoes mt-3" style={{ fontWeight: "bold", color: "#00585E", fontSize: 16 }}>
-              Demais presentes
-            </p>
-            <table className="table table-bordered" style={{ width: "100%" }}>
-              <thead style={{ backgroundColor: "#dadada" }}>
-                <tr>
-                  <th style={{ width: "70%" }}>Nome e cargo</th>
-                  <th style={{ width: "30%" }}>Assinatura</th>
-                </tr>
-              </thead>
-              <tbody>
-                {listaPresentesNaoMembros.map((presente, index) => (
-                  <tr key={presente.uuid || presente.identificacao || index}>
-                    <td>
-                      <div>
-                        <strong style={{ textTransform: "uppercase" }}>{presente.nome || "-"}</strong>
-                        {presente.cargo && (
-                          <div style={{ marginTop: "4px" }}>
-                            {presente.cargo} {presente.professor_gremio && " - Professor do Grêmio"}
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                    <td></td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                {listaPresentesNaoMembros?.some(
+                (presente) =>
+                    presente?.nome
+                ) && (
+                <>
+                    <p className="titulo-tabela-acoes mt-3" style={{ fontWeight: "bold", color: "#00585E", fontSize: 16 }}>
+                        Demais presentes
+                    </p>
+                    <table className="table table-bordered" style={{ width: "100%" }}>
+                        <thead style={{ backgroundColor: "#dadada" }}>
+                            <tr>
+                            <th style={{ width: "70%" }}>Nome e cargo</th>
+                            <th style={{ width: "30%" }}>Assinatura</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {listaPresentesNaoMembros.map((presente, index) => (
+                            <tr key={presente.uuid || presente.identificacao || index}>
+                                <td>
+                                <div>
+                                    <strong style={{ textTransform: "uppercase" }}>{presente.nome || "-"}</strong>
+                                    {presente.cargo && (
+                                    <div style={{ marginTop: "4px" }}>
+                                        {presente.cargo} {presente.professor_gremio && " - Professor do Grêmio"}
+                                    </div>
+                                    )}
+                                </div>
+                                </td>
+                                <td></td>
+                            </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </>
+            )}
         </div>
     )
 });

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/Manifestacoes/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/Manifestacoes/__tests__/index.test.js
@@ -21,9 +21,9 @@ describe('Componente Manifestacoes', () => {
     isLoading: false,
   };
 
-  it('deve renderizar o título principal do componente', () => {
+  it('deve renderizar o título principal do componente quando houver comentários', () => {
     render(<Manifestacoes {...defaultProps} />);
-    
+
     const titulo = screen.getByRole('heading', { name: /manifestações/i, level: 4 });
     expect(titulo).toBeInTheDocument();
   });
@@ -31,177 +31,20 @@ describe('Componente Manifestacoes', () => {
   describe('Renderização de Comentários', () => {
     it('deve renderizar os comentários quando fornecidos', () => {
       render(<Manifestacoes {...defaultProps} />);
-      
+
       expect(screen.getByText('Comentário padrão da ata')).toBeInTheDocument();
     });
 
-    it('não deve renderizar o parágrafo de comentários quando dadosAta.comentarios for nulo ou vazio', () => {
+    it('não deve renderizar o título nem o parágrafo de comentários quando dadosAta.comentarios for nulo ou vazio', () => {
       const propsSemComentarios = {
         ...defaultProps,
         dadosAta: { ...defaultProps.dadosAta, comentarios: '' },
       };
-      
+
       render(<Manifestacoes {...propsSemComentarios} />);
-      
+
+      expect(screen.queryByRole('heading', { name: /manifestações/i, level: 4 })).not.toBeInTheDocument();
       expect(screen.queryByText('Comentário padrão da ata')).not.toBeInTheDocument();
     });
   });
-
-  describe('Condições de Retorno Nulo do Parecer (Guard Clauses)', () => {
-    it('deve retornar nulo se dadosAta.parecer_conselho não for fornecido', () => {
-      const props = {
-        ...defaultProps,
-        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: undefined },
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
-    });
-
-    it('deve retornar nulo se tabelas.pareceres não for fornecido', () => {
-      const props = {
-        ...defaultProps,
-        tabelas: {},
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
-    });
-
-    it('deve retornar nulo se o parecer correspondente não for encontrado na tabela', () => {
-      const props = {
-        ...defaultProps,
-        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'ID_INEXISTENTE' },
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
-    });
-
-    it('deve retornar nulo se o parecerId não corresponder a nenhum padrão conhecido (Aprovado/Rejeitado/Reprovado)', () => {
-      const props = {
-        ...defaultProps,
-        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'OUTRO_STATUS' },
-        tabelas: {
-          pareceres: [{ id: 'OUTRO_STATUS' }]
-        }
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Fluxo de Aprovação', () => {
-    it('deve exibir mensagem de aprovado sem o termo "retificado" por padrão', () => {
-      render(<Manifestacoes {...defaultProps} />);
-      
-      const textoAprovado = screen.getByText(/diante ao exposto, o plano anual de atividades foi aprovado\./i);
-      expect(textoAprovado).toBeInTheDocument();
-      expect(textoAprovado).not.toHaveTextContent(/retificado/i);
-    });
-
-    it('deve exibir o termo "retificado" se paaRetificacao for verdadeiro e isLoading for falso', () => {
-      const props = {
-        ...defaultProps,
-        paaRetificacao: true,
-        isLoading: false,
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.getByText(/diante ao exposto, o plano anual de atividades retificado foi aprovado\./i)).toBeInTheDocument();
-    });
-
-    it('não deve exibir o termo "retificado" se paaRetificacao for verdadeiro mas isLoading for verdadeiro', () => {
-      const props = {
-        ...defaultProps,
-        paaRetificacao: true,
-        isLoading: true,
-      };
-      render(<Manifestacoes {...props} />);
-      
-      const textoAprovado = screen.getByText(/diante ao exposto, o plano anual de atividades foi aprovado\./i);
-      expect(textoAprovado).toBeInTheDocument();
-      expect(textoAprovado).not.toHaveTextContent(/retificado/i);
-    });
-
-    it('deve identificar a aprovação mesmo se o ID do parecer usar variações como minúsculas ou termos parciais ("APROV")', () => {
-      const props = {
-        ...defaultProps,
-        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'aprov' },
-        tabelas: {
-          pareceres: [{ id: 'aprov' }]
-        }
-      };
-      render(<Manifestacoes {...props} />);
-      
-      expect(screen.getByText(/foi aprovado\./i)).toBeInTheDocument();
-    });
-  });
-
-  describe('Fluxo de Reprovação / Rejeição', () => {
-    const mockTabelasReprovacao = {
-      pareceres: [
-        { id: 'REJEITADA', nome: 'Rejeitada' },
-        { id: 'REPROVADO_PELO_CONSELHO', nome: 'Reprovado' }
-      ]
-    };
-
-    const propsReprovadaBase = {
-      ...defaultProps,
-      tabelas: mockTabelasReprovacao,
-      dadosAta: {
-        ...defaultProps.dadosAta,
-        parecer_conselho: 'REJEITADA',
-        justificativa: 'Justificativa de reprovação.',
-      },
-    };
-
-    it('deve exibir mensagem de reprovado com a respectiva justificativa se fornecida', () => {
-      render(<Manifestacoes {...propsReprovadaBase} />);
-      
-      const textoPrincipal = screen.getByText((content, element) => {
-        const hasText = (node) => node.textContent.includes("Diante ao exposto, o Plano Anual de Atividades foi reprovado.");
-        const nodeHasText = hasText(element);
-        const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
-        return nodeHasText && childrenDontHaveText;
-      });
-      expect(textoPrincipal).toBeInTheDocument();
-
-      expect(screen.getByText(/Justificativa de reprovação\./i)).toBeInTheDocument();
-    });
-
-    it('deve exibir mensagem de reprovado sem estourar erro se a justificativa não for fornecida', () => {
-      const propsSemJustificativa = {
-        ...propsReprovadaBase,
-        dadosAta: {
-          ...propsReprovadaBase.dadosAta,
-          justificativa: undefined,
-        },
-      };
-      render(<Manifestacoes {...propsSemJustificativa} />);
-      
-      const textoPrincipal = screen.getByText((content, element) => {
-        const hasText = (node) => node.textContent.includes("Diante ao exposto, o Plano Anual de Atividades foi reprovado.");
-        const nodeHasText = hasText(element);
-        const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
-        return nodeHasText && childrenDontHaveText;
-      });
-      expect(textoPrincipal).toBeInTheDocument();
-
-      expect(screen.queryByText(/Justificativa de reprovação\./i)).not.toBeInTheDocument();
-    });
-
-    it('deve identificar a reprovação se o ID contiver termos como "REPROV"', () => {
-      const propsreprov = {
-        ...defaultProps,
-        tabelas: mockTabelasReprovacao,
-        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'REPROVADO_PELO_CONSELHO' }
-      };
-      render(<Manifestacoes {...propsreprov} />);
-      
-      expect(screen.getByText('reprovado')).toBeInTheDocument();
-    });
-  });
 });
-

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/Manifestacoes/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/Manifestacoes/index.jsx
@@ -2,41 +2,13 @@ import { memo } from "react"
 
 export const Manifestacoes = memo(({dadosAta, paaRetificacao,tabelas, isLoading }) => {
     return (
-        <>
-            <div className="col-12 mt-4">
-                <h4 style={{ fontWeight: "bold", fontSize: "20px", color: "#42474A" }}>Manifestações</h4>
-                {dadosAta.comentarios && <p className="mt-3">{dadosAta.comentarios}</p>}
-            </div>
-
-            <div className="col-12 mt-4">
-            {(() => {
-                if (!dadosAta.parecer_conselho || !tabelas.pareceres) {
-                return null;
-                }
-                const parecer = tabelas.pareceres.find((p) => p.id === dadosAta.parecer_conselho);
-                if (!parecer) {
-                return null;
-                }
-                const parecerId = (parecer.id || "").toUpperCase();
-
-                if (parecerId === "APROVADA" || parecerId.includes("APROV")) {
-                return <p style={{ fontWeight: "bold" }}>Diante ao exposto, o Plano Anual de Atividades
-                { paaRetificacao && !isLoading && " retificado" } foi aprovado.</p>;
-                }
-                if (parecerId === "REJEITADA" || parecerId.includes("REJEIT") || parecerId.includes("REPROV")) {
-                return (
-                    <>
-                    <p style={{ fontWeight: "bold" }}>
-                        Diante ao exposto, o Plano Anual de Atividades foi{" "}
-                        <span style={{ color: "#B40C02" }}>reprovado</span>.{" "}
-                        {dadosAta.justificativa && <>{dadosAta.justificativa}</>}
-                    </p>
-                    </>
-                );
-                }
-                return null;
-            })()}
-            </div>
-        </>
+        <div className="col-12 mt-4">
+            {dadosAta.comentarios &&
+                <>
+                    <h4 style={{ fontWeight: "bold", fontSize: "20px", color: "#42474A" }}>Manifestações</h4>
+                    <p className="mt-3">{dadosAta.comentarios}</p>
+                </>
+            }
+        </div>
     )
 })

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ParecerConselho/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ParecerConselho/__tests__/index.test.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ParecerConselho } from '../index';
+
+describe('Componente ParecerConselho', () => {
+  const mockTabelas = {
+    pareceres: [
+      { id: 'APROVADA', nome: 'Aprovada' },
+      { id: 'REPROVADA', nome: 'Reprovada' },
+    ],
+  };
+
+  const defaultProps = {
+    dadosAta: {
+      comentarios: 'Comentário padrão da ata',
+      parecer_conselho: 'APROVADA',
+      justificativa: '',
+    },
+    paaRetificacao: false,
+    tabelas: mockTabelas,
+    isLoading: false,
+  };
+
+  describe('Condições de Retorno Nulo do Parecer (Guard Clauses)', () => {
+    it('deve retornar nulo se dadosAta.parecer_conselho não for fornecido', () => {
+      const props = {
+        ...defaultProps,
+        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: undefined },
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
+    });
+
+    it('deve retornar nulo se tabelas.pareceres não for fornecido', () => {
+      const props = {
+        ...defaultProps,
+        tabelas: {},
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
+    });
+
+    it('deve retornar nulo se o parecer correspondente não for encontrado na tabela', () => {
+      const props = {
+        ...defaultProps,
+        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'ID_INEXISTENTE' },
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
+    });
+
+    it('deve retornar nulo se o parecerId não corresponder a nenhum padrão conhecido (Aprovado/Rejeitado/Reprovado)', () => {
+      const props = {
+        ...defaultProps,
+        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'OUTRO_STATUS' },
+        tabelas: {
+          pareceres: [{ id: 'OUTRO_STATUS' }]
+        }
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.queryByText(/diante ao exposto/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Fluxo de Aprovação', () => {
+    it('deve exibir mensagem de aprovado sem o termo "retificado" por padrão', () => {
+      render(<ParecerConselho {...defaultProps} />);
+
+      const textoAprovado = screen.getByText(/diante ao exposto, o plano anual de atividades foi aprovado\./i);
+      expect(textoAprovado).toBeInTheDocument();
+      expect(textoAprovado).not.toHaveTextContent(/retificado/i);
+    });
+
+    it('deve exibir o termo "retificado" se paaRetificacao for verdadeiro e isLoading for falso', () => {
+      const props = {
+        ...defaultProps,
+        paaRetificacao: true,
+        isLoading: false,
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.getByText(/diante ao exposto, o plano anual de atividades retificado foi aprovado\./i)).toBeInTheDocument();
+    });
+
+    it('não deve exibir o termo "retificado" se paaRetificacao for verdadeiro mas isLoading for verdadeiro', () => {
+      const props = {
+        ...defaultProps,
+        paaRetificacao: true,
+        isLoading: true,
+      };
+      render(<ParecerConselho {...props} />);
+
+      const textoAprovado = screen.getByText(/diante ao exposto, o plano anual de atividades foi aprovado\./i);
+      expect(textoAprovado).toBeInTheDocument();
+      expect(textoAprovado).not.toHaveTextContent(/retificado/i);
+    });
+
+    it('deve identificar a aprovação mesmo se o ID do parecer usar variações como minúsculas ou termos parciais ("APROV")', () => {
+      const props = {
+        ...defaultProps,
+        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'aprov' },
+        tabelas: {
+          pareceres: [{ id: 'aprov' }]
+        }
+      };
+      render(<ParecerConselho {...props} />);
+
+      expect(screen.getByText(/foi aprovado\./i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Fluxo de Reprovação / Rejeição', () => {
+    const mockTabelasReprovacao = {
+      pareceres: [
+        { id: 'REJEITADA', nome: 'Rejeitada' },
+        { id: 'REPROVADO_PELO_CONSELHO', nome: 'Reprovado' }
+      ]
+    };
+
+    const propsReprovadaBase = {
+      ...defaultProps,
+      tabelas: mockTabelasReprovacao,
+      dadosAta: {
+        ...defaultProps.dadosAta,
+        parecer_conselho: 'REJEITADA',
+        justificativa: 'Justificativa de reprovação.',
+      },
+    };
+
+    it('deve exibir mensagem de reprovado com a respectiva justificativa se fornecida', () => {
+      render(<ParecerConselho {...propsReprovadaBase} />);
+
+      const textoPrincipal = screen.getByText((content, element) => {
+        const hasText = (node) => node.textContent.includes("Diante ao exposto, o Plano Anual de Atividades foi reprovado.");
+        const nodeHasText = hasText(element);
+        const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+        return nodeHasText && childrenDontHaveText;
+      });
+      expect(textoPrincipal).toBeInTheDocument();
+
+      expect(screen.getByText(/Justificativa de reprovação\./i)).toBeInTheDocument();
+    });
+
+    it('deve exibir mensagem de reprovado sem estourar erro se a justificativa não for fornecida', () => {
+      const propsSemJustificativa = {
+        ...propsReprovadaBase,
+        dadosAta: {
+          ...propsReprovadaBase.dadosAta,
+          justificativa: undefined,
+        },
+      };
+      render(<ParecerConselho {...propsSemJustificativa} />);
+
+      const textoPrincipal = screen.getByText((content, element) => {
+        const hasText = (node) => node.textContent.includes("Diante ao exposto, o Plano Anual de Atividades foi reprovado.");
+        const nodeHasText = hasText(element);
+        const childrenDontHaveText = Array.from(element.children).every(child => !hasText(child));
+        return nodeHasText && childrenDontHaveText;
+      });
+      expect(textoPrincipal).toBeInTheDocument();
+
+      expect(screen.queryByText(/Justificativa de reprovação\./i)).not.toBeInTheDocument();
+    });
+
+    it('deve identificar a reprovação se o ID contiver termos como "REPROV"', () => {
+      const propsreprov = {
+        ...defaultProps,
+        tabelas: mockTabelasReprovacao,
+        dadosAta: { ...defaultProps.dadosAta, parecer_conselho: 'REPROVADO_PELO_CONSELHO' }
+      };
+      render(<ParecerConselho {...propsreprov} />);
+
+      expect(screen.getByText('reprovado')).toBeInTheDocument();
+    });
+  });
+});
+

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ParecerConselho/index.jsx
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/ParecerConselho/index.jsx
@@ -1,0 +1,38 @@
+import { memo } from "react"
+
+export const ParecerConselho = memo(({dadosAta, paaRetificacao,tabelas, isLoading }) => {
+    return (
+        <div className="col-12 mt-4">
+            {(() => {
+                if (!dadosAta.parecer_conselho || !tabelas.pareceres) {
+                    return null;
+                }
+
+                const parecer = tabelas.pareceres.find((p) => p.id === dadosAta.parecer_conselho);
+
+                if (!parecer) {
+                    return null;
+                }
+
+                const parecerId = (parecer.id || "").toUpperCase();
+
+                if (parecerId === "APROVADA" || parecerId.includes("APROV")) {
+                    return <p style={{ fontWeight: "bold" }}>Diante ao exposto, o Plano Anual de Atividades
+                    { paaRetificacao && !isLoading && " retificado" } foi aprovado.</p>;
+                }
+
+                if (parecerId === "REJEITADA" || parecerId.includes("REJEIT") || parecerId.includes("REPROV")) {
+                    return (
+                        <p style={{ fontWeight: "bold" }}>
+                            Diante ao exposto, o Plano Anual de Atividades foi{" "}
+                            <span style={{ color: "#B40C02" }}>reprovado</span>.{" "}
+                            {dadosAta.justificativa && <>{dadosAta.justificativa}</>}
+                        </p>
+                    );
+                }
+
+                return null;
+            })()}
+        </div>
+    )
+})

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/__tests__/index.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/__tests__/index.test.js
@@ -49,6 +49,10 @@ jest.mock("../Manifestacoes", () => ({
   Manifestacoes: () => <div data-testid="mock-manifestacoes" />,
 }));
 
+jest.mock("../ParecerConselho", () => ({
+  ParecerConselho: () => <div data-testid="mock-parecer-conselho" />,
+}));
+
 jest.mock("../ListaPresentes", () => ({
   ListaPresentes: () => <div data-testid="mock-lista-presentes" />,
 }));
@@ -119,6 +123,11 @@ describe("VisualizacaoAtaPaa - Container", () => {
       expect(screen.getByTestId("mock-topo-com-botoes")).toBeInTheDocument();
     });
 
+    it("deve renderizar o componente ParecerConselho na estrutura principal", () => {
+      renderComponent();
+      expect(screen.getByTestId("mock-parecer-conselho")).toBeInTheDocument();
+    });
+
     it("deve passar a lista de presentes filtrada corretamente para o subcomponente", () => {
       const listaPresentesMix = [
         { uuid: "1", membro: true, presente: true },
@@ -143,6 +152,7 @@ describe("VisualizacaoAtaPaa - Container", () => {
       expect(screen.getByTestId("mock-ata-elaboracao")).toBeInTheDocument();
       expect(screen.queryByTestId("mock-ata-retificacao")).not.toBeInTheDocument();
       expect(screen.getByTestId("mock-prioridades-elaboracao")).toBeInTheDocument();
+      expect(screen.getByTestId("mock-parecer-conselho")).toBeInTheDocument();
     });
 
     it("deve exibir o texto de encerramento específico para Elaboração com o secretário em negrito", () => {
@@ -182,6 +192,7 @@ describe("VisualizacaoAtaPaa - Container", () => {
       expect(screen.getByTestId("mock-ata-retificacao")).toBeInTheDocument();
       expect(screen.queryByTestId("mock-ata-elaboracao")).not.toBeInTheDocument();
       expect(screen.getByTestId("mock-prioridades-retificacao")).toBeInTheDocument();
+      expect(screen.getByTestId("mock-parecer-conselho")).toBeInTheDocument();
     });
 
     it("deve exibir a seção de justificativa da retificação preenchida", () => {

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/__tests__/useVisualizacaoAtaPaa.test.js
@@ -177,6 +177,29 @@ describe('useVisualizacaoAtaPaa', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/elaborar-novo-paa', expect.any(Object));
   });
 
+  it('deve navegar para retificacao-paa quando o tipo da ata for RETIFICACAO ao fechar', async () => {
+    getAtaPaa.mockResolvedValue({ tipo_ata: 'RETIFICACAO' });
+    const { result } = renderHook(() => useVisualizacaoAtaPaa());
+
+    await waitFor(() => {
+      expect(result.current.dadosAta.tipo_ata).toBe('RETIFICACAO');
+    });
+
+    act(() => {
+      result.current.handleClickFecharAta();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/retificacao-paa/123', {
+      state: {
+        activeTab: 'relatorios',
+        expandedSections: {
+          planoAnual: true,
+          componentes: true,
+        },
+      },
+    });
+  });
+
   it('deve processar rota atual e acionar window.location.assign na edição da ata', () => {
     window.location.pathname = '/teste-path';
     const { result } = renderHook(() => useVisualizacaoAtaPaa());
@@ -227,7 +250,7 @@ describe('useVisualizacaoAtaPaa', () => {
   });
 
   it('deve formatar como "primeiro" se o dia ajustado for 1', async () => {
-    getAtaPaa.mockResolvedValue({ data_reuniao: '2026-04-30' }); 
+    getAtaPaa.mockResolvedValue({ data_reuniao: '2026-04-30' });
     const { result } = renderHook(() => useVisualizacaoAtaPaa());
 
     await waitFor(() => expect(result.current.dadosAta.data_reuniao).toBe('2026-04-30'));

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/hooks/useVisualizacaoAtaPaa.js
@@ -79,6 +79,16 @@ export const useVisualizacaoAtaPaa = () => {
         const origem = location.state?.origem || searchParams.get("origem");
         if (origem === 'paa-vigente-e-anteriores') {
             navigate("/paa-vigente-e-anteriores");
+        }else if (dadosAta.tipo_ata === "RETIFICACAO") {
+            navigate(`/retificacao-paa/${uuid_paa}`, {
+                state: {
+                    activeTab: "relatorios",
+                    expandedSections: {
+                        planoAnual: true,
+                        componentes: true,
+                    },
+                },
+            });
         } else {
             navigate("/elaborar-novo-paa", {
                 state: {

--- a/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
+++ b/src/componentes/escolas/GeracaoDaAta/VisualizacaoDaAta/VisualizacaoAtaPaa/index.js
@@ -14,6 +14,7 @@ import { ListaPresentes } from "./ListaPresentes";
 import { BlocoPrioridadesRetificacao } from "./BlocoPrioridades/BlocoPrioridadesRetificacao";
 import { BlocoPrioridadesElaboracao } from "./BlocoPrioridades/BlocoPrioridadesElaboracao";
 import { Manifestacoes } from "./Manifestacoes";
+import { ParecerConselho } from "./ParecerConselho";
 
 export const VisualizacaoAtaPaa = () => {
   const {
@@ -55,9 +56,9 @@ export const VisualizacaoAtaPaa = () => {
   );
   const { uuid_paa } = useParams();
 
-  const { data: paaRetificacao, isLoading } = useGetPaaRetificacao(uuid_paa); 
+  const { data: paaRetificacao, isLoading } = useGetPaaRetificacao(uuid_paa);
   const dataReuniaoElaboracao = paaRetificacao?.ata_elaboracao?.data_reuniao;
-  
+
   return (
       <div className="col-12 container-visualizacao-da-ata mb-5" ref={referenciaDocumento}>
         {alturaDocumento > 0 && <WatermarkPrevia alturaDocumento={alturaDocumento} icon="rascunho" />}
@@ -145,6 +146,13 @@ export const VisualizacaoAtaPaa = () => {
           isLoading={isLoading}
         />
 
+        <ParecerConselho
+          dadosAta={dadosAta}
+          paaRetificacao={paaRetificacao}
+          tabelas={tabelas}
+          isLoading={isLoading}
+        />
+
         { !paaRetificacao && !isLoading ? (
           <div className="col-12 mt-4">
             <p>
@@ -164,7 +172,7 @@ export const VisualizacaoAtaPaa = () => {
         )}
 
         {listaPresentes && listaPresentes.length > 0 && (
-          <ListaPresentes 
+          <ListaPresentes
             listaPresentesMembros={listaPresentesMembros}
             listaPresentesNaoMembros={listaPresentesNaoMembros}
           />


### PR DESCRIPTION

Esse PR:

- Identifica se existe atividades estatutária com alterações, caso exista, apresentar o todas as atividades, caso contrario, não exibir o bloco.
- Omiti na visualização ata paa a seção manifestações quando o campo comentários não estiver preenchido.
- Melhora o redirecionamento da tela de Visualizar prévia da ata, a depender do ponto de origem: em Relatórios ou PAA vigente e anteriores.
- Melhora a exibição do campo de não membros na visualização da Ata do PAA de elaboração e retificação.
- Melhora a exibição do campo de professor do grêmio na edição da Ata do PAA de elaboração e retificação.
- Separa componente Parecer conselho em um componente próprio.
- Adiciona o preenchimento automático do valor em manifestações quando o mesmo já existir.

História: [AB#152458](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152458)
