### PR TITLE
fix(150753) Refatora abas por recurso e bloqueia campo tipo de texto no formulário de edição de textos fique de olho.

### DIFF
--- a/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/components/ModalForm.js
+++ b/src/componentes/sme/Parametrizacoes/EdicaoDeTextos/FiqueDeOlho/components/ModalForm.js
@@ -67,6 +67,7 @@ export const ModalForm = ({handleSubmitFormModal}) => {
                                         name="tipo_texto"
                                         id="tipo_texto"
                                         required
+                                        disabled={Boolean(values.id)}
                                     >
                                         <option data-qa="option-recurso-vazio" value=''>Selecione um tipo de texto</option>
                                         {

--- a/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/__tests__/RecursosContext.test.js
+++ b/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/__tests__/RecursosContext.test.js
@@ -1,0 +1,90 @@
+import React, { useContext } from "react";
+import { render, screen, act, renderHook } from "@testing-library/react";
+import {
+  AbasPorRecursoContext,
+  AbasPorRecursoProvider,
+} from "../context/Recursos";
+
+describe("AbasPorRecursoContext & AbasPorRecursoProvider", () => {
+  describe("Valores Padrão do Contexto (Sem Provider)", () => {
+    test("deve fornecer os valores iniciais definidos no createContext quando consumido fora do Provider", () => {
+      const { result } = renderHook(() => useContext(AbasPorRecursoContext));
+
+      expect(result.current.selectedRecurso).toBeNull();
+      expect(result.current.clickBtnEscolheOpcao).toEqual({});
+      expect(typeof result.current.setSelectedRecurso).toBe("function");
+      expect(typeof result.current.setClickBtnEscolheOpcao).toBe("function");
+    });
+  });
+
+  describe("AbasPorRecursoProvider", () => {
+    test("deve renderizar os componentes filhos (children) corretamente", () => {
+      render(
+        <AbasPorRecursoProvider>
+          <div data-testid="child-component">Conteúdo Filho</div>
+        </AbasPorRecursoProvider>
+      );
+
+      expect(screen.getByTestId("child-component")).toBeInTheDocument();
+      expect(screen.getByText("Conteúdo Filho")).toBeInTheDocument();
+    });
+
+    test("deve fornecer os valores iniciais de estado através do Provider", () => {
+      const { result } = renderHook(() => useContext(AbasPorRecursoContext), {
+        wrapper: AbasPorRecursoProvider,
+      });
+
+      expect(result.current.selectedRecurso).toBeNull();
+      expect(result.current.clickBtnEscolheOpcao).toEqual({});
+    });
+
+    test("deve atualizar o estado `selectedRecurso` corretamente", () => {
+      const { result } = renderHook(() => useContext(AbasPorRecursoContext), {
+        wrapper: AbasPorRecursoProvider,
+      });
+
+      const mockRecurso = { uuid: "rec-123", nome: "Relatórios" };
+
+      act(() => {
+        result.current.setSelectedRecurso(mockRecurso);
+      });
+
+      expect(result.current.selectedRecurso).toEqual(mockRecurso);
+    });
+
+    test("deve atualizar o estado `clickBtnEscolheOpcao` corretamente", () => {
+      const { result } = renderHook(() => useContext(AbasPorRecursoContext), {
+        wrapper: AbasPorRecursoProvider,
+      });
+
+      const novoEstadoBtn = { "rec-123": true };
+
+      act(() => {
+        result.current.setClickBtnEscolheOpcao(novoEstadoBtn);
+      });
+
+      expect(result.current.clickBtnEscolheOpcao).toEqual(novoEstadoBtn);
+    });
+
+    test("deve permitir resetar os estados para os valores padrão", () => {
+      const { result } = renderHook(() => useContext(AbasPorRecursoContext), {
+        wrapper: AbasPorRecursoProvider,
+      });
+
+      // Altera os estados
+      act(() => {
+        result.current.setSelectedRecurso({ uuid: "rec-1" });
+        result.current.setClickBtnEscolheOpcao({ "rec-1": true });
+      });
+
+      // Reseta os estados
+      act(() => {
+        result.current.setSelectedRecurso(null);
+        result.current.setClickBtnEscolheOpcao({});
+      });
+
+      expect(result.current.selectedRecurso).toBeNull();
+      expect(result.current.clickBtnEscolheOpcao).toEqual({});
+    });
+  });
+});

--- a/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/__tests__/index.test.js
+++ b/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/__tests__/index.test.js
@@ -1,0 +1,218 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { AbasPorRecurso } from "../index";
+
+// Importação direta dos hooks
+import { useRecursoSelecionadoContext } from "../../../../../../context/RecursoSelecionado";
+import { useAbasPorRecursoContext } from "../hooks/useAbasPorRecursoContext";
+
+// Mocks do React Router
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+// Mocks dos Contextos e Utilitários
+jest.mock("../hooks/useAbasPorRecursoContext", () => ({
+  useAbasPorRecursoContext: jest.fn(),
+}));
+
+jest.mock("../../../../../../context/RecursoSelecionado", () => ({
+  useRecursoSelecionadoContext: jest.fn(),
+}));
+
+jest.mock("../../../../../../utils/Loading", () => () => (
+  <div data-testid="loading-spinner">Carregando...</div>
+));
+
+describe("Componente <AbasPorRecurso />", () => {
+  const mockNavigate = jest.fn();
+  const mockSetSelectedRecurso = jest.fn();
+  const mockSetClickBtnEscolheOpcao = jest.fn();
+
+  // Função geradora de recursos isolados para evitar mutação in-place entre testes
+  const getFreshRecursos = () => [
+    { uuid: "rec-1", nome: "Recurso 1", nome_exibicao: "Aba Recurso 1", legado: false },
+    { uuid: "rec-2", nome: "Recurso 2", nome_exibicao: "Aba Recurso 2", legado: true },
+    { uuid: "rec-3", nome: "Recurso 3", nome_exibicao: "Aba Recurso 3", legado: false },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useNavigate.mockReturnValue(mockNavigate);
+    useLocation.mockReturnValue({ pathname: "/home" });
+
+    // Instâncias limpas para o estado inicial
+    const recursos = getFreshRecursos();
+
+    useAbasPorRecursoContext.mockReturnValue({
+      selectedRecurso: null,
+      setSelectedRecurso: mockSetSelectedRecurso,
+      clickBtnEscolheOpcao: {},
+      setClickBtnEscolheOpcao: mockSetClickBtnEscolheOpcao,
+    });
+
+    useRecursoSelecionadoContext.mockReturnValue({
+      isLoading: false,
+      recursos,
+    });
+  });
+
+  describe("1. Estados de Carregamento e Vazio", () => {
+    test("deve exibir o componente de Loading quando isLoading for true", () => {
+      useRecursoSelecionadoContext.mockReturnValue({
+        isLoading: true,
+        recursos: [],
+      });
+
+      render(<AbasPorRecurso />);
+
+      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    });
+
+    test("deve exibir mensagem de nenhum recurso disponível se a lista estiver vazia", () => {
+      useRecursoSelecionadoContext.mockReturnValue({
+        isLoading: false,
+        recursos: [],
+      });
+
+      render(<AbasPorRecurso />);
+
+      expect(screen.getByText("Nenhum recurso disponível")).toBeInTheDocument();
+    });
+  });
+
+  describe("2. Renderização e Ordenação das Abas", () => {
+    test("deve renderizar todas as abas de recurso e ordenar legados primeiro", () => {
+      render(<AbasPorRecurso />);
+
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(3);
+
+      // Recurso 2 possui legado: true, portanto é renderizado em primeiro
+      expect(tabs[0]).toHaveTextContent("Aba Recurso 2");
+      expect(tabs[1]).toHaveTextContent("Aba Recurso 1");
+      expect(tabs[2]).toHaveTextContent("Aba Recurso 3");
+    });
+
+    test("deve renderizar abas extras e o divisor visual quando informadas", () => {
+      const extraAbas = [
+        { id: "extra-1", label: "Relatórios", url: "relatorios" },
+      ];
+
+      const { container } = render(<AbasPorRecurso extra_abas={extraAbas} />);
+
+      expect(screen.getByText("Relatórios")).toBeInTheDocument();
+      const divider = container.querySelector('div[style*="background-color: rgb(204, 204, 204)"]');
+      expect(divider).toBeInTheDocument();
+    });
+  });
+
+  describe("3. Definição da Aba Ativa (`activeTabId`)", () => {
+    test("deve marcar como ativa a aba definida em `tab_initial_active` quando não houver seleção prévia", () => {
+      render(<AbasPorRecurso tab_initial_active="rec-1" />);
+
+      const tab1 = screen.getByText("Aba Recurso 1");
+      expect(tab1).toHaveClass("btn-escolhe-aba-active");
+      expect(tab1).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("deve priorizar a aba selecionada no contexto (`selectedRecurso`)", () => {
+      const recursos = getFreshRecursos();
+      const selectedResource = recursos[0]; // rec-1 ("Aba Recurso 1")
+
+      useAbasPorRecursoContext.mockReturnValue({
+        selectedRecurso: selectedResource,
+        setSelectedRecurso: mockSetSelectedRecurso,
+        clickBtnEscolheOpcao: { "rec-1": true },
+        setClickBtnEscolheOpcao: mockSetClickBtnEscolheOpcao,
+      });
+
+      useRecursoSelecionadoContext.mockReturnValue({
+        isLoading: false,
+        recursos,
+      });
+
+      render(<AbasPorRecurso tab_initial_active="rec-3" />);
+
+      const tab1 = screen.getByText("Aba Recurso 1");
+      expect(tab1).toHaveClass("btn-escolhe-aba-active");
+    });
+
+    test("deve priorizar a aba extra se a URL atual corresponder à rota da aba extra", () => {
+      useLocation.mockReturnValue({ pathname: "/dashboard/relatorios" });
+
+      const extraAbas = [
+        { id: "extra-1", label: "Relatórios", url: "dashboard/relatorios" },
+      ];
+
+      render(<AbasPorRecurso extra_abas={extraAbas} />);
+
+      const extraTab = screen.getByText("Relatórios");
+      expect(extraTab).toHaveClass("btn-escolhe-aba-active");
+    });
+  });
+
+  describe("4. Interações do Usuário (Eventos de Clique)", () => {
+    test("deve atualizar estado do contexto e executar callback ao clicar em uma aba de recurso", () => {
+      const mockExtraHandleClick = jest.fn();
+      const recursos = getFreshRecursos();
+
+      useRecursoSelecionadoContext.mockReturnValue({
+        isLoading: false,
+        recursos,
+      });
+
+      render(<AbasPorRecurso extra_handle_click_tab_recurso={mockExtraHandleClick} />);
+
+      const tab1 = screen.getByText("Aba Recurso 1");
+      fireEvent.click(tab1);
+
+      expect(mockSetClickBtnEscolheOpcao).toHaveBeenCalledWith({ "rec-1": true });
+      expect(mockSetSelectedRecurso).toHaveBeenCalledWith(expect.objectContaining({ uuid: "rec-1" }));
+      expect(mockExtraHandleClick).toHaveBeenCalledTimes(1);
+    });
+
+    test("deve limpar recurso selecionado, atualizar opção e navegar ao clicar em uma aba extra", () => {
+      const extraAbas = [
+        { id: "extra-config", label: "Configurações", url: "config" },
+      ];
+
+      render(<AbasPorRecurso extra_abas={extraAbas} />);
+
+      const extraTab = screen.getByText("Configurações");
+      fireEvent.click(extraTab);
+
+      expect(mockSetSelectedRecurso).toHaveBeenCalledWith(null);
+      expect(mockSetClickBtnEscolheOpcao).toHaveBeenCalledWith({ "extra-config": true });
+      expect(mockNavigate).toHaveBeenCalledWith("/config/");
+    });
+  });
+
+  describe("5. Efeitos de Sincronização e Limpeza (`useEffect`)", () => {
+    test("deve selecionar automaticamente a primeira aba de recurso na carga inicial", () => {
+      render(<AbasPorRecurso />);
+
+      // Por conta da ordenação (legado: true), o recurso 2 vem em primeiro
+      expect(mockSetSelectedRecurso).toHaveBeenCalledWith(expect.objectContaining({ uuid: "rec-2" }));
+      expect(mockSetClickBtnEscolheOpcao).toHaveBeenCalledWith({ "rec-2": true });
+    });
+
+    test("deve resetar o contexto quando o componente for desmontado para navegar para outra tela", () => {
+      const { unmount } = render(<AbasPorRecurso />);
+
+      // Simula navegação para outra página na desmontagem
+      Object.defineProperty(window, "location", {
+        value: { pathname: "/outra-tela-qualquer" },
+        writable: true,
+      });
+
+      unmount();
+
+      expect(mockSetSelectedRecurso).toHaveBeenCalledWith(null);
+      expect(mockSetClickBtnEscolheOpcao).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/index.js
+++ b/src/componentes/sme/Parametrizacoes/componentes/AbasPorRecurso/index.js
@@ -1,11 +1,11 @@
-import React, { Fragment, useMemo, useRef, useEffect } from "react";
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useMemo, useEffect } from "react";
 import "../../../../../componentes/Globais/MenuInterno";
 import "../../../../../componentes/dres/Associacoes/associacoes.scss";
-import { Divider } from 'primereact/divider';
 import Loading from "../../../../../utils/Loading";
 import { useRecursoSelecionadoContext } from "../../../../../context/RecursoSelecionado";
 import { useAbasPorRecursoContext } from "./hooks/useAbasPorRecursoContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export const AbasPorRecurso = ({
     extra_abas = [], 
@@ -13,10 +13,10 @@ export const AbasPorRecurso = ({
     tab_initial_active = null
 }) => {
     const navigate = useNavigate();
+    const location = useLocation();
+    
     const { selectedRecurso, setSelectedRecurso, clickBtnEscolheOpcao, setClickBtnEscolheOpcao } = useAbasPorRecursoContext();
     const { isLoading, recursos } = useRecursoSelecionadoContext();
-    // Ref para garantir que a inicialização da aba ativa ocorra apenas uma vez
-    const inicializado = useRef(false);
 
     // Transformar dados dos recursos em abas
     const recurso_tabs = useMemo(() => {
@@ -31,105 +31,178 @@ export const AbasPorRecurso = ({
         }));
     }, [recursos]);
 
+    // Identifica a aba extra ativa com base na URL atual, priorizando a correspondência mais longa
+    const activeExtraTab = useMemo(() => {
+        if (!extra_abas || extra_abas.length === 0) return null;
+
+        const currentPath = location.pathname.toLowerCase().replace(/\/$/, "");
+        let bestTab = null;
+        let maxLength = 0;
+
+        extra_abas.forEach((tab, index) => {
+            if (!tab.url) return;
+            
+            const cleanUrl = [tab.url, tab.origem].filter(Boolean).join("/").toLowerCase().replace(/\/+/g, "/").replace(/\/$/, "");
+            const fullPath = `/${cleanUrl}`;
+
+            if (currentPath === fullPath || currentPath.endsWith(fullPath) || (cleanUrl.length > 1 && currentPath.includes(cleanUrl))) {
+                if (cleanUrl.length > maxLength) {
+                    maxLength = cleanUrl.length;
+                    bestTab = { ...tab, id: tab.id || `extra-tab-${index}` };
+                }
+            }
+        });
+
+        return bestTab;
+    }, [extra_abas, location.pathname]);
+
+    // Cálculo direto da aba ativa para garantir estilização correta
+    const activeTabId = useMemo(() => {
+        if (activeExtraTab) {
+            return activeExtraTab.id;
+        }
+        if (selectedRecurso?.uuid && recurso_tabs.some(r => r.id === selectedRecurso.uuid)) {
+            return selectedRecurso.uuid;
+        }
+        if (tab_initial_active && recurso_tabs.some(r => r.id === tab_initial_active)) {
+            return tab_initial_active;
+        }
+        return recurso_tabs[0]?.id || null;
+    }, [activeExtraTab, selectedRecurso?.uuid, recurso_tabs, tab_initial_active]);
+
     const handleChangeTab = (tab_id) => {
-        // Ativa aba de recurso
-        setClickBtnEscolheOpcao({
-            [tab_id]: true,
-        });
-        // Atualiza o recurso selecionado no contexto
+        setClickBtnEscolheOpcao({ [tab_id]: true });
         const recursoSelecionado = recursos.find(r => r.uuid === tab_id);
-        setSelectedRecurso(recursoSelecionado);
+        if (recursoSelecionado) {
+            setSelectedRecurso(recursoSelecionado);
+        }
 
-        extra_handle_click_tab_recurso()
-    }
+        extra_handle_click_tab_recurso();
+    };
 
-    const handleClickExtraTab = ({
-        tab_id,
-        url,
-    }) => {
-        setClickBtnEscolheOpcao({
-            [tab_id]: true,
-        });
+    const handleClickExtraTab = ({ tab_id, url }) => {
         setSelectedRecurso(null);
-
+        setClickBtnEscolheOpcao({ [tab_id]: true });
         navigate(url);
-    }
+    };
 
-    const liItemTemplate = ({
-        handleClick,
-        tab_id,
-        label,
-    }) => {
-        const classNameActive = clickBtnEscolheOpcao[tab_id] ? "btn-escolhe-aba-active" : "";
+    // Template de item das abas (Usa estritamente activeTabId para definir a classe ativa)
+    const liItemTemplate = ({ handleClick, tab_id, label }) => {
+        const isTabActive = tab_id === activeTabId;
+        const classNameActive = isTabActive ? "btn-escolhe-aba-active" : "";
 
         return (
             <li key={tab_id}>
                 <a
-                    onClick={handleClick}
+                    onClick={(e) => {
+                        e.preventDefault();
+                        handleClick();
+                    }}
                     className={`nav-link btn-escolhe-aba ${classNameActive}`}
                     id={`nav-${tab_id}-tab`}
                     data-toggle="tab"
-                    href={`#nav-${tab_id}`}
+                    href="#"
                     role="tab"
-                    aria-controls={`nav-${tab_id}`}
-                    aria-selected={classNameActive ? "true" : "false"}
+                    aria-selected={isTabActive ? "true" : "false"}
                 >
                     {label}
                 </a>
             </li>
-        )
-    }
+        );
+    };
 
     const renderTabsRecursos = () => {
-        const tabsRecursos = recurso_tabs.filter(tab => tab.permissao).map(tab => {
+        return recurso_tabs.filter(tab => tab.permissao).map(tab => {
             return liItemTemplate({
                 handleClick: () => handleChangeTab(tab.id),
                 tab_id: tab.id,
                 label: tab.nome_exibicao,
             });
         });
-
-        return tabsRecursos;
-    }
+    };
 
     const renderExtraAbas = () => {
         return extra_abas.map((tab, index) => {
-            const tab_id = `extra-tab-${index}`;
+            const tab_id = tab.id || `extra-tab-${index}`;
+            const urlLimpa = [tab.url, tab.origem].filter(Boolean).join("/");
+            const urlFinal = `/${urlLimpa}/`.replace(/\/+/g, "/");
 
             return liItemTemplate({
-                handleClick: () => handleClickExtraTab({ tab_id, url: `/${tab.url}/${tab.origem}/` }),
+                handleClick: () => handleClickExtraTab({ tab_id, url: urlFinal }),
                 tab_id: tab_id,
                 label: tab.label,
             });
         });
-    }
+    };
 
-    // Inicializa primeira aba como ativa - executa apenas uma vez com a primeira aba
+    // Limpeza de estado ao sair da tela (ex: Dashboard/Menu) - preserva estado se voltando para uma aba de recurso
     useEffect(() => {
-        if (tab_initial_active) {
-            setClickBtnEscolheOpcao({
-                [tab_initial_active]: true,
-            });
-        } else if (recurso_tabs.length > 0 && !inicializado.current && !selectedRecurso) {
-            const primeiroRecurso = recursos.find(r => r.uuid === recurso_tabs[0].id);
-            setClickBtnEscolheOpcao({
-                [recurso_tabs[0].id]: true,
-            });
-            setSelectedRecurso(primeiroRecurso);
-            inicializado.current = true;
+        const currentPath = location.pathname;
+        const estavaEmAbaExtra = activeExtraTab !== null;
+
+        return () => {
+            const nextPath = window.location.pathname;
+
+            if (nextPath !== currentPath) {
+                const indoParaAbaExtra = extra_abas.some(tab => 
+                    tab.url && nextPath.toLowerCase().includes(tab.url.toLowerCase())
+                );
+
+                // Só limpa se formos para OUTRA tela (ex: painel-parametrizacoes)
+                // Se estávamos em uma aba extra e voltamos para uma aba de recurso, PRESERVA o recurso clicado
+                if (!estavaEmAbaExtra && !indoParaAbaExtra) {
+                    setSelectedRecurso(null);
+                    setClickBtnEscolheOpcao({});
+                }
+            }
+        };
+    }, [location.pathname, activeExtraTab, extra_abas, setSelectedRecurso, setClickBtnEscolheOpcao]);
+
+    // Sincronização de estado do contexto (Usando apenas primitivos nas dependências para evitar loops)
+    useEffect(() => {
+        if (isLoading) return;
+
+        // CENÁRIO A: Estamos em uma rota de Aba Extra
+        if (activeExtraTab) {
+            if (selectedRecurso !== null) {
+                setSelectedRecurso(null);
+            }
+            if (!clickBtnEscolheOpcao[activeExtraTab.id]) {
+                setClickBtnEscolheOpcao({ [activeExtraTab.id]: true });
+            }
+            return;
         }
-    }, [recurso_tabs, tab_initial_active]);
 
-    // Sincroniza o recurso selecionado quando a aba ativa muda
-    useEffect(() => {
-        const abaAtivaId = Object.keys(clickBtnEscolheOpcao).find(key => clickBtnEscolheOpcao[key]);
-        if (abaAtivaId && !selectedRecurso) {
-            const recursoAtivo = recursos.find(r => r.uuid === abaAtivaId);
-            if (recursoAtivo) {
-                setSelectedRecurso(recursoAtivo);
+        // CENÁRIO B: Estamos em Abas de Recurso Normais
+        if (recurso_tabs.length > 0) {
+            const recursoExiste = selectedRecurso && recurso_tabs.some(r => r.id === selectedRecurso.uuid);
+
+            if (!recursoExiste) {
+                // Primeira carga ou retorno de outra tela -> seleciona a 1ª aba
+                const targetId = tab_initial_active || recurso_tabs[0].id;
+                const targetResource = recursos.find(r => r.uuid === targetId);
+
+                if (targetResource) {
+                    setSelectedRecurso(targetResource);
+                    setClickBtnEscolheOpcao({ [targetId]: true });
+                }
+            } else {
+                if (!clickBtnEscolheOpcao[selectedRecurso.uuid]) {
+                    setClickBtnEscolheOpcao({ [selectedRecurso.uuid]: true });
+                }
             }
         }
-    }, [clickBtnEscolheOpcao, recursos]);
+    }, [
+        isLoading,
+        activeExtraTab,
+        recurso_tabs,
+        selectedRecurso?.uuid,
+        tab_initial_active,
+        recursos,
+        clickBtnEscolheOpcao,
+        setSelectedRecurso,
+        setClickBtnEscolheOpcao
+    ]);
 
     if (isLoading) {
         return (


### PR DESCRIPTION
Este PR inclui:

- Bloqueia campo tipo de texto no formulário de edição de Textos fique de olho em parametrizações SME;
- Refatoração e ajuste no componente de AbasPorRecurso para sempre deixar a primeira aba (PTRF) ativa ao abrir parametrizações que utilizam desse componente (e não mais salvar a última aba acessada e mantê-la ativa no próximo acesso);
- Criação de testes unitários para o componente de AbasPorRecurso;
- Validação dos demais testes unitários;

História: [AB#150753](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/150753)
Tarefa: [AB#154865](https://dev.azure.com/SME-Spassu/9517625e-d03b-4045-bc4f-69692f861ed6/_workitems/edit/154865)