### PR TITLE
feat(151566): Exibição de textos fique de olho por recurso.

### DIFF
--- a/src/componentes/dres/RelatorioConsolidado/index.js
+++ b/src/componentes/dres/RelatorioConsolidado/index.js
@@ -31,6 +31,7 @@ import useUnidadeSelecionada from "../../../hooks/Globais/useUnidadeSelecionada"
 import { useRecursoSelecionadoContext } from "../../../context/RecursoSelecionado";
 import { useGetComissaoResponsavelPC } from "./hooks/useGetComissaoResponsavelPC";
 import { toastCustom } from "../../Globais/ToastCustom";
+import { TEXTOS_FIQUE_DE_OLHO } from "../../../constantes/textosFiqueDeOlho";
 
 const RelatorioConsolidado = () => {
     const { getUUIDUnidadeSelecionadaTipoDRE } = useUnidadeSelecionada(visoesService)
@@ -201,12 +202,15 @@ const RelatorioConsolidado = () => {
 
     const buscaFiqueDeOlho = useCallback(async () => {
         try {
-            let fique_de_olho = await getFiqueDeOlhoRelatoriosConsolidados();
-            setFiqueDeOlho(fique_de_olho.detail);
+            let fique_de_olho = await getFiqueDeOlhoRelatoriosConsolidados(
+                TEXTOS_FIQUE_DE_OLHO.DRE_CONSOLIDADO_DAS_PCS,
+                recursoSelecionado?.uuid
+            );
+            setFiqueDeOlho(fique_de_olho.results[0].texto);
         } catch (e) {
             console.log("Erro ao buscar Fique de Olho ", e)
         }
-    }, [])
+    }, [recursoSelecionado?.uuid])
 
     useEffect(() => {
         buscaFiqueDeOlho()
@@ -388,9 +392,12 @@ const RelatorioConsolidado = () => {
         <PaginasContainer>
             <h1 className="titulo-itens-painel mt-5">Consolidado das PCs</h1>
             <>
-                <div className="col-12 container-texto-introdutorio mb-4 mt-3">
-                    <div dangerouslySetInnerHTML={{__html: fiqueDeOlho}}/>
-                </div>
+                { fiqueDeOlho?.trim() && (
+                    <div className="col-12 container-texto-introdutorio mb-4 mt-3">
+                        <div dangerouslySetInnerHTML={{__html: fiqueDeOlho}}/>
+                    </div>
+                )}
+
                 <div className="page-content-inner pt-0">
                     {statusBarraDeStatus &&
                         <BarraDeStatus

--- a/src/componentes/escolas/PrestacaoDeContas/InformacoesIniciais.js
+++ b/src/componentes/escolas/PrestacaoDeContas/InformacoesIniciais.js
@@ -2,25 +2,32 @@ import React, {useState, useEffect} from "react";
 import {
     getFiqueDeOlhoPrestacoesDeContas,
 } from "../../../services/escolas/PrestacaoDeContas.service";
+import { useRecursoSelecionadoContext } from "../../../context/RecursoSelecionado";
+import { TEXTOS_FIQUE_DE_OLHO } from "../../../constantes/textosFiqueDeOlho";
 
 export const InformacoesIniciais = () => {
     const [fique_de_olho, setFiqueDeOlho] = useState("");
+    const { recursoSelecionado } = useRecursoSelecionadoContext();
 
     useEffect(() => {
         buscaFiqueDeOlho();
     }, []);
 
     const buscaFiqueDeOlho = async () => {
-        await getFiqueDeOlhoPrestacoesDeContas().then((response) => {
-            setFiqueDeOlho(response.detail);
-        }).catch((error) => {
-            console.log(error);
-        })
+        let fiqueDeOlho = await getFiqueDeOlhoPrestacoesDeContas(
+            TEXTOS_FIQUE_DE_OLHO.UE_PRESTACAO_CONTAS,
+            recursoSelecionado?.uuid
+        )
+        if (fiqueDeOlho?.results?.length > 0) {
+            setFiqueDeOlho(fiqueDeOlho.results[0].texto);
+        }
     };
 
-    return(
-        <div className="col-12 container-texto-introdutorio mb-4">
-            <div dangerouslySetInnerHTML={{ __html: fique_de_olho }} />
-        </div>
+    return (
+        fique_de_olho?.trim() && (
+            <div className="col-12 container-texto-introdutorio mb-4">
+                <div dangerouslySetInnerHTML={{ __html: fique_de_olho }} />
+            </div>
+        )
     )
 };

--- a/src/componentes/escolas/PrestacaoDeContas/__tests__/InformacoesIniciais.test.js
+++ b/src/componentes/escolas/PrestacaoDeContas/__tests__/InformacoesIniciais.test.js
@@ -1,34 +1,56 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { InformacoesIniciais } from '../InformacoesIniciais';
+import { getFiqueDeOlhoPrestacoesDeContas } from '../../../../services/escolas/PrestacaoDeContas.service';
+import { useRecursoSelecionadoContext } from '../../../../context/RecursoSelecionado';
 
 // Mock da função de serviço
 jest.mock('../../../../services/escolas/PrestacaoDeContas.service', () => ({
   getFiqueDeOlhoPrestacoesDeContas: jest.fn(),
 }));
+jest.mock('../../../../context/RecursoSelecionado', () => ({
+  useRecursoSelecionadoContext: jest.fn(),
+}));
 
-import { getFiqueDeOlhoPrestacoesDeContas } from '../../../../services/escolas/PrestacaoDeContas.service';
+describe('Componente <InformacoesIniciais />', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
 
-describe('InformacoesIniciais', () => {
-  it('renderiza o HTML retornado pelo serviço', async () => {
-    const mockHtml = '<p><strong>Preste atenção nas pendências</strong></p>';
-
-    getFiqueDeOlhoPrestacoesDeContas.mockResolvedValue({
-      detail: mockHtml,
+        // Valor padrão do contexto para os testes
+        useRecursoSelecionadoContext.mockReturnValue({
+            recursoSelecionado: { uuid: 'recurso-uuid-123' },
+        });
     });
 
-    render(<InformacoesIniciais />);
+    it('renderiza o HTML retornado pelo serviço', async () => {
+        const mockHtml = '<p><strong>Preste atenção nas pendências</strong></p>';
 
-    await waitFor(() => {
-      expect(screen.getByText(/Preste atenção nas pendências/i)).toBeInTheDocument();
+        // Mock com a estrutura exata esperada pelo componente: response.results[0].texto
+        getFiqueDeOlhoPrestacoesDeContas.mockResolvedValue({
+            results: [
+                { texto: mockHtml }
+            ]
+        });
+
+        render(<InformacoesIniciais />);
+
+        // findByText aguarda a resolução do useEffect e a renderização do HTML
+        const textoRenderizado = await screen.findByText(/Preste atenção nas pendências/i);
+
+        expect(textoRenderizado).toBeInTheDocument();
+        expect(getFiqueDeOlhoPrestacoesDeContas).toHaveBeenCalledWith(
+            expect.anything(),
+            'recurso-uuid-123'
+        );
     });
-  });
 
-  it('lida com erro na chamada do serviço sem quebrar', async () => {
-    console.error = jest.fn(); // evitar log no console
+    it('não deve renderizar nada se o retorno estiver vazio', async () => {
+        getFiqueDeOlhoPrestacoesDeContas.mockResolvedValue({
+            results: [{ texto: '' }]
+        });
 
-    getFiqueDeOlhoPrestacoesDeContas.mockRejectedValue(new Error('Erro na API'));
+        const { container } = render(<InformacoesIniciais />);
 
-    render(<InformacoesIniciais />);
-
-  });
+        // Garante que nada é renderizado no DOM além do wrapper
+        expect(container.firstChild).toBeNull();
+    });
 });

--- a/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/__tests__/index.test.js
@@ -197,7 +197,7 @@ describe("Carrega página fique de olho", () => {
             expect(patchFiqueDeOlho).toHaveBeenCalledTimes(1);
 
             expect(toastCustom.ToastCustomError).toHaveBeenCalledWith(
-                "Erro ao atualizar o fique de olho",
+                "Erro ao atualizar o texto do fique de olho",
                 "Erro 007"
             );
         });

--- a/src/constantes/textosFiqueDeOlho.js
+++ b/src/constantes/textosFiqueDeOlho.js
@@ -1,0 +1,4 @@
+export const TEXTOS_FIQUE_DE_OLHO = {
+  UE_PRESTACAO_CONTAS: "associacoes_prestacao_contas",
+  DRE_CONSOLIDADO_DAS_PCS: "diretorias_consolidado_das_pcs"
+}

--- a/src/services/dres/RelatorioConsolidado.service.js
+++ b/src/services/dres/RelatorioConsolidado.service.js
@@ -88,8 +88,17 @@ export const devolverConsolidado = async (consolidado_uuid, dataLimiteDevolucao)
 
 // FIM Consolidado DRE
 
-export const getFiqueDeOlhoRelatoriosConsolidados = async () => {
-    return (await api.get(`/api/relatorios-consolidados-dre/fique-de-olho/`, authHeader())).data
+export const getFiqueDeOlhoRelatoriosConsolidados = async (tipo_texto, recurso_uuid) => {
+    const params = new URLSearchParams();
+    if (tipo_texto) 
+        params.append('tipo_texto', tipo_texto);
+    if (recurso_uuid) 
+        params.append('recurso_uuid', recurso_uuid);
+
+    return (await api.get(
+        `/api/fique-de-olho/?${params.toString()}`, 
+        authHeader()
+    )).data
 };
 
 export const getConsultarStatus = async (dre_uuid, periodo_uuid, conta_uuid) => {

--- a/src/services/dres/__tests__/RelatorioConsolidado.test.js
+++ b/src/services/dres/__tests__/RelatorioConsolidado.test.js
@@ -399,8 +399,13 @@ describe('Testes para funções de análise', () => {
     test('getFiqueDeOlhoRelatoriosConsolidados deve chamar a API corretamente', async () =>{
         api.get.mockResolvedValue({ data: mockData })
         
-        const result = await getFiqueDeOlhoRelatoriosConsolidados();
-        const url = `/api/relatorios-consolidados-dre/fique-de-olho/`
+        const tipo_texto = 'associacoes_geracao_documentos'
+        const recurso_uuid = '1234'
+        const result = await getFiqueDeOlhoRelatoriosConsolidados(
+            tipo_texto,
+            recurso_uuid
+        );
+        const url = `/api/fique-de-olho/?tipo_texto=${tipo_texto}&recurso_uuid=${recurso_uuid}`
         expect(api.get).toHaveBeenCalledWith(url, authHeader())
         expect(result).toEqual(mockData);
     });

--- a/src/services/escolas/PrestacaoDeContas.service.js
+++ b/src/services/escolas/PrestacaoDeContas.service.js
@@ -276,10 +276,20 @@ export const getConcluirPrestacaoDeConta = async (
   ).data
 };
 
-
-export const getFiqueDeOlhoPrestacoesDeContas = async () => {
-  return (await api.get(`/api/prestacoes-contas/fique-de-olho/`,authHeader())).data
-};
+export const getFiqueDeOlhoPrestacoesDeContas = async (tipo_texto, recurso_uuid = '') => {
+  const params = new URLSearchParams();
+  
+  if (tipo_texto) {
+    params.append('tipo_texto', tipo_texto);
+  }
+  if (recurso_uuid) {
+    params.append('recurso_uuid', recurso_uuid);
+  }
+  const queryString = params.toString();
+  const url = `/api/fique-de-olho/?${queryString}`;
+  
+  return (await api.get(url, authHeader())).data;
+}
 
 export const getAtaRetificadora = async (prestacao_uuid) => {
   return (await api.get(`/api/prestacoes-contas/${prestacao_uuid}/ata-retificacao/`,authHeader())).data

--- a/src/services/escolas/__tests__/PrestacaoDeContas.test.js
+++ b/src/services/escolas/__tests__/PrestacaoDeContas.test.js
@@ -537,9 +537,11 @@ describe('Testes para funções de análise', () => {
     
     test('getFiqueDeOlhoPrestacoesDeContas deve chamar a API corretamente', async () => {
         api.get.mockResolvedValue({ data: mockData })
-        const result = await getFiqueDeOlhoPrestacoesDeContas();
+        const recurso_uuid = '1234';
+        const tipo_texto = 'diretorias_consolidado_pcs';
+        const result = await getFiqueDeOlhoPrestacoesDeContas(tipo_texto, recurso_uuid);
         expect(api.get).toHaveBeenCalledWith(
-            `/api/prestacoes-contas/fique-de-olho/`,
+            `/api/fique-de-olho/?tipo_texto=${tipo_texto}&recurso_uuid=${recurso_uuid}`,
             getAuthHeader()
         )
         expect(result).toEqual(mockData);


### PR DESCRIPTION
Este PR inclui:

- Criação de arquivo de constantes para tipos de texto do fique de olho;
- Altera rota e parâmetros para buscar texto fique de olho de acordo com o tipo de texto e recurso especificado;
- Exibe painel apenas quando existir texto fique de olho para o recurso passado; 
- Correção e validação de testes unitários;

História: [AB#151566](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/151566)
Tarefa: [AB#152023](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/152023)